### PR TITLE
[PR-17] 実装の概要

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,13 @@ jobs:
     - name: Run plugin SBOM validation tests
       run: cargo test -p plugin-host --test plugin_sbom_validation --verbose
 
+  marketplace-bundle-verification:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run marketplace domain pack verification tests
+      run: cargo test -p plugin-host --test marketplace_bundle --verbose
+
   mcp-protocol-compliance:
     runs-on: ubuntu-latest
     steps:
@@ -221,6 +228,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run usage pricing snapshot diff check
       run: cargo test -p mcp-server --test mcp_pricing_snapshot --verbose
+
+  revenue-share-regression:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run marketplace revenue share regression tests
+      run: cargo test -p mcp-server --test mcp_revenue_share --verbose
 
   nfr-benchmark-short:
     if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,6 +1763,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -38,7 +38,7 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 | 4 | Security & Audit | PR-09〜11 | 3/3 | DONE |
 | 5 | Extensions & API | PR-12〜14 | 3/3 | DONE |
 | 6 | Monetization Meters | PR-16 | 1/1 | DONE |
-| 7 | Marketplace | PR-17 | 0/1 | NOT_STARTED |
+| 7 | Marketplace | PR-17 | 1/1 | DONE |
 | 8 | Robustness & Verification | PR-18 | 0/1 | NOT_STARTED |
 
 ## 3. PRバックログ（進捗チェック付き）
@@ -355,21 +355,21 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
   - [x] 仕様の課金メーターが再現性を持って収集できる。
 
 ### PR-17: Marketplace Integration
-- Status: `NOT_STARTED`
+- Status: `DONE` (Local)
 - Spec Ref: Section 7.3
 - Dependencies: PR-12, PR-16
 - 実装タスク
-  - [ ] Domain Pack（plugin + skill bundle）のパッケージ仕様を定義する。
-  - [ ] Marketplace向け公開メタデータ（署名、互換バージョン、依存情報）を実装する。
-  - [ ] Revenue Share集計に必要な利用イベント連携を実装する。
+  - [x] Domain Pack（plugin + skill bundle）のパッケージ仕様を定義する。
+  - [x] Marketplace向け公開メタデータ（署名、互換バージョン、依存情報）を実装する。
+  - [x] Revenue Share集計に必要な利用イベント連携を実装する。
 - テストタスク
-  - [ ] Bundleの署名検証・互換性検証テストを追加する。
-  - [ ] 利用イベントから収益分配集計が再現できるテストを追加する。
+  - [x] Bundleの署名検証・互換性検証テストを追加する。
+  - [x] 利用イベントから収益分配集計が再現できるテストを追加する。
 - CIタスク
-  - [ ] Marketplace bundleの検証ジョブを必須化する。
-  - [ ] Revenue Share集計回帰テストを必須化する。
+  - [x] Marketplace bundleの検証ジョブを必須化する。
+  - [x] Revenue Share集計回帰テストを必須化する。
 - Exit Criteria
-  - [ ] Domain Pack公開に必要な最小機能が実装されている。
+  - [x] Domain Pack公開に必要な最小機能が実装されている。
 
 ### PR-18: Advanced E2E Verification & Security Audit
 - Status: `NOT_STARTED`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -216,3 +216,11 @@ Model Context Protocol (MCP) 準拠のツール定義。
 
 - **Domain Packs**: 特定業務（経理、人事等）向けPlugin/Skillセットの販売。
 - **Revenue Share**: 認定Plugin開発者への収益分配。
+- **Domain Pack Package Specification**:
+  - `manifest`: `pack_id`, `version`, `plugin_id`, `skill_ids` を必須とする。
+  - `marketplace metadata`: `publisher_id`, `signature`（`key_id`, `signature_hex`）, `runtime_compatibility`（`runtime_api`, `min_runtime_version`, `max_runtime_version?`）, `dependencies[]`（`package`, `version_req`）を公開する。
+  - `artifacts`: 署名済み Plugin Package（Wasm + SBOM + Plugin Manifest）と Skill 定義群（`skill_id`, `version`, `definition`）を同梱する。
+  - `verification`: Plugin 署名検証 + Domain Pack 署名検証 + Runtime 互換バージョン検証 + `skill_ids` と同梱 Skill の整合検証を必須とする。
+- **Revenue Share Aggregation Rule**:
+  - `State Generations`, `Visual Captures`, `Actions Executed`, `HITL Events` を利用イベントとして連携する。
+  - 利用イベントをプラン別レートカードで `gross_microusd` に換算し、`revenue_share_bps` により publisher/platform の配分額を算出する。

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -113,11 +113,6 @@ enum RevenueUsageEventKind {
     HitlEvent,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RevenueUsageEvent {
-    kind: RevenueUsageEventKind,
-}
-
 #[derive(Debug, Clone, Default)]
 struct UsageMeters {
     state_generations: StateGenerationUsage,
@@ -275,7 +270,7 @@ pub struct McpServer<B> {
     plan_tier: PlanTier,
     usage_meters: UsageMeters,
     marketplace_attribution: Option<MarketplaceAttribution>,
-    revenue_events: Vec<RevenueUsageEvent>,
+    revenue_usage: RevenueShareUsage,
 }
 
 impl<B: McpBackend> McpServer<B> {
@@ -289,7 +284,7 @@ impl<B: McpBackend> McpServer<B> {
             plan_tier,
             usage_meters: UsageMeters::default(),
             marketplace_attribution: None,
-            revenue_events: Vec::new(),
+            revenue_usage: RevenueShareUsage::default(),
         }
     }
 
@@ -449,7 +444,7 @@ impl<B: McpBackend> McpServer<B> {
             }));
         };
 
