### PR TITLE
[PR-00] ワークスペース test profile の安定化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [profile.test]
-# Keep the default `cargo test --workspace` path stable across developer filesystems.
+# Keep the default workspace test and compile-only verification paths stable across developer filesystems.
 incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ tracing-subscriber = "0.3"
 headless_chrome = "1.0"  # Specific version to be checked
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[profile.test]
+# Keep the default `cargo test --workspace` path stable across developer filesystems.
+incremental = false

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,6 +54,9 @@ The CI pipeline is defined in `.github/workflows/`.
 # Run all unit and integration tests
 cargo test
 
+# Compile the full workspace test suite without running it
+cargo test --workspace --no-run
+
 # Run specific test
 cargo test test_name
 
@@ -61,7 +64,7 @@ cargo test test_name
 cargo test --test e2e
 ```
 
-The workspace disables incremental compilation for the `test` profile so the default `cargo test --workspace` flow remains stable on filesystems where incremental dep-graph artifact creation is unreliable.
+The workspace disables incremental compilation for the `test` profile so the default `cargo test --workspace` and `cargo test --workspace --no-run` flows remain stable on filesystems where incremental dep-graph artifact creation is unreliable.
 
 ## 4. Exit Criteria for PRs
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,6 +61,8 @@ cargo test test_name
 cargo test --test e2e
 ```
 
+The workspace disables incremental compilation for the `test` profile so the default `cargo test --workspace` flow remains stable on filesystems where incremental dep-graph artifact creation is unreliable.
+
 ## 4. Exit Criteria for PRs
 
 - All tests must pass.


### PR DESCRIPTION
## 関連
- Closes #33
- Spec Ref: Section 6, docs/testing.md, PR-00 (Test Strategy & CI Foundation)

## 概要
- Cargo workspace の test プロファイルで incremental compilation を無効化し、既定の cargo test --workspace / cargo test --workspace --no-run が dep-graph.part.bin エラーなしで完走できるようにしました
- docs/testing.md に、この設定がデフォルトのローカル検証経路を安定化するためのものだと追記しました

## Exit Criteria
- [x] 既定の cargo test --workspace --no-run が追加の環境変数なしで通る
- [x] 既定の cargo test --workspace が追加の環境変数なしで通る
- [x] テスト戦略ドキュメントに挙動を反映している

## テスト
- cargo test --workspace --no-run
- cargo test --workspace
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings