### PR TITLE
[PR-19] 包括評価テストベンチ拡張

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "feature/**" ]
+    branches: [ "main", "feature/**", "codex/**" ]
   pull_request:
     branches: [ "main" ]
 
@@ -272,3 +272,40 @@ jobs:
         path: |
           core-runtime/target/nfr-dashboard.md
           core-runtime/target/nfr-metrics/*.json
+
+  evaluation-bench-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      CHROME_INSTALLED: "true"
+      DRAGON_HEAD_EVAL_MODE: "smoke"
+      DRAGON_HEAD_EVAL_OUTPUT_DIR: "${{ github.workspace }}/target/evaluation-bench"
+      DRAGON_HEAD_EVAL_DASHBOARD_PATH: "${{ github.workspace }}/target/evaluation-dashboard.md"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install chromium
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y chromium-browser
+    - name: Run core-runtime evaluation bench
+      run: cargo test -p core-runtime --test comprehensive_evaluation -- --nocapture
+    - name: Run mcp-server evaluation bench
+      run: cargo test -p mcp-server --test comprehensive_evaluation -- --nocapture
+    - name: Run skills-engine evaluation bench
+      run: cargo test -p skills-engine --test comprehensive_evaluation --verbose
+    - name: Run plugin-host evaluation bench
+      run: cargo test -p plugin-host --test comprehensive_evaluation --verbose
+    - name: Run marketplace evaluation bench
+      run: cargo test -p marketplace --test comprehensive_evaluation --verbose
+    - name: Generate evaluation dashboard
+      run: |
+        python3 scripts/evaluation_dashboard.py --input-dir "$DRAGON_HEAD_EVAL_OUTPUT_DIR" --output "$DRAGON_HEAD_EVAL_DASHBOARD_PATH"
+        cat "$DRAGON_HEAD_EVAL_DASHBOARD_PATH" >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload evaluation bench artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: evaluation-bench-smoke
+        path: |
+          target/evaluation-dashboard.md
+          target/evaluation-bench/*.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,3 +75,39 @@ jobs:
         path: |
           *.png
           *.log
+
+  evaluation-bench-full:
+    runs-on: ubuntu-latest
+    env:
+      CHROME_INSTALLED: "true"
+      DRAGON_HEAD_EVAL_MODE: "full"
+      DRAGON_HEAD_EVAL_OUTPUT_DIR: "${{ github.workspace }}/target/evaluation-bench"
+      DRAGON_HEAD_EVAL_DASHBOARD_PATH: "${{ github.workspace }}/target/evaluation-dashboard.md"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y chromium-browser
+    - name: Run core-runtime evaluation bench
+      run: cargo test -p core-runtime --test comprehensive_evaluation -- --nocapture
+    - name: Run mcp-server evaluation bench
+      run: cargo test -p mcp-server --test comprehensive_evaluation -- --nocapture
+    - name: Run skills-engine evaluation bench
+      run: cargo test -p skills-engine --test comprehensive_evaluation --verbose
+    - name: Run plugin-host evaluation bench
+      run: cargo test -p plugin-host --test comprehensive_evaluation --verbose
+    - name: Run marketplace evaluation bench
+      run: cargo test -p marketplace --test comprehensive_evaluation --verbose
+    - name: Generate evaluation dashboard
+      run: |
+        python3 scripts/evaluation_dashboard.py --input-dir "$DRAGON_HEAD_EVAL_OUTPUT_DIR" --output "$DRAGON_HEAD_EVAL_DASHBOARD_PATH"
+        cat "$DRAGON_HEAD_EVAL_DASHBOARD_PATH" >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload evaluation bench artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: evaluation-bench-full
+        path: |
+          target/evaluation-dashboard.md
+          target/evaluation-bench/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "test-bench-support",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1508,6 +1509,7 @@ dependencies = [
 name = "marketplace"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ed25519-dalek",
  "hex",
  "plugin-host",
@@ -1516,6 +1518,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "skills-engine",
+ "test-bench-support",
  "thiserror 1.0.69",
 ]
 
@@ -1531,6 +1534,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "skills-engine",
+ "test-bench-support",
  "thiserror 1.0.69",
  "tokio",
  "urlencoding",
@@ -1777,11 +1781,13 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "plugin-host"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ed25519-dalek",
  "hex",
  "serde",
  "serde_json",
  "sha2",
+ "test-bench-support",
  "thiserror 1.0.69",
  "wasmtime",
  "wat",
@@ -2345,6 +2351,7 @@ dependencies = [
  "jsonschema",
  "serde",
  "serde_json",
+ "test-bench-support",
  "thiserror 1.0.69",
 ]
 
@@ -2475,6 +2482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-bench-support"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "plugin-host",
     "skills-engine",
     "marketplace",
+    "test-bench-support",
 ]
 resolver = "2"
 

--- a/Justfile
+++ b/Justfile
@@ -17,3 +17,23 @@ check:
 
 test-all: test lint fmt
     @echo "All checks passed!"
+
+evaluation-bench-smoke:
+    rm -rf target/evaluation-bench
+    mkdir -p target/evaluation-bench
+    DRAGON_HEAD_EVAL_MODE=smoke DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p core-runtime --test comprehensive_evaluation -- --nocapture
+    DRAGON_HEAD_EVAL_MODE=smoke DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p mcp-server --test comprehensive_evaluation -- --nocapture
+    DRAGON_HEAD_EVAL_MODE=smoke DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p skills-engine --test comprehensive_evaluation
+    DRAGON_HEAD_EVAL_MODE=smoke DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p plugin-host --test comprehensive_evaluation
+    DRAGON_HEAD_EVAL_MODE=smoke DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p marketplace --test comprehensive_evaluation
+    python3 scripts/evaluation_dashboard.py --input-dir target/evaluation-bench --output target/evaluation-dashboard.md
+
+evaluation-bench-full:
+    rm -rf target/evaluation-bench
+    mkdir -p target/evaluation-bench
+    DRAGON_HEAD_EVAL_MODE=full DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p core-runtime --test comprehensive_evaluation -- --nocapture
+    DRAGON_HEAD_EVAL_MODE=full DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p mcp-server --test comprehensive_evaluation -- --nocapture
+    DRAGON_HEAD_EVAL_MODE=full DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p skills-engine --test comprehensive_evaluation
+    DRAGON_HEAD_EVAL_MODE=full DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p plugin-host --test comprehensive_evaluation
+    DRAGON_HEAD_EVAL_MODE=full DRAGON_HEAD_EVAL_OUTPUT_DIR="$PWD/target/evaluation-bench" cargo test -p marketplace --test comprehensive_evaluation
+    python3 scripts/evaluation_dashboard.py --input-dir target/evaluation-bench --output target/evaluation-dashboard.md

--- a/core-runtime/Cargo.toml
+++ b/core-runtime/Cargo.toml
@@ -28,3 +28,4 @@ hmac = "0.12"
 urlencoding = "2.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 jsonschema = "0.37"
+test-bench-support = { path = "../test-bench-support" }

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -1,0 +1,482 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use anyhow::Context;
+use core_runtime::{
+    audit::AuditEvent,
+    sre::{normalize_dom, LoadProfile, SemanticState},
+    ActionError, BrowserClient, KmsAdapter, LocalSessionVault, PageSession, PolicyAction,
+    PolicyRule, SoftwareKms,
+};
+use serde_json::{json, Value};
+use test_bench_support::{EvaluationBench, EvaluationMode};
+
+fn should_skip() -> bool {
+    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
+}
+
+#[test]
+fn test_core_runtime_comprehensive_evaluation_suite() -> anyhow::Result<()> {
+    if should_skip() {
+        return Ok(());
+    }
+
+    let mut bench = EvaluationBench::new(
+        "core-runtime",
+        "comprehensive_evaluation",
+        EvaluationMode::from_env(),
+    );
+
+    bench.run_scenario(
+        "semantic_state_capture",
+        "sre",
+        scenario_semantic_state_capture,
+    );
+    bench.run_scenario(
+        "stable_key_recovery",
+        "actions",
+        scenario_stable_key_recovery,
+    );
+    bench.run_scenario("semantic_wait", "waits", scenario_semantic_wait);
+    bench.run_scenario("policy_hitl", "policy", scenario_policy_hitl);
+    bench.run_scenario("audit_redaction", "audit", scenario_audit_redaction);
+    bench.run_scenario(
+        "session_vault_roundtrip",
+        "session_vault",
+        scenario_session_vault_roundtrip,
+    );
+
+    bench.write_if_configured()?;
+    bench.assert_required_scenarios(&[
+        "semantic_state_capture",
+        "stable_key_recovery",
+        "semantic_wait",
+        "policy_hitl",
+        "audit_redaction",
+        "session_vault_roundtrip",
+    ])?;
+    bench.assert_all_passed()?;
+
+    Ok(())
+}
+
+fn scenario_semantic_state_capture() -> anyhow::Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <h1>Checkout</h1>
+                <button id="purchase">Purchase</button>
+                <div role="status">Ready</div>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let state = page.capture_semantic_state(LoadProfile::Interactive)?;
+    let fast_state = state.generate_fast_state();
+    let purchase = fast_state
+        .interactive_elements
+        .iter()
+        .find(|node| {
+            node.role == "button"
+                && node
+                    .attributes
+                    .as_ref()
+                    .and_then(|attrs| attrs.get("id"))
+                    .is_some_and(|id| id == "purchase")
+        })
+        .context("purchase button missing from fast state")?;
+
+    let indexed = page.refresh_stable_key_index(LoadProfile::Interactive)?;
+    let backend_id = purchase.backend_node_id;
+    let stable_key = purchase
+        .stable_key
+        .as_ref()
+        .context("purchase button stable_key missing")?;
+
+    assert!(
+        indexed > 0,
+        "stable key index should contain at least one interactive element"
+    );
+    assert_eq!(
+        page.lookup_backend_node_id_by_stable_key(stable_key),
+        Some(backend_id)
+    );
+
+    Ok(json!({
+        "interactive_elements": fast_state.interactive_elements.len(),
+        "indexed_elements": indexed,
+        "purchase_stable_key": stable_key,
+    }))
+}
+
+fn scenario_stable_key_recovery() -> anyhow::Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <div id="container">
+                    <button id="btn" onclick="document.body.dataset.clicked='true'">Target</button>
+                </div>
+                <script>
+                    function replaceButton() {
+                        const container = document.getElementById('container');
+                        container.innerHTML = '<button id="btn" onclick="document.body.dataset.clicked = \'true\'">Target</button>';
+                    }
+                </script>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Minimal, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Minimal);
+    let (_, stable_key) = find_button_info(state.root()).context("button not found")?;
+
+    page.evaluate_script("replaceButton()")?;
+    page.act(Some(999_999), Some(&stable_key), "click", None)?;
+
+    let clicked = page.evaluate_script("document.body.dataset.clicked")?.value;
+    assert_eq!(
+        clicked
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+            .as_deref(),
+        Some("true")
+    );
+
+    let recovered = page.action_logs()?.into_iter().any(|entry| {
+        entry.code == "stable_key_fallback_recovered"
+            && entry.stable_key.as_deref() == Some(stable_key.as_str())
+    });
+    assert!(
+        recovered,
+        "stable_key fallback should emit recovery warning"
+    );
+
+    Ok(json!({
+        "stable_key": stable_key,
+        "recovered": recovered,
+    }))
+}
+
+fn scenario_semantic_wait() -> anyhow::Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="btn_login" disabled>Login</button>
+                <script>
+                    setTimeout(() => {
+                        document.getElementById("btn_login").removeAttribute("disabled");
+                    }, 250);
+                </script>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    let stable_key = find_button_key(state.root()).context("login button stable_key missing")?;
+
+    page.wait_for_semantic(
+        core_runtime::SemanticTarget::StableKey(stable_key.clone()),
+        core_runtime::SemanticWaitState::Enabled,
+        Duration::from_secs(2),
+    )?;
+
+    let is_disabled = page
+        .evaluate_script(r#"document.getElementById("btn_login").hasAttribute("disabled")"#)?
+        .value
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true);
+    assert!(!is_disabled, "button should become enabled");
+
+    Ok(json!({
+        "stable_key": stable_key,
+        "enabled": true,
+    }))
+}
+
+fn scenario_policy_hitl() -> anyhow::Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![PolicyRule {
+        id: "purchase-approval".to_string(),
+        domain: None,
+        path_prefix: None,
+        role: Some("button".to_string()),
+        text_regex: Some("(?i)purchase".to_string()),
+        context_regex: None,
+        action: PolicyAction::RequireHumanApproval,
+        scope: Some(core_runtime::ApprovalScope::ActionOnly),
+    }])?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="purchase" onclick="document.body.dataset.approved='yes'">Purchase</button>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let (target_id, stable_key) = find_button_info_from_page(&page)?;
+    let first_attempt = page.act(Some(target_id), Some(&stable_key), "click", None);
+    let first_error = first_attempt.expect_err("approval should be required");
+    let action_error = first_error
+        .downcast_ref::<ActionError>()
+        .context("expected ActionError")?;
+    assert!(matches!(
+        action_error,
+        ActionError::HumanApprovalRequired { .. }
+    ));
+
+    page.approve_pending_policy_action()?;
+    page.act(Some(target_id), Some(&stable_key), "click", None)?;
+
+    let approved = page
+        .evaluate_script("document.body.dataset.approved")?
+        .value
+        .and_then(|value| value.as_str().map(ToOwned::to_owned));
+    assert_eq!(approved.as_deref(), Some("yes"));
+
+    Ok(json!({
+        "target_id": target_id,
+        "stable_key": stable_key,
+        "approved": true,
+    }))
+}
+
+fn scenario_audit_redaction() -> anyhow::Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <input id="email" type="email" value="seed@example.com" />
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    let (target_id, stable_key) =
+        find_node_info_by_dom_id(state.root(), "email").context("email input not found")?;
+
+    page.clear_audit_events();
+    page.act(
+        Some(target_id),
+        Some(&stable_key),
+        "type",
+        Some("alice@example.com 4000 1234 5678 9012"),
+    )?;
+
+    let tool_args = page
+        .audit_events()
+        .into_iter()
+        .find_map(|event| match event {
+            AuditEvent::ToolCall {
+                tool_name, args, ..
+            } if tool_name == "act" => Some(args),
+            _ => None,
+        })
+        .context("TOOL_CALL(act) missing")?;
+    let tool_args_text = serde_json::to_string(&tool_args)?;
+
+    assert!(!tool_args_text.contains("alice@example.com"));
+    assert!(!tool_args_text.contains("4000 1234 5678 9012"));
+    assert_eq!(tool_args["value"], json!("***"));
+
+    Ok(json!({
+        "masked_value": tool_args["value"],
+    }))
+}
+
+fn scenario_session_vault_roundtrip() -> anyhow::Result<Value> {
+    let kms_log = Arc::new(Mutex::new(KmsCallLog::default()));
+    let vault = Arc::new(LocalSessionVault::new(Box::new(RecordingKms::new(
+        [1u8; 32],
+        "key-1".to_string(),
+        Arc::clone(&kms_log),
+    ))));
+    let client = BrowserClient::new_with_vault(vault)?;
+    let page = client.new_page()?;
+    let runtime = tokio::runtime::Runtime::new()?;
+
+    page.navigate("https://example.com")?;
+    set_cookie(&page, "session_com", "alpha")?;
+    runtime.block_on(page.save_to_vault("session-example-com"))?;
+
+    clear_cookie(&page, "session_com")?;
+    assert!(cookie_value(&page, "session_com")?.is_none());
+
+    runtime.block_on(page.load_from_vault("session-example-com"))?;
+    assert_eq!(
+        cookie_value(&page, "session_com")?.as_deref(),
+        Some("alpha")
+    );
+    assert_eq!(last_encrypt_key_id(&kms_log).as_deref(), Some("key-1"));
+
+    Ok(json!({
+        "session_id": "session-example-com",
+        "encrypt_key_id": last_encrypt_key_id(&kms_log),
+    }))
+}
+
+fn find_button_info(node: &core_runtime::sre::state::SemanticNode) -> Option<(i64, String)> {
+    if node.role == "button" {
+        return Some((node.backend_node_id, node.stable_key.clone()?));
+    }
+    for child in &node.children {
+        if let Some(found) = find_button_info(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_button_key(node: &core_runtime::sre::state::SemanticNode) -> Option<String> {
+    if node.role == "button" {
+        return node.stable_key.clone();
+    }
+    for child in &node.children {
+        if let Some(found) = find_button_key(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_button_info_from_page(page: &PageSession) -> anyhow::Result<(i64, String)> {
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    find_button_info(state.root()).context("button not found")
+}
+
+fn find_node_info_by_dom_id(
+    node: &core_runtime::sre::state::SemanticNode,
+    dom_id: &str,
+) -> Option<(i64, String)> {
+    if node
+        .attributes
+        .as_ref()
+        .and_then(|attrs| attrs.get("id"))
+        .is_some_and(|id| id == dom_id)
+    {
+        return Some((node.backend_node_id, node.stable_key.clone()?));
+    }
+
+    for child in &node.children {
+        if let Some(found) = find_node_info_by_dom_id(child, dom_id) {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
+fn set_cookie(page: &PageSession, name: &str, value: &str) -> anyhow::Result<()> {
+    let script = format!(
+        r#"document.cookie = "{}={}; path=/; max-age=3600";"#,
+        name, value
+    );
+    page.evaluate_script(&script)?;
+    Ok(())
+}
+
+fn clear_cookie(page: &PageSession, name: &str) -> anyhow::Result<()> {
+    let script = format!(
+        r#"document.cookie = "{}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";"#,
+        name
+    );
+    page.evaluate_script(&script)?;
+    Ok(())
+}
+
+fn cookie_value(page: &PageSession, name: &str) -> anyhow::Result<Option<String>> {
+    let raw = page
+        .evaluate_script("document.cookie")?
+        .value
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .context("document.cookie should return string")?;
+
+    Ok(raw.split(';').find_map(|entry| {
+        let mut parts = entry.trim().splitn(2, '=');
+        let key = parts.next()?;
+        let value = parts.next().unwrap_or_default();
+        (key == name).then(|| value.to_string())
+    }))
+}
+
+#[derive(Debug, Default)]
+struct KmsCallLog {
+    encrypt_key_ids: Vec<String>,
+}
+
+struct RecordingKms {
+    inner: SoftwareKms,
+    log: Arc<Mutex<KmsCallLog>>,
+}
+
+impl RecordingKms {
+    fn new(key: [u8; 32], key_id: String, log: Arc<Mutex<KmsCallLog>>) -> Self {
+        Self {
+            inner: SoftwareKms::new(key, key_id),
+            log,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl KmsAdapter for RecordingKms {
+    async fn encrypt(&self, plaintext: &[u8]) -> anyhow::Result<(Vec<u8>, String)> {
+        let (ciphertext, key_id) = self.inner.encrypt(plaintext).await?;
+        self.log
+            .lock()
+            .expect("kms log lock should not be poisoned")
+            .encrypt_key_ids
+            .push(key_id.clone());
+        Ok((ciphertext, key_id))
+    }
+
+    async fn decrypt(&self, ciphertext: &[u8], key_id: &str) -> anyhow::Result<Vec<u8>> {
+        self.inner.decrypt(ciphertext, key_id).await
+    }
+
+    fn current_key_id(&self) -> String {
+        self.inner.current_key_id()
+    }
+
+    fn add_key(&mut self, key: [u8; 32], key_id: String, make_current: bool) {
+        self.inner.add_key(key, key_id, make_current);
+    }
+}
+
+fn last_encrypt_key_id(log: &Arc<Mutex<KmsCallLog>>) -> Option<String> {
+    log.lock()
+        .expect("kms log lock should not be poisoned")
+        .encrypt_key_ids
+        .last()
+        .cloned()
+}

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -191,7 +191,9 @@ fn scenario_semantic_wait() -> anyhow::Result<Value> {
     let root = page.get_document_node()?;
     let sem = normalize_dom(LoadProfile::Interactive, &root)?;
     let state = SemanticState::new(sem, LoadProfile::Interactive);
-    let stable_key = find_button_key(state.root()).context("login button stable_key missing")?;
+    let stable_key = find_button_info(state.root())
+        .map(|(_, k)| k)
+        .context("login button stable_key missing")?;
 
     page.wait_for_semantic(
         core_runtime::SemanticTarget::StableKey(stable_key.clone()),
@@ -349,18 +351,6 @@ fn find_button_info(node: &core_runtime::sre::state::SemanticNode) -> Option<(i6
     }
     for child in &node.children {
         if let Some(found) = find_button_info(child) {
-            return Some(found);
-        }
-    }
-    None
-}
-
-fn find_button_key(node: &core_runtime::sre::state::SemanticNode) -> Option<String> {
-    if node.role == "button" {
-        return node.stable_key.clone();
-    }
-    for child in &node.children {
-        if let Some(found) = find_button_key(child) {
             return Some(found);
         }
     }

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,7 +1,7 @@
 # Neural-Browser Runtime 実装計画（進捗管理版）
 
 - 対象仕様: [SPEC.md](./SPEC.md) v2.1（2026-02-10）
-- 最終更新日: 2026-02-28
+- 最終更新日: 2026-03-17
 - プラン状態: In Progress
 
 ## 1. 進捗管理ルール
@@ -40,6 +40,7 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 | 6 | Monetization Meters | PR-16 | 1/1 | DONE |
 | 7 | Marketplace | PR-17 | 1/1 | DONE |
 | 8 | Robustness & Verification | PR-18 | 1/1 | DONE |
+| 9 | Comprehensive Evaluation Bench | PR-19 | 1/1 | DONE |
 
 ## 3. PRバックログ（進捗チェック付き）
 
@@ -386,6 +387,29 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
   - [x] 新規 E2E テストを `cdp-smoke` または `full-e2e` ジョブに追加。
 - Exit Criteria
   - [x] 実機環境（Headless Chrome）において、仕様通りのセキュリティ・監査・リカバリが保証されている。
+
+### PR-19: Comprehensive Evaluation Bench Expansion
+- Status: `DONE` (Local)
+- Spec Ref: Section 2.2, Section 5.2, Section 6, Section 7.1〜7.3
+- Dependencies: PR-08, PR-10, PR-14, PR-16, PR-17, PR-18
+- 実装タスク
+  - [x] `smoke` / `full` の2モードで共通利用できる評価結果スキーマと artifact writer を整備する。
+  - [x] `core-runtime` の代表シナリオ（semantic state, stable_key recovery, semantic wait, policy/HITL, audit redaction, session vault）を横断評価するベンチを追加する。
+  - [x] `mcp-server` の代表シナリオ（tool contract, HITL flow, usage metering / plan gating）を横断評価するベンチを追加する。
+  - [x] `skills-engine` / `plugin-host` / `marketplace` が同一フォーマットで結果を出力できる評価フックを追加する。
+  - [x] 集約 JSON から Markdown ダッシュボードを生成するスクリプトと保存先規約を追加する。
+- テストタスク
+  - [x] `smoke` モードで必須シナリオ群がすべて評価対象に含まれることを失敗テストで固定化する。
+  - [x] `full` モードで crate 横断の結果集約と failure / warning 反映が行われることを検証する。
+  - [x] 主要な回帰（stable_key fallback, policy approval, audit masking, session restore, MCP ask_human）を評価ダッシュボード経由でも追跡できることを検証する。
+- CIタスク
+  - [x] PR 用の `evaluation-bench-smoke` ジョブを追加し、評価結果 JSON / Markdown を artifact として保存する。
+  - [x] nightly / dispatch 用の `evaluation-bench-full` ジョブを追加し、全 crate の評価結果とダッシュボードを保存する。
+  - [x] 必須シナリオ欠落または閾値超過時に CI を fail させるガードを追加する。
+- Exit Criteria
+  - [x] `dragon-head` の主要機能群を1つの評価ダッシュボードで横断確認できる。
+  - [x] PR では短尺 smoke、nightly では full 評価が自動実行される。
+  - [x] 追加された主要機能は評価ベンチへの登録なしでは完了扱いにできない運用ルールが `docs/` に明記されている。
 
 ## 4. 共通 Definition of Done（全PR共通）
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,6 +35,18 @@ The CI pipeline is defined in `.github/workflows/`.
 - **Performance Gate (PR Short)**: `ci.yml` runs a short NFR suite (`ttft`, `nfr_latency`, `nfr_bandwidth`, `nfr_capacity`) and generates `core-runtime/target/nfr-dashboard.md`.
 - **Performance Gate (Nightly Full)**: `e2e.yml` runs the full NFR suite (including long TTFT and full capacity targets) and publishes the same dashboard format for regression tracking.
 - **Threshold Enforcement**: `scripts/nfr_dashboard.py` evaluates metric thresholds from JSON outputs and fails CI on regressions.
+- **Comprehensive Evaluation Bench**: `just evaluation-bench-smoke` runs crate-spanning feature evaluation suites and emits JSON reports plus `target/evaluation-dashboard.md`. Nightly/full runs use the same format with `DRAGON_HEAD_EVAL_MODE=full`.
+
+## 2.1 Comprehensive Evaluation Bench
+
+- **Goal**: Provide a single dashboard that verifies the main Dragon Head feature areas across `core-runtime`, `mcp-server`, `skills-engine`, `plugin-host`, and `marketplace`.
+- **Modes**:
+  - `smoke`: Required on PRs. Covers representative scenarios for state capture, action recovery, wait semantics, policy/HITL, audit/session, MCP flow, skill execution, plugin validation, and marketplace accounting.
+  - `full`: Runs on nightly/manual workflows. Uses the same report format and is reserved for expanded scenario sets and longer-running variants.
+- **Artifacts**:
+  - JSON reports: `target/evaluation-bench/*.json`
+  - Markdown dashboard: `target/evaluation-dashboard.md`
+- **Registration Rule**: New major features are not considered complete until a corresponding scenario is added to the evaluation bench or an explicit exemption is documented in `docs/`.
 
 ## 3. Running Tests Locally
 

--- a/marketplace/Cargo.toml
+++ b/marketplace/Cargo.toml
@@ -14,4 +14,6 @@ sha2 = "0.10"
 hex = "0.4"
 
 [dev-dependencies]
+anyhow = { workspace = true }
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
+test-bench-support = { path = "../test-bench-support" }

--- a/marketplace/tests/comprehensive_evaluation.rs
+++ b/marketplace/tests/comprehensive_evaluation.rs
@@ -1,0 +1,105 @@
+use ed25519_dalek::{Signer, SigningKey};
+use marketplace::{
+    DomainPack, MarketplaceMetadata, UsageEvent, calculate_revenue_share, verify_domain_pack,
+};
+use rand_core::OsRng;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use test_bench_support::{EvaluationBench, EvaluationMode};
+
+#[test]
+fn test_marketplace_comprehensive_evaluation_suite() -> anyhow::Result<()> {
+    let mut bench = EvaluationBench::new(
+        "marketplace",
+        "comprehensive_evaluation",
+        EvaluationMode::from_env(),
+    );
+
+    bench.run_scenario(
+        "domain_pack_signature_verification",
+        "signature",
+        scenario_domain_pack_signature_verification,
+    );
+    bench.run_scenario(
+        "revenue_share_accounting",
+        "monetization",
+        scenario_revenue_share_accounting,
+    );
+
+    bench.write_if_configured()?;
+    bench.assert_required_scenarios(&[
+        "domain_pack_signature_verification",
+        "revenue_share_accounting",
+    ])?;
+    bench.assert_all_passed()?;
+    Ok(())
+}
+
+fn scenario_domain_pack_signature_verification() -> anyhow::Result<Value> {
+    let mut csprng = OsRng;
+    let signing_key = SigningKey::generate(&mut csprng);
+    let pubkey_bytes = signing_key.verifying_key().to_bytes();
+    let pubkey_hex = hex::encode(pubkey_bytes);
+
+    let pack_id = "com.example.testpack";
+    let author = "Test Author";
+    let version = "1.0.0";
+
+    let mut hasher = Sha256::new();
+    hasher.update(pack_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(author.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(version.as_bytes());
+    let payload = hasher.finalize();
+
+    let signature = signing_key.sign(&payload);
+    let signature_hex = hex::encode(signature.to_bytes());
+
+    let metadata = MarketplaceMetadata {
+        pack_id: pack_id.to_string(),
+        author: author.to_string(),
+        version: version.to_string(),
+        compatible_version: "2.1".to_string(),
+        dependencies: vec![],
+        signature: Some(signature_hex),
+    };
+
+    let pack = DomainPack {
+        metadata,
+        plugin: None,
+        skills: vec![],
+    };
+
+    assert!(verify_domain_pack(&pack, &pubkey_hex).is_ok());
+    assert!(verify_domain_pack(&pack, &"00".repeat(32)).is_err());
+
+    Ok(json!({
+        "pack_id": pack_id,
+        "verified": true,
+    }))
+}
+
+fn scenario_revenue_share_accounting() -> anyhow::Result<Value> {
+    let skill_event = UsageEvent {
+        pack_id: "com.example.testpack".to_string(),
+        event_type: "skill_run".to_string(),
+        count: 100,
+    };
+    let state_event = UsageEvent {
+        pack_id: "com.example.testpack".to_string(),
+        event_type: "state_generation".to_string(),
+        count: 100,
+    };
+
+    let skill_revenue = calculate_revenue_share(&skill_event);
+    let state_revenue = calculate_revenue_share(&state_event);
+
+    assert_eq!(skill_revenue, 2.0);
+    assert_eq!(state_revenue, 0.5);
+
+    Ok(json!({
+        "skill_run_revenue": skill_revenue,
+        "state_generation_revenue": state_revenue,
+    }))
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -17,3 +17,4 @@ hex = "0.4"
 jsonschema = "0.37"
 tokio = { workspace = true }
 urlencoding = "2.1"
+test-bench-support = { path = "../test-bench-support" }

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
@@ -132,10 +132,12 @@ fn scenario_hitl_flow() -> Result<Value> {
         }),
     )?;
 
-    let target_id = state["interactive_elements"][0]["id"].as_i64().unwrap();
+    let target_id = state["interactive_elements"][0]["id"]
+        .as_i64()
+        .context("target id should exist in hitl state")?;
     let stable_key = state["interactive_elements"][0]["stable_key"]
         .as_str()
-        .unwrap()
+        .context("stable key should exist in hitl state")?
         .to_string();
 
     let first_act = server.call_tool(

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -1,0 +1,273 @@
+use anyhow::Result;
+use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
+use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
+use serde_json::{json, Value};
+use test_bench_support::{EvaluationBench, EvaluationMode};
+
+fn should_skip() -> bool {
+    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
+}
+
+#[test]
+fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
+    if should_skip() {
+        return Ok(());
+    }
+
+    let mut bench = EvaluationBench::new(
+        "mcp-server",
+        "comprehensive_evaluation",
+        EvaluationMode::from_env(),
+    );
+
+    bench.run_scenario(
+        "tool_flow_state_and_act",
+        "tool_flow",
+        scenario_tool_flow_state_and_act,
+    );
+    bench.run_scenario("hitl_flow", "hitl", scenario_hitl_flow);
+    bench.run_scenario(
+        "usage_report_plan_gating",
+        "metering",
+        scenario_usage_report_plan_gating,
+    );
+
+    bench.write_if_configured()?;
+    bench.assert_required_scenarios(&[
+        "tool_flow_state_and_act",
+        "hitl_flow",
+        "usage_report_plan_gating",
+    ])?;
+    bench.assert_all_passed()?;
+
+    Ok(())
+}
+
+fn scenario_tool_flow_state_and_act() -> Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="purchase" onclick="document.body.dataset.clicked='yes'">Purchase</button>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let mut server = McpServer::new(CoreRuntimeBackend::new(page));
+    let state = server.call_tool(
+        "get_state",
+        json!({
+            "format": "json",
+            "force_refresh": true
+        }),
+    )?;
+
+    let target_id = state["interactive_elements"][0]["id"]
+        .as_i64()
+        .expect("target id should exist");
+    let stable_key = state["interactive_elements"][0]["stable_key"]
+        .as_str()
+        .expect("stable key should exist")
+        .to_string();
+
+    let act = server.call_tool(
+        "act",
+        json!({
+            "target_id": target_id,
+            "target_stable_key": stable_key,
+            "action": "click"
+        }),
+    )?;
+    assert_eq!(act["status"], json!("ok"));
+
+    let clicked = server
+        .backend_mut()
+        .page()
+        .evaluate_script("document.body.dataset.clicked")?
+        .value
+        .and_then(|value| value.as_str().map(ToOwned::to_owned));
+    assert_eq!(clicked.as_deref(), Some("yes"));
+
+    Ok(json!({
+        "interactive_elements": state["interactive_elements"].as_array().map_or(0, Vec::len),
+        "clicked": true,
+    }))
+}
+
+fn scenario_hitl_flow() -> Result<Value> {
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    page.set_policy_rules(vec![PolicyRule {
+        id: "checkout-approval".to_string(),
+        domain: None,
+        path_prefix: None,
+        role: Some("button".to_string()),
+        text_regex: Some("purchase".to_string()),
+        context_regex: None,
+        action: PolicyAction::RequireHumanApproval,
+        scope: Some(ApprovalScope::ActionOnly),
+    }])?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="purchase" onclick="document.body.dataset.clicked='yes'">Purchase</button>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let mut server = McpServer::new(CoreRuntimeBackend::new(page));
+    let state = server.call_tool(
+        "get_state",
+        json!({
+            "format": "json",
+            "force_refresh": true
+        }),
+    )?;
+
+    let target_id = state["interactive_elements"][0]["id"].as_i64().unwrap();
+    let stable_key = state["interactive_elements"][0]["stable_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let first_act = server.call_tool(
+        "act",
+        json!({
+            "target_id": target_id,
+            "target_stable_key": stable_key,
+            "action": "click"
+        }),
+    )?;
+    assert_eq!(first_act["status"], json!("requires_human_approval"));
+
+    let approval = server.call_tool(
+        "ask_human",
+        json!({
+            "reason": "checkout requires approval",
+            "context": true
+        }),
+    )?;
+    assert_eq!(approval["approved"], json!(true));
+
+    let second_act = server.call_tool(
+        "act",
+        json!({
+            "target_id": target_id,
+            "target_stable_key": stable_key,
+            "action": "click"
+        }),
+    )?;
+    assert_eq!(second_act["status"], json!("ok"));
+
+    Ok(json!({
+        "approved": true,
+        "rule_id": approval["rule_id"],
+    }))
+}
+
+fn scenario_usage_report_plan_gating() -> Result<Value> {
+    let mut server = McpServer::new_with_plan(
+        MockBackend {
+            audit_snapshot: Some(AuditRetentionSnapshot {
+                retained_events: 12,
+                retained_bytes: 4096,
+            }),
+            act_responses: vec![
+                json!({"status": "requires_human_approval"}),
+                json!({"status": "ok"}),
+            ],
+            act_call_count: 0,
+        },
+        PlanTier::Enterprise,
+    );
+
+    server.call_tool("get_state", json!({"format": "json"}))?;
+    server.call_tool("act", json!({"action": "click"}))?;
+    server.call_tool("ask_human", json!({"reason": "review"}))?;
+    server.call_tool("act", json!({"action": "click"}))?;
+    server.call_tool("get_visual", json!({"mode": "som"}))?;
+
+    let enterprise_report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(enterprise_report["actions_executed"], json!(1));
+    assert_eq!(enterprise_report["hitl_events"], json!(1));
+
+    let mut developer = McpServer::new_with_plan(MockBackend::default(), PlanTier::Developer);
+    let visual_gate = developer.call_tool("get_visual", json!({"mode": "som"}))?;
+    assert_eq!(visual_gate["status"], json!("plan_upgrade_required"));
+    assert_eq!(visual_gate["feature"], json!("som_visual_capture"));
+
+    Ok(json!({
+        "enterprise_total_cost": enterprise_report["cost_microusd"]["total"],
+        "developer_gate": visual_gate["feature"],
+    }))
+}
+
+struct MockBackend {
+    audit_snapshot: Option<AuditRetentionSnapshot>,
+    act_responses: Vec<Value>,
+    act_call_count: usize,
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self {
+            audit_snapshot: None,
+            act_responses: vec![json!({"status": "ok"})],
+            act_call_count: 0,
+        }
+    }
+}
+
+impl McpBackend for MockBackend {
+    fn get_state(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({
+            "metadata": {
+                "url": "https://example.com",
+                "page_instance_id": "pid",
+                "state_hash": "hash",
+                "load_profile": "interactive",
+                "timestamp": 123
+            },
+            "interactive_elements": []
+        }))
+    }
+
+    fn act(&mut self, _arguments: Value) -> Result<Value> {
+        let response = self
+            .act_responses
+            .get(self.act_call_count)
+            .cloned()
+            .or_else(|| self.act_responses.last().cloned())
+            .unwrap_or_else(|| json!({"status": "ok"}));
+        self.act_call_count += 1;
+        Ok(response)
+    }
+
+    fn verify(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"matched": true}))
+    }
+
+    fn get_visual(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"image_sha256": "abc"}))
+    }
+
+    fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"approved": true}))
+    }
+
+    fn run_skill(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"status": "completed"}))
+    }
+
+    fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {
+        self.audit_snapshot
+    }
+}

--- a/plugin-host/Cargo.toml
+++ b/plugin-host/Cargo.toml
@@ -13,4 +13,6 @@ sha2 = "0.10"
 hex = "0.4"
 
 [dev-dependencies]
+anyhow = { workspace = true }
 wat = "1.240"
+test-bench-support = { path = "../test-bench-support" }

--- a/plugin-host/tests/comprehensive_evaluation.rs
+++ b/plugin-host/tests/comprehensive_evaluation.rs
@@ -1,0 +1,142 @@
+use ed25519_dalek::{Signer, SigningKey};
+use plugin_host::{
+    Capability, ExtensionPoint, KeyRegistry, PluginError, PluginHost, PluginManifest,
+    PluginPackage, SbomComponent, SbomDocument, SignatureBlock, signature_payload,
+};
+use serde_json::{Value, json};
+use test_bench_support::{EvaluationBench, EvaluationMode};
+
+#[test]
+fn test_plugin_host_comprehensive_evaluation_suite() -> anyhow::Result<()> {
+    let mut bench = EvaluationBench::new(
+        "plugin-host",
+        "comprehensive_evaluation",
+        EvaluationMode::from_env(),
+    );
+
+    bench.run_scenario(
+        "unsigned_plugin_rejected",
+        "signature",
+        scenario_unsigned_plugin_rejected,
+    );
+    bench.run_scenario(
+        "signed_plugin_capability_enforcement",
+        "capability",
+        scenario_signed_plugin_capability_enforcement,
+    );
+
+    bench.write_if_configured()?;
+    bench.assert_required_scenarios(&[
+        "unsigned_plugin_rejected",
+        "signed_plugin_capability_enforcement",
+    ])?;
+    bench.assert_all_passed()?;
+    Ok(())
+}
+
+fn scenario_unsigned_plugin_rejected() -> anyhow::Result<Value> {
+    let host = PluginHost::default();
+    let package = PluginPackage {
+        manifest: sample_manifest(vec![Capability::ReadState]),
+        wasm_module: sample_wasm_module(),
+    };
+
+    let err = host
+        .load_plugin(&package)
+        .expect_err("unsigned plugin must fail");
+    assert!(matches!(err, PluginError::UnsignedPlugin));
+
+    Ok(json!({
+        "error": "UnsignedPlugin",
+    }))
+}
+
+fn scenario_signed_plugin_capability_enforcement() -> anyhow::Result<Value> {
+    let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+    let key_id = "fixture-key";
+
+    let mut registry = KeyRegistry::default();
+    registry
+        .register_hex_ed25519(key_id, &hex::encode(signing_key.verifying_key().to_bytes()))
+        .expect("must register key");
+
+    let wasm_module = sample_wasm_module();
+    let mut manifest = sample_manifest(vec![Capability::ReadState]);
+    manifest.signature = Some(sign_manifest(&manifest, &wasm_module, &signing_key, key_id));
+
+    let package = PluginPackage {
+        manifest,
+        wasm_module,
+    };
+
+    let host = PluginHost::new(registry);
+    let plugin = host.load_plugin(&package)?;
+    plugin.authorize_extension(ExtensionPoint::OnState)?;
+
+    let err = plugin
+        .authorize_extension(ExtensionPoint::Connector)
+        .expect_err("connector must be blocked without network_out capability");
+    assert!(matches!(
+        err,
+        PluginError::CapabilityViolation {
+            required: Capability::NetworkOut
+        }
+    ));
+
+    Ok(json!({
+        "on_state": "allowed",
+        "connector": "blocked",
+    }))
+}
+
+fn sample_wasm_module() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (func (export "on_state"))
+            (func (export "before_act"))
+            (func (export "connector"))
+        )"#,
+    )
+    .expect("failed to build wasm fixture")
+}
+
+fn sample_sbom() -> SbomDocument {
+    SbomDocument {
+        format: "cyclonedx-1.5".to_string(),
+        components: vec![SbomComponent {
+            name: "fixture-component".to_string(),
+            version: "1.0.0".to_string(),
+            license: Some("MIT".to_string()),
+        }],
+    }
+}
+
+fn sample_manifest(capabilities: Vec<Capability>) -> PluginManifest {
+    PluginManifest {
+        plugin_id: "fixture.plugin".to_string(),
+        version: "0.1.0".to_string(),
+        entry_points: vec![
+            ExtensionPoint::OnState,
+            ExtensionPoint::BeforeAct,
+            ExtensionPoint::Connector,
+        ],
+        capabilities,
+        signature: None,
+        sbom: sample_sbom(),
+    }
+}
+
+fn sign_manifest(
+    manifest: &PluginManifest,
+    wasm: &[u8],
+    signing_key: &SigningKey,
+    key_id: &str,
+) -> SignatureBlock {
+    let payload = signature_payload(manifest, wasm).expect("signature payload must be buildable");
+    let signature = signing_key.sign(&payload);
+
+    SignatureBlock {
+        key_id: key_id.to_string(),
+        signature_hex: hex::encode(signature.to_bytes()),
+    }
+}

--- a/scripts/evaluation_dashboard.py
+++ b/scripts/evaluation_dashboard.py
@@ -55,13 +55,16 @@ def render_dashboard(reports: list[dict]) -> str:
             details = scenario.get("error") or json.dumps(
                 scenario.get("details", {}), ensure_ascii=False, sort_keys=True
             )
+            details = details.replace("|", "\\|")
+            if len(details) > 120:
+                details = details[:117] + "..."
             lines.append(
                 "| {scenario_id} | {feature_area} | {status} | {duration_ms:.2f} | {details} |".format(
                     scenario_id=scenario.get("scenario_id", "unknown"),
                     feature_area=scenario.get("feature_area", "unknown"),
                     status=scenario.get("status", "unknown"),
                     duration_ms=float(scenario.get("duration_ms", 0.0)),
-                    details=details.replace("|", "\\|"),
+                    details=details,
                 )
             )
 

--- a/scripts/evaluation_dashboard.py
+++ b/scripts/evaluation_dashboard.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_reports(input_dir: Path) -> list[dict]:
+    reports = []
+    for path in sorted(input_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            reports.append(json.load(handle))
+    return reports
+
+
+def render_dashboard(reports: list[dict]) -> str:
+    overall_failed = sum(report.get("summary", {}).get("failed", 0) for report in reports)
+    overall_passed = overall_failed == 0 and bool(reports)
+
+    lines = [
+        "# Dragon Head Evaluation Bench Dashboard",
+        "",
+        f"- Reports: {len(reports)}",
+        f"- Overall Status: {'PASS' if overall_passed else 'FAIL'}",
+        "",
+        "| Crate | Suite | Mode | Passed | Failed | Total |",
+        "| :--- | :--- | :--- | ---: | ---: | ---: |",
+    ]
+
+    for report in reports:
+        summary = report.get("summary", {})
+        lines.append(
+            "| {crate} | {suite} | {mode} | {passed} | {failed} | {total} |".format(
+                crate=report.get("crate_name", "unknown"),
+                suite=report.get("suite_name", "unknown"),
+                mode=report.get("mode", "unknown"),
+                passed=summary.get("passed", 0),
+                failed=summary.get("failed", 0),
+                total=summary.get("total", 0),
+            )
+        )
+
+    for report in reports:
+        lines.extend(
+            [
+                "",
+                f"## {report.get('crate_name', 'unknown')} / {report.get('suite_name', 'unknown')}",
+                "",
+                "| Scenario | Feature | Status | Duration (ms) | Details |",
+                "| :--- | :--- | :--- | ---: | :--- |",
+            ]
+        )
+        for scenario in report.get("scenarios", []):
+            details = scenario.get("error") or json.dumps(
+                scenario.get("details", {}), ensure_ascii=False, sort_keys=True
+            )
+            lines.append(
+                "| {scenario_id} | {feature_area} | {status} | {duration_ms:.2f} | {details} |".format(
+                    scenario_id=scenario.get("scenario_id", "unknown"),
+                    feature_area=scenario.get("feature_area", "unknown"),
+                    status=scenario.get("status", "unknown"),
+                    duration_ms=float(scenario.get("duration_ms", 0.0)),
+                    details=details.replace("|", "\\|"),
+                )
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate evaluation bench dashboard from crate reports"
+    )
+    parser.add_argument("--input-dir", default="target/evaluation-bench")
+    parser.add_argument("--output", default="target/evaluation-dashboard.md")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_path = Path(args.output)
+    reports = load_reports(input_dir)
+    if not reports:
+        print(f"No evaluation reports found in {input_dir}", file=sys.stderr)
+        return 1
+
+    dashboard = render_dashboard(reports)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(dashboard, encoding="utf-8")
+    print(dashboard)
+
+    overall_failed = sum(report.get("summary", {}).get("failed", 0) for report in reports)
+    return 0 if overall_failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills-engine/Cargo.toml
+++ b/skills-engine/Cargo.toml
@@ -11,3 +11,4 @@ jsonschema = "0.37"
 
 [dev-dependencies]
 anyhow = { workspace = true }
+test-bench-support = { path = "../test-bench-support" }

--- a/skills-engine/tests/comprehensive_evaluation.rs
+++ b/skills-engine/tests/comprehensive_evaluation.rs
@@ -1,0 +1,262 @@
+use skills_engine::{
+    ActStep, ExtractStep, HandoffStep, LocateStep, OperationOutcome, SkillDefinition, SkillEngine,
+    SkillRunStatus, SkillRuntime, SkillStep, StepControl, VerifyStep,
+};
+use std::collections::{HashMap, VecDeque};
+
+use serde_json::{Value, json};
+use test_bench_support::{EvaluationBench, EvaluationMode};
+
+#[derive(Default)]
+struct MockRuntime {
+    scripts: HashMap<&'static str, VecDeque<OperationOutcome>>,
+}
+
+impl MockRuntime {
+    fn with_script(mut self, operation: &'static str, outcomes: Vec<OperationOutcome>) -> Self {
+        self.scripts
+            .insert(operation, outcomes.into_iter().collect());
+        self
+    }
+
+    fn next(&mut self, operation: &'static str) -> OperationOutcome {
+        self.scripts
+            .get_mut(operation)
+            .and_then(VecDeque::pop_front)
+            .unwrap_or(OperationOutcome::Success)
+    }
+}
+
+impl SkillRuntime for MockRuntime {
+    fn locate(
+        &mut self,
+        _step: &LocateStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        self.next("locate")
+    }
+
+    fn verify(
+        &mut self,
+        _step: &VerifyStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        self.next("verify")
+    }
+
+    fn act(
+        &mut self,
+        _step: &ActStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        self.next("act")
+    }
+
+    fn extract(
+        &mut self,
+        _step: &ExtractStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        self.next("extract")
+    }
+
+    fn handoff(
+        &mut self,
+        _step: &HandoffStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        self.next("handoff")
+    }
+}
+
+#[test]
+fn test_skills_engine_comprehensive_evaluation_suite() -> anyhow::Result<()> {
+    let mut bench = EvaluationBench::new(
+        "skills-engine",
+        "comprehensive_evaluation",
+        EvaluationMode::from_env(),
+    );
+
+    bench.run_scenario("skill_happy_path", "workflow", scenario_skill_happy_path);
+    bench.run_scenario(
+        "verify_failure_suppresses_act",
+        "workflow",
+        scenario_verify_failure_suppresses_act,
+    );
+    bench.run_scenario(
+        "retry_branch_and_handoff",
+        "workflow",
+        scenario_retry_branch_and_handoff,
+    );
+
+    bench.write_if_configured()?;
+    bench.assert_required_scenarios(&[
+        "skill_happy_path",
+        "verify_failure_suppresses_act",
+        "retry_branch_and_handoff",
+    ])?;
+    bench.assert_all_passed()?;
+    Ok(())
+}
+
+fn scenario_skill_happy_path() -> anyhow::Result<Value> {
+    let skill = happy_path_skill();
+    let mut runtime = MockRuntime::default();
+    let report = SkillEngine::new().run(&skill, &mut runtime)?;
+    let operations = report
+        .trace
+        .iter()
+        .map(|entry| entry.operation.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(report.status, SkillRunStatus::Completed);
+    assert_eq!(
+        operations,
+        vec![
+            "locate",
+            "verify",
+            "policy_check",
+            "act",
+            "post_check",
+            "extract"
+        ]
+    );
+
+    Ok(json!({
+        "status": "completed",
+        "trace_len": operations.len(),
+    }))
+}
+
+fn scenario_verify_failure_suppresses_act() -> anyhow::Result<Value> {
+    let skill = happy_path_skill();
+    let mut runtime = MockRuntime::default().with_script(
+        "verify",
+        vec![OperationOutcome::Failure {
+            reason: "not enabled".to_string(),
+        }],
+    );
+
+    let report = SkillEngine::new().run(&skill, &mut runtime)?;
+    let operations = report
+        .trace
+        .iter()
+        .map(|entry| entry.operation.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(report.status, SkillRunStatus::Failed);
+    assert!(operations.contains(&"verify"));
+    assert!(!operations.contains(&"act"));
+
+    Ok(json!({
+        "status": "failed",
+        "operations": operations,
+    }))
+}
+
+fn scenario_retry_branch_and_handoff() -> anyhow::Result<Value> {
+    let skill = SkillDefinition {
+        schema_version: 1,
+        name: "retry-branch-handoff".to_string(),
+        steps: vec![
+            SkillStep::Locate(LocateStep {
+                id: Some("locate_first".to_string()),
+                query: "submit button".to_string(),
+                control: StepControl {
+                    max_retries: 1,
+                    on_success: None,
+                    on_failure: None,
+                },
+            }),
+            SkillStep::Verify(VerifyStep {
+                id: Some("verify_first".to_string()),
+                target: "submit button".to_string(),
+                expected: "visible".to_string(),
+                control: StepControl::default(),
+            }),
+            SkillStep::Act(ActStep {
+                id: Some("act_first".to_string()),
+                action: "click".to_string(),
+                target: "submit button".to_string(),
+                value: None,
+                control: StepControl {
+                    max_retries: 0,
+                    on_success: Some("handoff_step".to_string()),
+                    on_failure: None,
+                },
+            }),
+            SkillStep::Extract(ExtractStep {
+                id: Some("extract_should_skip".to_string()),
+                key: "ignored".to_string(),
+                selector: "#ignored".to_string(),
+                control: StepControl::default(),
+            }),
+            SkillStep::Handoff(HandoffStep {
+                id: Some("handoff_step".to_string()),
+                reason: "manual approval".to_string(),
+                assignee: Some("ops-team".to_string()),
+                control: StepControl::default(),
+            }),
+        ],
+    };
+
+    let mut runtime = MockRuntime::default().with_script(
+        "locate",
+        vec![
+            OperationOutcome::Failure {
+                reason: "transient".to_string(),
+            },
+            OperationOutcome::Success,
+        ],
+    );
+
+    let report = SkillEngine::new().run(&skill, &mut runtime)?;
+    let operations = report
+        .trace
+        .iter()
+        .map(|entry| entry.operation.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(report.status, SkillRunStatus::Handoff);
+    assert_eq!(operations.iter().filter(|op| **op == "locate").count(), 2);
+    assert!(operations.contains(&"handoff"));
+    assert!(!operations.contains(&"extract"));
+
+    Ok(json!({
+        "status": "handoff",
+        "locate_retries": 2,
+    }))
+}
+
+fn happy_path_skill() -> SkillDefinition {
+    SkillDefinition {
+        schema_version: 1,
+        name: "search-and-extract".to_string(),
+        steps: vec![
+            SkillStep::Locate(LocateStep {
+                id: Some("locate_product".to_string()),
+                query: "search button".to_string(),
+                control: StepControl::default(),
+            }),
+            SkillStep::Verify(VerifyStep {
+                id: Some("verify_product".to_string()),
+                target: "search button".to_string(),
+                expected: "enabled".to_string(),
+                control: StepControl::default(),
+            }),
+            SkillStep::Act(ActStep {
+                id: Some("click_product".to_string()),
+                action: "click".to_string(),
+                target: "search button".to_string(),
+                value: None,
+                control: StepControl::default(),
+            }),
+            SkillStep::Extract(ExtractStep {
+                id: Some("extract_product".to_string()),
+                key: "product_name".to_string(),
+                selector: "#product-name".to_string(),
+                control: StepControl::default(),
+            }),
+        ],
+    }
+}

--- a/test-bench-support/Cargo.toml
+++ b/test-bench-support/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-bench-support"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/test-bench-support/src/lib.rs
+++ b/test-bench-support/src/lib.rs
@@ -1,0 +1,217 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationMode {
+    Smoke,
+    Full,
+}
+
+impl EvaluationMode {
+    pub fn from_env() -> Self {
+        match env::var("DRAGON_HEAD_EVAL_MODE")
+            .unwrap_or_else(|_| "smoke".to_string())
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "full" => Self::Full,
+            _ => Self::Smoke,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Smoke => "smoke",
+            Self::Full => "full",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScenarioRecord {
+    pub scenario_id: String,
+    pub feature_area: String,
+    pub status: ScenarioStatus,
+    pub duration_ms: f64,
+    pub details: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct EvaluationSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvaluationReport {
+    pub crate_name: String,
+    pub suite_name: String,
+    pub mode: EvaluationMode,
+    pub scenarios: Vec<ScenarioRecord>,
+    pub summary: EvaluationSummary,
+}
+
+pub struct EvaluationBench {
+    report: EvaluationReport,
+}
+
+impl EvaluationBench {
+    pub fn new(crate_name: &str, suite_name: &str, mode: EvaluationMode) -> Self {
+        Self {
+            report: EvaluationReport {
+                crate_name: crate_name.to_string(),
+                suite_name: suite_name.to_string(),
+                mode,
+                scenarios: Vec::new(),
+                summary: EvaluationSummary::default(),
+            },
+        }
+    }
+
+    pub fn run_scenario<F>(&mut self, scenario_id: &str, feature_area: &str, scenario: F)
+    where
+        F: FnOnce() -> Result<Value>,
+    {
+        let started = Instant::now();
+        match scenario() {
+            Ok(details) => self.push_record(ScenarioRecord {
+                scenario_id: scenario_id.to_string(),
+                feature_area: feature_area.to_string(),
+                status: ScenarioStatus::Passed,
+                duration_ms: started.elapsed().as_secs_f64() * 1_000.0,
+                details,
+                error: None,
+            }),
+            Err(err) => self.push_record(ScenarioRecord {
+                scenario_id: scenario_id.to_string(),
+                feature_area: feature_area.to_string(),
+                status: ScenarioStatus::Failed,
+                duration_ms: started.elapsed().as_secs_f64() * 1_000.0,
+                details: Value::Null,
+                error: Some(format!("{err:#}")),
+            }),
+        }
+    }
+
+    pub fn write_if_configured(&self) -> Result<Option<PathBuf>> {
+        let Ok(output_dir) = env::var("DRAGON_HEAD_EVAL_OUTPUT_DIR") else {
+            return Ok(None);
+        };
+
+        let file_name = format!(
+            "{}--{}.json",
+            sanitize_component(&self.report.crate_name),
+            sanitize_component(&self.report.suite_name)
+        );
+        let path = Path::new(&output_dir).join(file_name);
+
+        fs::create_dir_all(&output_dir).with_context(|| {
+            format!(
+                "failed to create evaluation output directory at {}",
+                Path::new(&output_dir).display()
+            )
+        })?;
+        let body = serde_json::to_vec_pretty(&self.report)
+            .context("failed to serialize evaluation report")?;
+        fs::write(&path, body)
+            .with_context(|| format!("failed to write evaluation report at {}", path.display()))?;
+
+        Ok(Some(path))
+    }
+
+    pub fn assert_required_scenarios(&self, required: &[&str]) -> Result<()> {
+        let missing = required
+            .iter()
+            .filter(|scenario_id| {
+                !self
+                    .report
+                    .scenarios
+                    .iter()
+                    .any(|record| record.scenario_id == **scenario_id)
+            })
+            .copied()
+            .collect::<Vec<_>>();
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        anyhow::bail!(
+            "missing required evaluation scenarios: {}",
+            missing.join(", ")
+        );
+    }
+
+    pub fn assert_all_passed(&self) -> Result<()> {
+        let failed = self
+            .report
+            .scenarios
+            .iter()
+            .filter(|record| record.status == ScenarioStatus::Failed)
+            .map(|record| match &record.error {
+                Some(error) => format!("{} ({error})", record.scenario_id),
+                None => record.scenario_id.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        if failed.is_empty() {
+            return Ok(());
+        }
+
+        anyhow::bail!("evaluation scenarios failed: {}", failed.join("; "));
+    }
+
+    pub fn report(&self) -> &EvaluationReport {
+        &self.report
+    }
+
+    fn push_record(&mut self, record: ScenarioRecord) {
+        self.report.scenarios.push(record);
+        self.report.summary = EvaluationSummary {
+            total: self.report.scenarios.len(),
+            passed: self
+                .report
+                .scenarios
+                .iter()
+                .filter(|record| record.status == ScenarioStatus::Passed)
+                .count(),
+            failed: self
+                .report
+                .scenarios
+                .iter()
+                .filter(|record| record.status == ScenarioStatus::Failed)
+                .count(),
+        };
+    }
+}
+
+fn sanitize_component(input: &str) -> String {
+    input
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary
- add a shared `test-bench-support` crate for cross-crate evaluation report output
- add comprehensive evaluation suites for `core-runtime`, `mcp-server`, `skills-engine`, `plugin-host`, and `marketplace`
- add `scripts/evaluation_dashboard.py`, `Justfile` targets, and CI jobs for smoke/full evaluation bench runs
- update `docs/PLAN.md` and `docs/testing.md` to track PR-19 and document the bench registration rule

## Related Spec / Plan
- Spec Ref: Section 2.2, Section 5.2, Section 6, Section 7.1〜7.3
- Plan: `docs/PLAN.md` PR-19
- Testing: `docs/testing.md` Comprehensive Evaluation Bench

## Exit Criteria
- [x] `dragon-head` の主要機能群を1つの評価ダッシュボードで横断確認できる
- [x] PR では短尺 smoke、nightly では full 評価が自動実行される
- [x] 追加された主要機能は評価ベンチへの登録なしでは完了扱いにできない運用ルールが `docs/` に明記されている

## Test Results
- [x] `just evaluation-bench-smoke`
- [x] `just evaluation-bench-full`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`

## Notes
- smoke/full ともに 5 reports を集約し、ダッシュボード生成までローカル確認済み
- 既存の未追跡 patch (`nfr_latency_fix.patch`, `update_ci.patch`) はこの PR に含めていません