-        let usage = aggregate_revenue_usage(&self.revenue_events);
+        let usage = self.revenue_usage.clone();
         let gross = estimate_usage_cost(
             self.plan_tier,
             &usage.state_generations,
@@ -468,7 +463,12 @@ impl<B: McpBackend> McpServer<B> {
             pack_id: attribution.pack_id.clone(),
             publisher_id: attribution.publisher_id.clone(),
             revenue_share_bps: normalized_bps,
-            event_count: self.revenue_events.len() as u64,
+            event_count: usage.state_generations.fast
+                + usage.state_generations.full
+                + usage.state_generations.delta
+                + usage.visual_captures
+                + usage.actions_executed
+                + usage.hitl_events,
             usage,
             gross_microusd: gross,
             publisher_share_microusd,
@@ -597,7 +597,20 @@ impl<B: McpBackend> McpServer<B> {
         }
 
         if self.marketplace_attribution.is_some() {
-            self.revenue_events.push(RevenueUsageEvent { kind });
+            match kind {
+                RevenueUsageEventKind::StateGenerationFast => {
+                    self.revenue_usage.state_generations.fast += 1
+                }
+                RevenueUsageEventKind::StateGenerationFull => {
+                    self.revenue_usage.state_generations.full += 1
+                }
+                RevenueUsageEventKind::StateGenerationDelta => {
+                    self.revenue_usage.state_generations.delta += 1
+                }
+                RevenueUsageEventKind::VisualCapture => self.revenue_usage.visual_captures += 1,
+                RevenueUsageEventKind::ActionExecuted => self.revenue_usage.actions_executed += 1,
+                RevenueUsageEventKind::HitlEvent => self.revenue_usage.hitl_events += 1,
+            }
         }
     }
 }
