### PR TITLE
[PR-18] 高度なE2E検証とセキュリティ監査

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,11 @@ jobs:
     - name: Run semantic wait smoke test
       env:
         CHROME_INSTALLED: "true"
-      run: cargo test -p core-runtime --test semantic_wait -- --nocapture
+      run: |
+        cargo test -p core-runtime --test semantic_wait -- --nocapture
+        cargo test -p core-runtime --test session_management --verbose
+        cargo test -p core-runtime --test audit_logging --verbose
+        cargo test -p core-runtime --test spa_stable_key_stress --verbose
   cdp-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -208,13 +208,39 @@ fn redact_sensitive_text(text: &str) -> String {
     static CC_RE: OnceLock<Regex> = OnceLock::new();
     static EMAIL_RE: OnceLock<Regex> = OnceLock::new();
 
-    let cc_re = CC_RE.get_or_init(|| {
-        Regex::new(r"\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,4}\b").expect("Invalid CC regex")
-    });
+    let cc_re =
+        CC_RE.get_or_init(|| Regex::new(r"\b\d(?:[ -]?\d){12,18}\b").expect("Invalid CC regex"));
     let email_re = EMAIL_RE.get_or_init(|| {
         Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b").expect("Invalid email regex")
     });
 
     let cc_redacted = cc_re.replace_all(text, "****-****-****-XXXX");
     email_re.replace_all(&cc_redacted, "***").into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_sensitive_text;
+
+    #[test]
+    fn redact_sensitive_text_masks_card_numbers_up_to_nineteen_digits() {
+        let cases = [
+            (
+                "Card 4111-1111-1111-1111 for alice@example.com",
+                "Card ****-****-****-XXXX for ***",
+            ),
+            (
+                "Card 4000 1234 5678 9012 345 for alice@example.com",
+                "Card ****-****-****-XXXX for ***",
+            ),
+            (
+                "Card 4000123456789012345 for alice@example.com",
+                "Card ****-****-****-XXXX for ***",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(redact_sensitive_text(input), expected);
+        }
+    }
 }

--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -151,7 +151,7 @@ fn redact_json_value(
             for (key, child) in map {
                 let key_lower = key.to_ascii_lowercase();
                 let masked_child = if is_sensitive_key(&key_lower)
-                    || (mask_tool_value_field && key_lower == "value")
+                    || (mask_tool_value_field && should_mask_tool_argument_key(&key_lower))
                 {
                     serde_json::Value::String("***".to_string())
                 } else {
@@ -176,6 +176,10 @@ fn redact_json_value(
         }
         _ => value.clone(),
     }
+}
+
+fn should_mask_tool_argument_key(key: &str) -> bool {
+    key == "value" || key == "text" || key.ends_with("_text")
 }
 
 fn is_sensitive_key(key: &str) -> bool {

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -25,7 +25,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
             <body>
                 <input id="email" type="email" value="seed@example.com" />
                 <input id="password" type="password" value="MySecretP@ssw0rd!" />
-                <div id="cc-note">Card: 5555-4444-3333-2222</div>
+                <div id="cc-note">Card: 4000 1234 5678 9012 345</div>
                 <button id="submit">Submit</button>
             </body>
         </html>
@@ -44,7 +44,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
         Some(input_id),
         Some(&input_key),
         "type",
-        Some("alice@example.com 4111-1111-1111-1111"),
+        Some("alice@example.com 4000 1234 5678 9012 345"),
     )?;
 
     let events = wait_for_events(&page, 3, Duration::from_secs(2));
@@ -105,7 +105,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
         "state snapshot must mask password value"
     );
     assert!(
-        !snapshot_text.contains("5555-4444-3333-2222"),
+        !snapshot_text.contains("4000 1234 5678 9012 345"),
         "state snapshot must mask card number"
     );
     let email_input =
@@ -168,7 +168,7 @@ fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
     page.clear_audit_events();
     let result = page.verify_text(
         target_id,
-        "MySecretP@ssw0rd! alice@example.com 4111-1111-1111-1111",
+        "MySecretP@ssw0rd! alice@example.com 4000 1234 5678 9012 345",
     );
     assert!(
         result.is_err(),
@@ -196,7 +196,7 @@ fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
         "verify_text tool args should redact email addresses"
     );
     assert!(
-        !tool_args_text.contains("4111-1111-1111-1111"),
+        !tool_args_text.contains("4000 1234 5678 9012 345"),
         "verify_text tool args should redact card numbers"
     );
     assert_eq!(

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -24,6 +24,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
         <html>
             <body>
                 <input id="email" type="email" value="seed@example.com" />
+                <input id="password" type="password" value="MySecretP@ssw0rd!" />
                 <div id="cc-note">Card: 5555-4444-3333-2222</div>
                 <button id="submit">Submit</button>
             </body>
@@ -100,12 +101,110 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
         "state snapshot must mask email value"
     );
     assert!(
+        !snapshot_text.contains("MySecretP@ssw0rd!"),
+        "state snapshot must mask password value"
+    );
+    assert!(
         !snapshot_text.contains("5555-4444-3333-2222"),
         "state snapshot must mask card number"
     );
+    let email_input =
+        find_node_by_dom_id(snapshot_payload, "email").context("email input snapshot missing")?;
+    assert_eq!(
+        email_input
+            .pointer("/attributes/value")
+            .and_then(|value| value.as_str()),
+        Some("***"),
+        "email input value should be masked in state snapshot"
+    );
+
+    let password_input = find_node_by_dom_id(snapshot_payload, "password")
+        .context("password input snapshot missing")?;
+    assert_eq!(
+        password_input
+            .pointer("/attributes/value")
+            .and_then(|value| value.as_str()),
+        Some("***"),
+        "password input value should be masked in state snapshot"
+    );
+
+    let card_text =
+        find_node_by_role_and_label_fragment(snapshot_payload, "text", "****-****-****-XXXX")
+            .context("redacted card text snapshot missing")?;
+    assert_eq!(
+        card_text.get("label").and_then(|value| value.as_str()),
+        Some("Card: ****-****-****-XXXX"),
+        "card text should preserve the redaction marker"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
+    if should_skip() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <div id="status">Ready for verification</div>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    let (target_id, _) =
+        find_node_info_by_dom_id(state.root(), "status").context("status element not found")?;
+
+    page.clear_audit_events();
+    let result = page.verify_text(
+        target_id,
+        "MySecretP@ssw0rd! alice@example.com 4111-1111-1111-1111",
+    );
     assert!(
-        snapshot_text.contains("****-****-****-XXXX"),
-        "state snapshot should keep redaction marker for card numbers"
+        result.is_err(),
+        "verify_text should fail on mismatched expectation"
+    );
+
+    let events = wait_for_events(&page, 1, Duration::from_secs(2));
+    let tool_args = events
+        .iter()
+        .find_map(|event| match event {
+            AuditEvent::ToolCall {
+                tool_name, args, ..
+            } if tool_name == "verify_text" => Some(args),
+            _ => None,
+        })
+        .context("TOOL_CALL(verify_text) event not found")?;
+
+    let tool_args_text = serde_json::to_string(tool_args)?;
+    assert!(
+        !tool_args_text.contains("MySecretP@ssw0rd!"),
+        "verify_text tool args should redact password-like secrets"
+    );
+    assert!(
+        !tool_args_text.contains("alice@example.com"),
+        "verify_text tool args should redact email addresses"
+    );
+    assert!(
+        !tool_args_text.contains("4111-1111-1111-1111"),
+        "verify_text tool args should redact card numbers"
+    );
+    assert_eq!(
+        tool_args
+            .get("expected_text")
+            .and_then(|value| value.as_str()),
+        Some("***"),
+        "verify_text expected_text should be masked"
     );
 
     Ok(())
@@ -146,4 +245,44 @@ fn find_node_info_by_dom_id(
     }
 
     None
+}
+
+fn find_node_by_dom_id<'a>(
+    node: &'a serde_json::Value,
+    dom_id: &str,
+) -> Option<&'a serde_json::Value> {
+    let is_match = node
+        .get("attributes")
+        .and_then(|attributes| attributes.as_object())
+        .and_then(|attributes| attributes.get("id"))
+        .and_then(|value| value.as_str())
+        == Some(dom_id);
+    if is_match {
+        return Some(node);
+    }
+
+    node.get("children")?
+        .as_array()?
+        .iter()
+        .find_map(|child| find_node_by_dom_id(child, dom_id))
+}
+
+fn find_node_by_role_and_label_fragment<'a>(
+    node: &'a serde_json::Value,
+    role: &str,
+    label_fragment: &str,
+) -> Option<&'a serde_json::Value> {
+    let role_matches = node.get("role").and_then(|value| value.as_str()) == Some(role);
+    let label_matches = node
+        .get("label")
+        .and_then(|value| value.as_str())
+        .is_some_and(|label| label.contains(label_fragment));
+    if role_matches && label_matches {
+        return Some(node);
+    }
+
+    node.get("children")?
+        .as_array()?
+        .iter()
+        .find_map(|child| find_node_by_role_and_label_fragment(child, role, label_fragment))
 }

--- a/core-runtime/tests/session_management.rs
+++ b/core-runtime/tests/session_management.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use core_runtime::{BrowserClient, LocalSessionVault, SessionVault, SoftwareKms};
+use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, SoftwareKms};
 
 fn should_skip() -> bool {
     std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
@@ -73,9 +73,11 @@ async fn test_session_management_key_rotation_restore_roundtrip() -> anyhow::Res
         return Ok(());
     }
 
-    let vault = Arc::new(LocalSessionVault::new(Box::new(SoftwareKms::new(
+    let kms_log = Arc::new(Mutex::new(KmsCallLog::default()));
+    let vault = Arc::new(LocalSessionVault::new(Box::new(RecordingKms::new(
         [1u8; 32],
         "key-1".to_string(),
+        Arc::clone(&kms_log),
     ))));
     let client = BrowserClient::new_with_vault(vault.clone())?;
     let page = client.new_page()?;
@@ -83,27 +85,54 @@ async fn test_session_management_key_rotation_restore_roundtrip() -> anyhow::Res
     page.navigate("https://example.com")?;
     set_cookie(&page, "rotate_cookie", "before_rotation")?;
     page.save_to_vault("rotation-session").await?;
+    assert_eq!(
+        last_encrypt_key_id(&kms_log).as_deref(),
+        Some("key-1"),
+        "pre-rotation saves must use the original key"
+    );
 
     vault.rotate_key([2u8; 32], "key-2".to_string()).await?;
+    clear_decrypt_log(&kms_log);
 
-    clear_cookie(&page, "rotate_cookie")?;
+    let restored_page = client.new_page()?;
+    restored_page.navigate("https://example.com")?;
+    clear_cookie(&restored_page, "rotate_cookie")?;
     assert!(
-        cookie_value(&page, "rotate_cookie")?.is_none(),
+        cookie_value(&restored_page, "rotate_cookie")?.is_none(),
         "cookie should be absent before restore"
     );
-    page.load_from_vault("rotation-session").await?;
+    restored_page.load_from_vault("rotation-session").await?;
     assert_eq!(
-        cookie_value(&page, "rotate_cookie")?.as_deref(),
+        cookie_value(&restored_page, "rotate_cookie")?.as_deref(),
         Some("before_rotation")
     );
-
-    set_cookie(&page, "rotate_cookie", "after_rotation")?;
-    page.save_to_vault("rotation-session").await?;
-    clear_cookie(&page, "rotate_cookie")?;
-    page.load_from_vault("rotation-session").await?;
     assert_eq!(
-        cookie_value(&page, "rotate_cookie")?.as_deref(),
+        last_decrypt_key_id(&kms_log).as_deref(),
+        Some("key-2"),
+        "restores after rotation must decrypt with the rotated key"
+    );
+
+    set_cookie(&restored_page, "rotate_cookie", "after_rotation")?;
+    restored_page.save_to_vault("rotation-session").await?;
+    assert_eq!(
+        last_encrypt_key_id(&kms_log).as_deref(),
+        Some("key-2"),
+        "post-rotation saves must use the rotated key"
+    );
+
+    clear_decrypt_log(&kms_log);
+    let verifier_page = client.new_page()?;
+    verifier_page.navigate("https://example.com")?;
+    clear_cookie(&verifier_page, "rotate_cookie")?;
+    verifier_page.load_from_vault("rotation-session").await?;
+    assert_eq!(
+        cookie_value(&verifier_page, "rotate_cookie")?.as_deref(),
         Some("after_rotation")
+    );
+    assert_eq!(
+        last_decrypt_key_id(&kms_log).as_deref(),
+        Some("key-2"),
+        "updated sessions must remain readable with the rotated key"
     );
 
     Ok(())
@@ -140,4 +169,77 @@ fn cookie_value(page: &core_runtime::PageSession, name: &str) -> anyhow::Result<
         let value = parts.next().unwrap_or_default();
         (key == name).then(|| value.to_string())
     }))
+}
+
+#[derive(Debug, Default)]
+struct KmsCallLog {
+    encrypt_key_ids: Vec<String>,
+    decrypt_key_ids: Vec<String>,
+}
+
+struct RecordingKms {
+    inner: SoftwareKms,
+    log: Arc<Mutex<KmsCallLog>>,
+}
+
+impl RecordingKms {
+    fn new(key: [u8; 32], key_id: String, log: Arc<Mutex<KmsCallLog>>) -> Self {
+        Self {
+            inner: SoftwareKms::new(key, key_id),
+            log,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl KmsAdapter for RecordingKms {
+    async fn encrypt(&self, plaintext: &[u8]) -> anyhow::Result<(Vec<u8>, String)> {
+        let (ciphertext, key_id) = self.inner.encrypt(plaintext).await?;
+        self.log
+            .lock()
+            .expect("kms log lock should not be poisoned")
+            .encrypt_key_ids
+            .push(key_id.clone());
+        Ok((ciphertext, key_id))
+    }
+
+    async fn decrypt(&self, ciphertext: &[u8], key_id: &str) -> anyhow::Result<Vec<u8>> {
+        self.log
+            .lock()
+            .expect("kms log lock should not be poisoned")
+            .decrypt_key_ids
+            .push(key_id.to_string());
+        self.inner.decrypt(ciphertext, key_id).await
+    }
+
+    fn current_key_id(&self) -> String {
+        self.inner.current_key_id()
+    }
+
+    fn add_key(&mut self, key: [u8; 32], key_id: String, make_current: bool) {
+        self.inner.add_key(key, key_id, make_current);
+    }
+}
+
+fn clear_decrypt_log(log: &Arc<Mutex<KmsCallLog>>) {
+    log.lock()
+        .expect("kms log lock should not be poisoned")
+        .decrypt_key_ids
+        .clear();
+}
+
+fn last_encrypt_key_id(log: &Arc<Mutex<KmsCallLog>>) -> Option<String> {
+    log.lock()
+        .expect("kms log lock should not be poisoned")
+        .encrypt_key_ids
+        .last()
+        .cloned()
+}
+
+fn last_decrypt_key_id(log: &Arc<Mutex<KmsCallLog>>) -> Option<String> {
+    log.lock()
+        .expect("kms log lock should not be poisoned")
+        .decrypt_key_ids
+        .last()
+        .cloned()
 }

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -21,22 +21,31 @@ fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
             <body>
                 <div id="app"></div>
                 <script>
-                    window.__clicks = 0;
-                    function render(step) {
-                        const rows = Array.from({length: (step % 5) + 1}, (_, i) =>
-                            `<li data-step="${step}" data-index="${i}">row-${step}-${i}</li>`
+                    window.__clicks = [];
+                    function render(route, step) {
+                        const rows = Array.from({length: (step % 4) + 2}, (_, i) =>
+                            `<li data-route="${route}" data-index="${i}">row-${route}-${i}</li>`
                         ).join("");
                         document.getElementById("app").innerHTML = `
-                            <section>
-                                <h2>Checkout Flow</h2>
-                                <ul>${rows}</ul>
-                                <button id="target" onclick="window.__clicks = (window.__clicks || 0) + 1;">
-                                    Confirm Purchase
-                                </button>
+                            <section data-route="${route}" data-step="${step}">
+                                <aside>
+                                    <button class="cta secondary" style="position:absolute; left:24px; top:24px;"
+                                        onclick="window.__clicks.push('secondary:${route}')">
+                                        Continue
+                                    </button>
+                                </aside>
+                                <main>
+                                    <h2>Checkout Flow</h2>
+                                    <ul>${rows}</ul>
+                                    <button class="cta primary" style="position:absolute; left:520px; top:24px;"
+                                        onclick="window.__clicks.push('${route}')">
+                                        Continue
+                                    </button>
+                                </main>
                             </section>
                         `;
                     }
-                    render(0);
+                    render('catalog', 0);
                 </script>
             </body>
         </html>
@@ -44,27 +53,50 @@ fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
     let url = format!("data:text/html,{}", urlencoding::encode(html));
     page.navigate(&url)?;
 
-    let root = page.get_document_node()?;
-    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
-    let state = SemanticState::new(sem, LoadProfile::Interactive);
-    let (initial_target_id, stable_key) =
-        find_node_info_by_dom_id(state.root(), "target").expect("target button not found");
+    let mut current_target =
+        capture_primary_button_info(&page)?.expect("primary CTA should exist on initial render");
+    let stable_key = current_target.1.clone();
+    let routes = [
+        "shipping",
+        "payment",
+        "review",
+        "confirmation",
+        "upsell",
+        "receipt",
+    ];
 
-    let iterations: i64 = 20;
-    for step in 1..=iterations {
-        page.evaluate_script(&format!("render({step});"))?;
-        let stale_id = initial_target_id + 1_000_000 + step;
-        page.act(Some(stale_id), Some(&stable_key), "click", None)?;
+    for (step, route) in routes.iter().enumerate() {
+        let previous_target_id = current_target.0;
+        page.evaluate_script(&format!("render('{route}', {});", step + 1))?;
+
+        let refreshed_target = capture_primary_button_info(&page)?
+            .expect("primary CTA should remain discoverable after rerender");
+        assert_ne!(
+            refreshed_target.0, previous_target_id,
+            "SPA rerender for route {route} should replace the previous backend node id"
+        );
+        assert_eq!(
+            refreshed_target.1, stable_key,
+            "stable_key should stay fixed for the primary CTA across route {route}"
+        );
+
+        // Some Chromium backends keep detached backend_node_id values actionable for a short
+        // time. Derive a guaranteed-invalid id from the retired node to force the fallback path
+        // while still asserting that the real DOM id churned across the SPA transition.
+        let forced_stale_id = previous_target_id + 1_000_000;
+        page.act(Some(forced_stale_id), Some(&stable_key), "click", None)?;
+        current_target = refreshed_target;
     }
 
-    let clicks = page
-        .evaluate_script("window.__clicks")?
+    let click_log = page
+        .evaluate_script("JSON.stringify(window.__clicks)")?
         .value
-        .and_then(|v| v.as_u64())
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
         .unwrap_or_default();
     assert_eq!(
-        clicks, iterations as u64,
-        "all fallback actions should succeed"
+        click_log,
+        serde_json::to_string(&routes)?,
+        "all route transitions should click the primary CTA through stale-id recovery"
     );
 
     let fallback_recoveries = page
@@ -73,28 +105,38 @@ fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
         .filter(|entry| entry.code == "stable_key_fallback_recovered")
         .count();
     assert!(
-        fallback_recoveries >= iterations as usize,
-        "expected at least {iterations} fallback recovery logs, got {fallback_recoveries}"
+        fallback_recoveries >= routes.len(),
+        "expected at least {} fallback recovery logs, got {fallback_recoveries}",
+        routes.len()
     );
 
     Ok(())
 }
 
-fn find_node_info_by_dom_id(
+fn capture_primary_button_info(
+    page: &core_runtime::PageSession,
+) -> anyhow::Result<Option<(i64, String)>> {
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    Ok(find_node_info_by_class(state.root(), "primary"))
+}
+
+fn find_node_info_by_class(
     node: &core_runtime::sre::state::SemanticNode,
-    dom_id: &str,
+    class_name: &str,
 ) -> Option<(i64, String)> {
-    if node
+    let has_class = node
         .attributes
         .as_ref()
-        .and_then(|attrs| attrs.get("id"))
-        .is_some_and(|id| id == dom_id)
-    {
+        .and_then(|attrs| attrs.get("class"))
+        .is_some_and(|class| class.split_whitespace().any(|token| token == class_name));
+    if has_class && node.role == "button" {
         return Some((node.backend_node_id, node.stable_key.clone()?));
     }
 
     for child in &node.children {
-        if let Some(found) = find_node_info_by_dom_id(child, dom_id) {
+        if let Some(found) = find_node_info_by_class(child, class_name) {
             return Some(found);
         }
     }

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -39,7 +39,7 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 | 5 | Extensions & API | PR-12〜14 | 3/3 | DONE |
 | 6 | Monetization Meters | PR-16 | 1/1 | DONE |
 | 7 | Marketplace | PR-17 | 1/1 | DONE |
-| 8 | Robustness & Verification | PR-18 | 0/1 | NOT_STARTED |
+| 8 | Robustness & Verification | PR-18 | 1/1 | DONE |
 
 ## 3. PRバックログ（進捗チェック付き）
 
@@ -372,20 +372,20 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
   - [x] Domain Pack公開に必要な最小機能が実装されている。
 
 ### PR-18: Advanced E2E Verification & Security Audit
-- Status: `NOT_STARTED`
+- Status: `DONE`
 - Spec Ref: SEC-02, AUD-01, ACT-01
 - Dependencies: PR-11, PR-10, PR-03
 - 実装タスク
-  - [ ] `core-runtime/tests/session_management.rs` の実装（ドメイン跨ぎセッション保存/復元、鍵ローテーション E2E）。
-  - [ ] `core-runtime/tests/audit_logging.rs` の実装（操作シーケンス一貫性、PIIマスク実効性）。
-  - [ ] 複雑な SPA 遷移における `stable_key` 自己修復のストレステストの実装。
+  - [x] `core-runtime/tests/session_management.rs` の実装（ドメイン跨ぎセッション保存/復元、鍵ローテーション E2E）。
+  - [x] `core-runtime/tests/audit_logging.rs` の実装（操作シーケンス一貫性、PIIマスク実効性）。
+  - [x] 複雑な SPA 遷移における `stable_key` 自己修復のストレステストの実装。
 - テストタスク
-  - [ ] `TOOL_CALL` および `STATE_SNAPSHOT` の両方で PII がマスクされていることを確認。
-  - [ ] 鍵ローテーション後、新しい鍵で旧セッションデータが正しく復号・再利用できることを確認。
+  - [x] `TOOL_CALL` および `STATE_SNAPSHOT` の両方で PII がマスクされていることを確認。
+  - [x] 鍵ローテーション後、新しい鍵で旧セッションデータが正しく復号・再利用できることを確認。
 - CIタスク
-  - [ ] 新規 E2E テストを `cdp-smoke` または `full-e2e` ジョブに追加。
+  - [x] 新規 E2E テストを `cdp-smoke` または `full-e2e` ジョブに追加。
 - Exit Criteria
-  - [ ] 実機環境（Headless Chrome）において、仕様通りのセキュリティ・監査・リカバリが保証されている。
+  - [x] 実機環境（Headless Chrome）において、仕様通りのセキュリティ・監査・リカバリが保証されている。
 
 ## 4. 共通 Definition of Done（全PR共通）
 


### PR DESCRIPTION
## Summary
- PR-18 の高度な E2E 検証を追加し、`session_management` / `audit_logging` / `spa_stable_key_stress` のカバレッジを拡充
- `TOOL_CALL` / `STATE_SNAPSHOT` における PII マスク、鍵ローテーション後のセッション復元、SPA 再レンダリング時の stable key 自己修復を実機系テストで確認
- CI で PR-18 向けの追加検証が継続実行されるよう更新

## Spec Traceability
- `docs/SPEC.md`: `SEC-02`, `AUD-01`, `ACT-01`
- `docs/PLAN.md`: `PR-18: Advanced E2E Verification & Security Audit`

## Exit Criteria
- [x] `core-runtime/tests/session_management.rs` の実装（ドメイン跨ぎセッション保存/復元、鍵ローテーション E2E）
- [x] `core-runtime/tests/audit_logging.rs` の実装（操作シーケンス一貫性、PIIマスク実効性）
- [x] 複雑な SPA 遷移における `stable_key` 自己修復のストレステストの実装
- [x] `TOOL_CALL` および `STATE_SNAPSHOT` の両方で PII がマスクされていることを確認
- [x] 鍵ローテーション後、新しい鍵で旧セッションデータが正しく復号・再利用できることを確認
- [x] 新規 E2E テストを `cdp-smoke` または `full-e2e` ジョブに追加

## Tests
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`

## Notes
- `docs/PLAN.md` の PR-18 を `DONE` に更新済み
- 破壊的変更なし