@@ -755,21 +768,6 @@ fn default_skill_params() -> Value {
 
 fn parse_get_state_arguments(arguments: &Value) -> GetStateArguments {
     serde_json::from_value(arguments.clone()).unwrap_or_default()
-}
-
-fn aggregate_revenue_usage(events: &[RevenueUsageEvent]) -> RevenueShareUsage {
-    let mut usage = RevenueShareUsage::default();
-    for event in events {
-        match event.kind {
-            RevenueUsageEventKind::StateGenerationFast => usage.state_generations.fast += 1,
-            RevenueUsageEventKind::StateGenerationFull => usage.state_generations.full += 1,
-            RevenueUsageEventKind::StateGenerationDelta => usage.state_generations.delta += 1,
-            RevenueUsageEventKind::VisualCapture => usage.visual_captures += 1,
-            RevenueUsageEventKind::ActionExecuted => usage.actions_executed += 1,
-            RevenueUsageEventKind::HitlEvent => usage.hitl_events += 1,
-        }
-    }
-    usage
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -76,6 +76,48 @@ pub struct UsageCostBreakdown {
     pub total: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MarketplaceAttribution {
+    pub pack_id: String,
+    pub publisher_id: String,
+    pub revenue_share_bps: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RevenueShareUsage {
+    pub state_generations: StateGenerationUsage,
+    pub visual_captures: u64,
+    pub actions_executed: u64,
+    pub hitl_events: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RevenueShareReport {
+    pub pack_id: String,
+    pub publisher_id: String,
+    pub revenue_share_bps: u16,
+    pub event_count: u64,
+    pub usage: RevenueShareUsage,
+    pub gross_microusd: u64,
+    pub publisher_share_microusd: u64,
+    pub platform_share_microusd: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RevenueUsageEventKind {
+    StateGenerationFast,
+    StateGenerationFull,
+    StateGenerationDelta,
+    VisualCapture,
+    ActionExecuted,
+    HitlEvent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RevenueUsageEvent {
+    kind: RevenueUsageEventKind,
+}
+
 #[derive(Debug, Clone, Default)]
 struct UsageMeters {
     state_generations: StateGenerationUsage,
@@ -232,6 +274,8 @@ pub struct McpServer<B> {
     backend: B,
     plan_tier: PlanTier,
     usage_meters: UsageMeters,
+    marketplace_attribution: Option<MarketplaceAttribution>,
+    revenue_events: Vec<RevenueUsageEvent>,
 }
 
 impl<B: McpBackend> McpServer<B> {
@@ -244,7 +288,19 @@ impl<B: McpBackend> McpServer<B> {
             backend,
             plan_tier,
             usage_meters: UsageMeters::default(),
+            marketplace_attribution: None,
+            revenue_events: Vec::new(),
         }
+    }
+
+    pub fn new_with_marketplace(
+        backend: B,
+        plan_tier: PlanTier,
+        marketplace_attribution: MarketplaceAttribution,
+    ) -> Self {
+        let mut server = Self::new_with_plan(backend, plan_tier);
+        server.marketplace_attribution = Some(marketplace_attribution);
+        server
     }
 
     pub fn tools(&self) -> Vec<ToolDefinition> {
@@ -284,12 +340,20 @@ impl<B: McpBackend> McpServer<B> {
                 description: "Retrieve usage meters and plan tier summary".to_string(),
                 input_schema: get_usage_report_input_schema(),
             },
+            ToolDefinition {
+                name: "get_revenue_share_report".to_string(),
+                description: "Retrieve marketplace revenue-share usage summary".to_string(),
+                input_schema: get_revenue_share_report_input_schema(),
+            },
         ]
     }
 
     pub fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value> {
         if name == "get_usage_report" {
             return self.get_usage_report_payload();
+        }
+        if name == "get_revenue_share_report" {
+            return self.get_revenue_share_report_payload();
         }
 
         if let Some(payload) = self.check_plan_gate(name, &arguments) {
@@ -378,6 +442,42 @@ impl<B: McpBackend> McpServer<B> {
         serde_json::to_value(report).context("failed to serialize usage report")
     }
 
+    fn get_revenue_share_report_payload(&self) -> Result<Value> {
+        let Some(attribution) = &self.marketplace_attribution else {
+            return Ok(json!({
+                "status": "marketplace_context_required"
+            }));
+        };
+
+        let usage = aggregate_revenue_usage(&self.revenue_events);
+        let gross = estimate_usage_cost(
+            self.plan_tier,
+            &usage.state_generations,
+            usage.visual_captures,
+            usage.actions_executed,
+            usage.hitl_events,
+            AuditRetentionSnapshot::default(),
+        )
+        .total;
+
+        let normalized_bps = attribution.revenue_share_bps.min(10_000);
+        let publisher_share_microusd = gross.saturating_mul(normalized_bps as u64) / 10_000;
+        let platform_share_microusd = gross.saturating_sub(publisher_share_microusd);
+
+        let report = RevenueShareReport {
+            pack_id: attribution.pack_id.clone(),
+            publisher_id: attribution.publisher_id.clone(),
+            revenue_share_bps: normalized_bps,
+            event_count: self.revenue_events.len() as u64,
+            usage,
+            gross_microusd: gross,
+            publisher_share_microusd,
+            platform_share_microusd,
+        };
+
+        serde_json::to_value(report).context("failed to serialize revenue share report")
+    }
+
     fn check_plan_gate(&self, name: &str, arguments: &Value) -> Option<Value> {
         match name {
             "get_state" => {
@@ -445,11 +545,11 @@ impl<B: McpBackend> McpServer<B> {
                 let args = parse_get_state_arguments(arguments);
                 match args.delivery {
                     StateDelivery::Delta => {
-                        self.usage_meters.state_generations.delta += 1;
+                        self.record_usage_event(RevenueUsageEventKind::StateGenerationDelta);
                     }
                     StateDelivery::Full => {
-                        self.usage_meters.state_generations.fast += 1;
-                        self.usage_meters.state_generations.full += 1;
+                        self.record_usage_event(RevenueUsageEventKind::StateGenerationFast);
+                        self.record_usage_event(RevenueUsageEventKind::StateGenerationFull);
                     }
                 }
             }
@@ -464,19 +564,40 @@ impl<B: McpBackend> McpServer<B> {
                         .and_then(Value::as_str)
                         .is_some()
                 {
-                    self.usage_meters.visual_captures += 1;
+                    self.record_usage_event(RevenueUsageEventKind::VisualCapture);
                 }
             }
             "act" => match payload.get("status").and_then(Value::as_str) {
                 Some("ok") => {
-                    self.usage_meters.actions_executed += 1;
+                    self.record_usage_event(RevenueUsageEventKind::ActionExecuted);
                 }
                 Some("requires_human_approval") => {
-                    self.usage_meters.hitl_events += 1;
+                    self.record_usage_event(RevenueUsageEventKind::HitlEvent);
                 }
                 _ => {}
             },
             _ => {}
+        }
+    }
+
+    fn record_usage_event(&mut self, kind: RevenueUsageEventKind) {
+        match kind {
+            RevenueUsageEventKind::StateGenerationFast => {
+                self.usage_meters.state_generations.fast += 1
+            }
+            RevenueUsageEventKind::StateGenerationFull => {
+                self.usage_meters.state_generations.full += 1
+            }
+            RevenueUsageEventKind::StateGenerationDelta => {
+                self.usage_meters.state_generations.delta += 1
+            }
+            RevenueUsageEventKind::VisualCapture => self.usage_meters.visual_captures += 1,
+            RevenueUsageEventKind::ActionExecuted => self.usage_meters.actions_executed += 1,
+            RevenueUsageEventKind::HitlEvent => self.usage_meters.hitl_events += 1,
+        }
+
+        if self.marketplace_attribution.is_some() {
+            self.revenue_events.push(RevenueUsageEvent { kind });
         }
     }
 }
@@ -634,6 +755,21 @@ fn default_skill_params() -> Value {
 
 fn parse_get_state_arguments(arguments: &Value) -> GetStateArguments {
     serde_json::from_value(arguments.clone()).unwrap_or_default()
+}
+
+fn aggregate_revenue_usage(events: &[RevenueUsageEvent]) -> RevenueShareUsage {
+    let mut usage = RevenueShareUsage::default();
+    for event in events {
+        match event.kind {
+            RevenueUsageEventKind::StateGenerationFast => usage.state_generations.fast += 1,
+            RevenueUsageEventKind::StateGenerationFull => usage.state_generations.full += 1,
+            RevenueUsageEventKind::StateGenerationDelta => usage.state_generations.delta += 1,
+            RevenueUsageEventKind::VisualCapture => usage.visual_captures += 1,
+            RevenueUsageEventKind::ActionExecuted => usage.actions_executed += 1,
+            RevenueUsageEventKind::HitlEvent => usage.hitl_events += 1,
+        }
+    }
+    usage
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1374,6 +1510,14 @@ fn run_skill_input_schema() -> Value {
 }
 
 fn get_usage_report_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+    })
+}
+
+fn get_revenue_share_report_input_schema() -> Value {
     json!({
         "type": "object",
         "additionalProperties": false,

--- a/mcp-server/tests/mcp_revenue_share.rs
+++ b/mcp-server/tests/mcp_revenue_share.rs
@@ -1,0 +1,119 @@
+use anyhow::Result;
+use mcp_server::{AuditRetentionSnapshot, MarketplaceAttribution, McpBackend, McpServer, PlanTier};
+use serde_json::{json, Value};
+
+struct MockBackend {
+    act_responses: Vec<Value>,
+    act_calls: usize,
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self {
+            act_responses: vec![json!({"status": "ok"})],
+            act_calls: 0,
+        }
+    }
+}
+
+impl McpBackend for MockBackend {
+    fn get_state(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({
+            "metadata": {
+                "url": "https://example.com",
+                "page_instance_id": "pid",
+                "state_hash": "hash",
+                "load_profile": "interactive",
+                "timestamp": 123
+            },
+            "interactive_elements": []
+        }))
+    }
+
+    fn act(&mut self, _arguments: Value) -> Result<Value> {
+        let response = self
+            .act_responses
+            .get(self.act_calls)
+            .cloned()
+            .or_else(|| self.act_responses.last().cloned())
+            .unwrap_or_else(|| json!({"status": "ok"}));
+        self.act_calls += 1;
+        Ok(response)
+    }
+
+    fn verify(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"matched": true}))
+    }
+
+    fn get_visual(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"image_sha256": "abc"}))
+    }
+
+    fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"approved": true}))
+    }
+
+    fn run_skill(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"status": "completed"}))
+    }
+
+    fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {
+        Some(AuditRetentionSnapshot {
+            retained_events: 8,
+            retained_bytes: 2_400_000,
+        })
+    }
+}
+
+#[test]
+fn test_revenue_share_report_aggregates_marketplace_usage_events() -> Result<()> {
+    let backend = MockBackend {
+        act_responses: vec![
+            json!({"status": "requires_human_approval"}),
+            json!({"status": "ok"}),
+        ],
+        act_calls: 0,
+    };
+    let attribution = MarketplaceAttribution {
+        pack_id: "acme.checkout.pack".to_string(),
+        publisher_id: "acme-inc".to_string(),
+        revenue_share_bps: 3000,
+    };
+
+    let mut server = McpServer::new_with_marketplace(backend, PlanTier::Enterprise, attribution);
+
+    server.call_tool("get_state", json!({"format": "json"}))?;
+    server.call_tool("get_state", json!({"delivery": "delta"}))?;
+    server.call_tool("act", json!({"action": "click"}))?;
+    server.call_tool("act", json!({"action": "click"}))?;
+    server.call_tool("get_visual", json!({"mode": "som"}))?;
+
+    let report = server.call_tool("get_revenue_share_report", json!({}))?;
+
+    assert_eq!(report["pack_id"], json!("acme.checkout.pack"));
+    assert_eq!(report["publisher_id"], json!("acme-inc"));
+    assert_eq!(report["revenue_share_bps"], json!(3000));
+    assert_eq!(report["event_count"], json!(6));
+    assert_eq!(report["usage"]["state_generations"]["fast"], json!(1));
+    assert_eq!(report["usage"]["state_generations"]["full"], json!(1));
+    assert_eq!(report["usage"]["state_generations"]["delta"], json!(1));
+    assert_eq!(report["usage"]["visual_captures"], json!(1));
+    assert_eq!(report["usage"]["actions_executed"], json!(1));
+    assert_eq!(report["usage"]["hitl_events"], json!(1));
+    assert_eq!(report["gross_microusd"], json!(2430));
+    assert_eq!(report["publisher_share_microusd"], json!(729));
+    assert_eq!(report["platform_share_microusd"], json!(1701));
+
+    Ok(())
+}
+
+#[test]
+fn test_revenue_share_report_is_disabled_without_marketplace_context() -> Result<()> {
+    let mut server = McpServer::new_with_plan(MockBackend::default(), PlanTier::Enterprise);
+
+    let report = server.call_tool("get_revenue_share_report", json!({}))?;
+
+    assert_eq!(report["status"], json!("marketplace_context_required"));
+
+    Ok(())
+}

--- a/plugin-host/Cargo.toml
+++ b/plugin-host/Cargo.toml
@@ -11,6 +11,7 @@ wasmtime = "30.0"
 ed25519-dalek = "2.1"
 sha2 = "0.10"
 hex = "0.4"
+semver = "1.0"
 
 [dev-dependencies]
 wat = "1.240"

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -1,7 +1,8 @@
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use wasmtime::{Engine, Module};
 
@@ -76,12 +77,63 @@ pub struct PluginPackage {
     pub wasm_module: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCompatibility {
+    pub runtime_api: String,
+    pub min_runtime_version: String,
+    #[serde(default)]
+    pub max_runtime_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MarketplaceDependency {
+    pub package: String,
+    pub version_req: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DomainPackMarketplaceMetadata {
+    pub publisher_id: String,
+    pub runtime_compatibility: RuntimeCompatibility,
+    #[serde(default)]
+    pub dependencies: Vec<MarketplaceDependency>,
+    #[serde(default)]
+    pub signature: Option<SignatureBlock>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DomainPackManifest {
+    pub pack_id: String,
+    pub version: String,
+    pub plugin_id: String,
+    pub skill_ids: Vec<String>,
+    pub marketplace: DomainPackMarketplaceMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DomainPackSkill {
+    pub skill_id: String,
+    pub version: String,
+    pub definition: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DomainPackBundle {
+    pub manifest: DomainPackManifest,
+    pub plugin: PluginPackage,
+    pub skills: Vec<DomainPackSkill>,
+}
+
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum PluginError {
     #[error("plugin manifest validation failed: {message}")]
     ManifestValidation { message: String },
+    #[error("domain pack validation failed: {message}")]
+    DomainPackValidation { message: String },
     #[error("unsigned plugin is not allowed")]
     UnsignedPlugin,
+    #[error("unsigned domain pack is not allowed")]
+    UnsignedDomainPack,
     #[error("unknown signing key: {key_id}")]
     UnknownSigningKey { key_id: String },
     #[error("invalid ed25519 public key: {reason}")]
@@ -100,6 +152,16 @@ pub enum PluginError {
     CapabilityViolation { required: Capability },
     #[error("failed to serialize signature payload: {message}")]
     SignaturePayloadSerialization { message: String },
+    #[error("invalid runtime version for {field}: {value}")]
+    InvalidRuntimeVersion { field: &'static str, value: String },
+    #[error(
+        "runtime version {runtime_version} is outside supported range [{min_supported}, {max_supported}]"
+    )]
+    IncompatibleRuntimeVersion {
+        runtime_version: String,
+        min_supported: String,
+        max_supported: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -110,6 +172,26 @@ struct SignaturePayload<'a> {
     capabilities: &'a [Capability],
     sbom: &'a SbomDocument,
     wasm_sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DomainPackSignaturePayload<'a> {
+    pack_id: &'a str,
+    version: &'a str,
+    plugin_id: &'a str,
+    skill_ids: &'a [String],
+    publisher_id: &'a str,
+    runtime_compatibility: &'a RuntimeCompatibility,
+    dependencies: &'a [MarketplaceDependency],
+    plugin_signature_payload_sha256: String,
+    skills: Vec<DomainPackSkillDigest>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DomainPackSkillDigest {
+    skill_id: String,
+    version: String,
+    definition_sha256: String,
 }
 
 pub fn signature_payload(
@@ -123,6 +205,45 @@ pub fn signature_payload(
         capabilities: &manifest.capabilities,
         sbom: &manifest.sbom,
         wasm_sha256: hex::encode(Sha256::digest(wasm_module)),
+    };
+
+    serde_json::to_vec(&payload).map_err(|err| PluginError::SignaturePayloadSerialization {
+        message: err.to_string(),
+    })
+}
+
+pub fn domain_pack_signature_payload(bundle: &DomainPackBundle) -> Result<Vec<u8>, PluginError> {
+    let plugin_payload = signature_payload(&bundle.plugin.manifest, &bundle.plugin.wasm_module)?;
+    let plugin_signature_payload_sha256 = hex::encode(Sha256::digest(&plugin_payload));
+
+    let mut skills = bundle
+        .skills
+        .iter()
+        .map(|skill| {
+            serde_json::to_vec(&skill.definition)
+                .map(|serialized| DomainPackSkillDigest {
+                    skill_id: skill.skill_id.clone(),
+                    version: skill.version.clone(),
+                    definition_sha256: hex::encode(Sha256::digest(serialized)),
+                })
+                .map_err(|err| PluginError::SignaturePayloadSerialization {
+                    message: err.to_string(),
+                })
+        })
+        .collect::<Result<Vec<_>, PluginError>>()?;
+
+    skills.sort_by(|left, right| left.skill_id.cmp(&right.skill_id));
+
+    let payload = DomainPackSignaturePayload {
+        pack_id: &bundle.manifest.pack_id,
+        version: &bundle.manifest.version,
+        plugin_id: &bundle.manifest.plugin_id,
+        skill_ids: &bundle.manifest.skill_ids,
+        publisher_id: &bundle.manifest.marketplace.publisher_id,
+        runtime_compatibility: &bundle.manifest.marketplace.runtime_compatibility,
+        dependencies: &bundle.manifest.marketplace.dependencies,
+        plugin_signature_payload_sha256,
+        skills,
     };
 
     serde_json::to_vec(&payload).map_err(|err| PluginError::SignaturePayloadSerialization {
@@ -209,6 +330,26 @@ impl PluginHost {
         })
     }
 
+    pub fn load_domain_pack(
+        &self,
+        bundle: &DomainPackBundle,
+        runtime_version: &str,
+    ) -> Result<LoadedDomainPack, PluginError> {
+        validate_domain_pack(bundle)?;
+        validate_runtime_compatibility(
+            runtime_version,
+            &bundle.manifest.marketplace.runtime_compatibility,
+        )?;
+        self.verify_domain_pack_signature(bundle)?;
+        let loaded_plugin = self.load_plugin(&bundle.plugin)?;
+
+        Ok(LoadedDomainPack {
+            manifest: bundle.manifest.clone(),
+            plugin: loaded_plugin,
+            skills: bundle.skills.clone(),
+        })
+    }
+
     fn verify_signature(&self, package: &PluginPackage) -> Result<(), PluginError> {
         let signature = package
             .manifest
@@ -223,6 +364,38 @@ impl PluginHost {
         })?;
 
         let payload = signature_payload(&package.manifest, &package.wasm_module)?;
+        let signature_bytes = hex::decode(&signature.signature_hex).map_err(|err| {
+            PluginError::InvalidSignatureEncoding {
+                reason: err.to_string(),
+            }
+        })?;
+
+        let parsed_signature = Signature::from_slice(&signature_bytes).map_err(|err| {
+            PluginError::InvalidSignatureEncoding {
+                reason: err.to_string(),
+            }
+        })?;
+
+        verifying_key
+            .verify(&payload, &parsed_signature)
+            .map_err(|_| PluginError::InvalidSignature)
+    }
+
+    fn verify_domain_pack_signature(&self, bundle: &DomainPackBundle) -> Result<(), PluginError> {
+        let signature = bundle
+            .manifest
+            .marketplace
+            .signature
+            .as_ref()
+            .ok_or(PluginError::UnsignedDomainPack)?;
+
+        let verifying_key = self.key_registry.get(&signature.key_id).ok_or_else(|| {
+            PluginError::UnknownSigningKey {
+                key_id: signature.key_id.clone(),
+            }
+        })?;
+
+        let payload = domain_pack_signature_payload(bundle)?;
         let signature_bytes = hex::decode(&signature.signature_hex).map_err(|err| {
             PluginError::InvalidSignatureEncoding {
                 reason: err.to_string(),
@@ -272,6 +445,34 @@ impl LoadedPlugin {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LoadedDomainPack {
+    manifest: DomainPackManifest,
+    plugin: LoadedPlugin,
+    skills: Vec<DomainPackSkill>,
+}
+
+impl LoadedDomainPack {
+    pub fn manifest(&self) -> &DomainPackManifest {
+        &self.manifest
+    }
+
+    pub fn plugin(&self) -> &LoadedPlugin {
+        &self.plugin
+    }
+
+    pub fn skills(&self) -> &[DomainPackSkill] {
+        &self.skills
+    }
+
+    pub fn skill_ids(&self) -> Vec<String> {
+        self.skills
+            .iter()
+            .map(|skill| skill.skill_id.clone())
+            .collect()
+    }
+}
+
 fn validate_manifest(manifest: &PluginManifest) -> Result<(), PluginError> {
     if manifest.plugin_id.trim().is_empty() {
         return Err(PluginError::ManifestValidation {
@@ -292,6 +493,159 @@ fn validate_manifest(manifest: &PluginManifest) -> Result<(), PluginError> {
     }
 
     Ok(())
+}
+
+fn validate_domain_pack(bundle: &DomainPackBundle) -> Result<(), PluginError> {
+    let manifest = &bundle.manifest;
+
+    if manifest.pack_id.trim().is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "pack_id must not be empty".to_string(),
+        });
+    }
+
+    if manifest.version.trim().is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "version must not be empty".to_string(),
+        });
+    }
+
+    if manifest.plugin_id.trim().is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "plugin_id must not be empty".to_string(),
+        });
+    }
+
+    if manifest.plugin_id != bundle.plugin.manifest.plugin_id {
+        return Err(PluginError::DomainPackValidation {
+            message: format!(
+                "domain pack plugin_id '{}' does not match plugin package id '{}'",
+                manifest.plugin_id, bundle.plugin.manifest.plugin_id
+            ),
+        });
+    }
+
+    if manifest.skill_ids.is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "skill_ids must contain at least one skill".to_string(),
+        });
+    }
+
+    if bundle.skills.is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "skills bundle must contain at least one skill".to_string(),
+        });
+    }
+
+    if manifest.marketplace.publisher_id.trim().is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "publisher_id must not be empty".to_string(),
+        });
+    }
+
+    for dependency in &manifest.marketplace.dependencies {
+        if dependency.package.trim().is_empty() || dependency.version_req.trim().is_empty() {
+            return Err(PluginError::DomainPackValidation {
+                message: "dependencies must include non-empty package and version_req".to_string(),
+            });
+        }
+    }
+
+    let mut declared_skill_ids = HashSet::new();
+    for skill_id in &manifest.skill_ids {
+        if skill_id.trim().is_empty() {
+            return Err(PluginError::DomainPackValidation {
+                message: "skill_ids must not contain empty values".to_string(),
+            });
+        }
+        if !declared_skill_ids.insert(skill_id.clone()) {
+            return Err(PluginError::DomainPackValidation {
+                message: format!("duplicate skill_id declared: {skill_id}"),
+            });
+        }
+    }
+
+    let mut bundled_skill_ids = HashSet::new();
+    for skill in &bundle.skills {
+        if skill.skill_id.trim().is_empty() || skill.version.trim().is_empty() {
+            return Err(PluginError::DomainPackValidation {
+                message: "skill entries must include non-empty skill_id and version".to_string(),
+            });
+        }
+        if !bundled_skill_ids.insert(skill.skill_id.clone()) {
+            return Err(PluginError::DomainPackValidation {
+                message: format!("duplicate skill bundle entry: {}", skill.skill_id),
+            });
+        }
+    }
+
+    for skill_id in &manifest.skill_ids {
+        if !bundled_skill_ids.contains(skill_id) {
+            return Err(PluginError::DomainPackValidation {
+                message: format!("skill_id '{skill_id}' declared but not bundled"),
+            });
+        }
+    }
+
+    for skill_id in bundled_skill_ids {
+        if !declared_skill_ids.contains(&skill_id) {
+            return Err(PluginError::DomainPackValidation {
+                message: format!("skill '{skill_id}' bundled but missing from skill_ids"),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_runtime_compatibility(
+    runtime_version: &str,
+    compatibility: &RuntimeCompatibility,
+) -> Result<(), PluginError> {
+    if compatibility.runtime_api.trim().is_empty() {
+        return Err(PluginError::DomainPackValidation {
+            message: "runtime_compatibility.runtime_api must not be empty".to_string(),
+        });
+    }
+
+    let runtime = parse_runtime_version("runtime_version", runtime_version)?;
+    let min_supported = parse_runtime_version(
+        "runtime_compatibility.min_runtime_version",
+        &compatibility.min_runtime_version,
+    )?;
+
+    let max_supported = compatibility
+        .max_runtime_version
+        .as_ref()
+        .map(|raw| {
+            parse_runtime_version("runtime_compatibility.max_runtime_version", raw)
+                .map(|parsed| (raw.clone(), parsed))
+        })
+        .transpose()?;
+
+    if runtime < min_supported
+        || max_supported
+            .as_ref()
+            .map(|(_, max)| runtime > *max)
+            .unwrap_or(false)
+    {
+        return Err(PluginError::IncompatibleRuntimeVersion {
+            runtime_version: runtime_version.to_string(),
+            min_supported: compatibility.min_runtime_version.clone(),
+            max_supported: max_supported
+                .map(|(raw, _)| raw)
+                .unwrap_or_else(|| "unbounded".to_string()),
+        });
+    }
+
+    Ok(())
+}
+
+fn parse_runtime_version(field: &'static str, value: &str) -> Result<Version, PluginError> {
+    Version::parse(value).map_err(|_| PluginError::InvalidRuntimeVersion {
+        field,
+        value: value.to_string(),
+    })
 }
 
 fn validate_sbom(sbom: &SbomDocument) -> Result<(), PluginError> {

--- a/plugin-host/tests/marketplace_bundle.rs
+++ b/plugin-host/tests/marketplace_bundle.rs
@@ -1,0 +1,183 @@
+use ed25519_dalek::{Signer, SigningKey};
+use plugin_host::{
+    Capability, DomainPackBundle, DomainPackManifest, DomainPackMarketplaceMetadata,
+    DomainPackSkill, ExtensionPoint, KeyRegistry, MarketplaceDependency, PluginError, PluginHost,
+    PluginManifest, PluginPackage, RuntimeCompatibility, SbomComponent, SbomDocument,
+    SignatureBlock, domain_pack_signature_payload, signature_payload,
+};
+use serde_json::json;
+
+fn sample_wasm_module() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (func (export "on_state"))
+            (func (export "before_act"))
+        )"#,
+    )
+    .expect("failed to build wasm fixture")
+}
+
+fn sample_sbom() -> SbomDocument {
+    SbomDocument {
+        format: "cyclonedx-1.5".to_string(),
+        components: vec![SbomComponent {
+            name: "fixture-component".to_string(),
+            version: "1.0.0".to_string(),
+            license: Some("MIT".to_string()),
+        }],
+    }
+}
+
+fn sample_plugin_manifest() -> PluginManifest {
+    PluginManifest {
+        plugin_id: "acme.checkout".to_string(),
+        version: "1.3.0".to_string(),
+        entry_points: vec![ExtensionPoint::OnState, ExtensionPoint::BeforeAct],
+        capabilities: vec![Capability::ReadState],
+        signature: None,
+        sbom: sample_sbom(),
+    }
+}
+
+fn sign_plugin_manifest(
+    manifest: &PluginManifest,
+    wasm: &[u8],
+    signing_key: &SigningKey,
+    key_id: &str,
+) -> SignatureBlock {
+    let payload = signature_payload(manifest, wasm).expect("signature payload must be buildable");
+    let signature = signing_key.sign(&payload);
+
+    SignatureBlock {
+        key_id: key_id.to_string(),
+        signature_hex: hex::encode(signature.to_bytes()),
+    }
+}
+
+fn sign_domain_pack(
+    bundle: &DomainPackBundle,
+    signing_key: &SigningKey,
+    key_id: &str,
+) -> SignatureBlock {
+    let payload = domain_pack_signature_payload(bundle)
+        .expect("domain pack signature payload must be buildable");
+    let signature = signing_key.sign(&payload);
+
+    SignatureBlock {
+        key_id: key_id.to_string(),
+        signature_hex: hex::encode(signature.to_bytes()),
+    }
+}
+
+fn sample_bundle(signing_key: &SigningKey, key_id: &str) -> DomainPackBundle {
+    let wasm_module = sample_wasm_module();
+    let mut plugin_manifest = sample_plugin_manifest();
+    plugin_manifest.signature = Some(sign_plugin_manifest(
+        &plugin_manifest,
+        &wasm_module,
+        signing_key,
+        key_id,
+    ));
+
+    let plugin = PluginPackage {
+        manifest: plugin_manifest,
+        wasm_module,
+    };
+
+    let marketplace = DomainPackMarketplaceMetadata {
+        publisher_id: "acme-inc".to_string(),
+        runtime_compatibility: RuntimeCompatibility {
+            runtime_api: "2.1".to_string(),
+            min_runtime_version: "0.16.0".to_string(),
+            max_runtime_version: Some("0.20.0".to_string()),
+        },
+        dependencies: vec![MarketplaceDependency {
+            package: "skills-engine.checkout".to_string(),
+            version_req: "^1.0".to_string(),
+        }],
+        signature: None,
+    };
+
+    let manifest = DomainPackManifest {
+        pack_id: "acme.checkout.pack".to_string(),
+        version: "2026.03.0".to_string(),
+        plugin_id: "acme.checkout".to_string(),
+        skill_ids: vec!["checkout.submit".to_string()],
+        marketplace,
+    };
+
+    let skills = vec![DomainPackSkill {
+        skill_id: "checkout.submit".to_string(),
+        version: "1.0.0".to_string(),
+        definition: json!({
+            "schema_version": 1,
+            "name": "checkout.submit",
+            "steps": [
+                {
+                    "type": "verify",
+                    "target": "id:42",
+                    "expected": "Purchase"
+                },
+                {
+                    "type": "act",
+                    "action": "click",
+                    "target": "id:42"
+                }
+            ]
+        }),
+    }];
+
+    let mut bundle = DomainPackBundle {
+        manifest,
+        plugin,
+        skills,
+    };
+
+    let signature = sign_domain_pack(&bundle, signing_key, key_id);
+    bundle.manifest.marketplace.signature = Some(signature);
+    bundle
+}
+
+#[test]
+fn test_load_domain_pack_accepts_signed_compatible_bundle() {
+    let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+    let key_id = "marketplace-key";
+
+    let mut registry = KeyRegistry::default();
+    registry
+        .register_hex_ed25519(key_id, &hex::encode(signing_key.verifying_key().to_bytes()))
+        .expect("must register key");
+
+    let host = PluginHost::new(registry);
+    let bundle = sample_bundle(&signing_key, key_id);
+
+    let loaded = host
+        .load_domain_pack(&bundle, "0.18.2")
+        .expect("signed compatible bundle should load");
+
+    assert_eq!(loaded.manifest().pack_id, "acme.checkout.pack");
+    assert_eq!(loaded.skill_ids(), vec!["checkout.submit"]);
+}
+
+#[test]
+fn test_load_domain_pack_rejects_incompatible_runtime_version() {
+    let signing_key = SigningKey::from_bytes(&[13u8; 32]);
+    let key_id = "marketplace-key";
+
+    let mut registry = KeyRegistry::default();
+    registry
+        .register_hex_ed25519(key_id, &hex::encode(signing_key.verifying_key().to_bytes()))
+        .expect("must register key");
+
+    let host = PluginHost::new(registry);
+    let bundle = sample_bundle(&signing_key, key_id);
+
+    let err = host
+        .load_domain_pack(&bundle, "0.24.0")
+        .expect_err("runtime outside compatibility range must fail");
+
+    assert!(matches!(
+        err,
+        PluginError::IncompatibleRuntimeVersion { .. }
+    ));
+}


### PR DESCRIPTION
## 概要
PR-17 (Marketplace Integration) を実装しました。`plugin-host` に Domain Pack（plugin + skill bundle）仕様と署名/互換性検証を追加し、`mcp-server` に Revenue Share 用の利用イベント連携と集計レポートを追加しています。

## Spec / Plan
- Spec Ref: `docs/SPEC.md` Section 7.3
- Plan Ref: `docs/PLAN.md` PR-17

## Exit Criteria
- [x] Domain Pack 公開に必要な最小機能（bundle仕様、公開メタデータ、署名検証、互換性検証）を実装
- [x] Revenue Share 集計に必要な利用イベント連携を実装
- [x] Bundle 署名検証・互換性検証テストを追加
- [x] Revenue Share 集計回帰テストを追加
- [x] Marketplace bundle / Revenue Share 回帰の CI ジョブを追加

## 変更内容
- `plugin-host`
  - `DomainPackBundle` / `DomainPackManifest` / `DomainPackMarketplaceMetadata` / `RuntimeCompatibility` / `MarketplaceDependency` / `DomainPackSkill` を追加
  - `domain_pack_signature_payload(...)` を追加
  - `PluginHost::load_domain_pack(...)` を追加
  - Domain Pack の署名検証、skill 同梱整合性検証、runtime semver 互換性検証を追加
- `mcp-server`
  - `MarketplaceAttribution` / `RevenueShareUsage` / `RevenueShareReport` を追加
  - `McpServer::new_with_marketplace(...)` を追加
  - 利用メーター記録を Revenue Share イベント連携可能な形へ統合
  - `get_revenue_share_report` ツールを追加
- CI
  - `marketplace-bundle-verification` ジョブ追加
  - `revenue-share-regression` ジョブ追加
- Docs
  - `docs/PLAN.md` の PR-17 を DONE (Local) に更新
  - `docs/SPEC.md` 7.3 に Domain Pack package spec / Revenue Share 集計ルールを追記

## テスト結果
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test -p plugin-host --test marketplace_bundle`
- `cargo test -p mcp-server --test mcp_revenue_share`

上記すべてローカルで成功。
