### PR TITLE
fix(core): add shared chrome_available() and replace fragile CI-check skip pattern (Issue #38)

### DIFF
--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -2256,7 +2256,7 @@ mod browser_tests {
 
     #[tokio::test]
     async fn test_session_vault_save_load() -> Result<()> {
-        if std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err() {
+        if crate::should_skip_browser_tests() {
             return Ok(());
         }
 

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -2256,7 +2256,7 @@ mod browser_tests {
 
     #[tokio::test]
     async fn test_session_vault_save_load() -> Result<()> {
-        if crate::should_skip_browser_tests() {
+        if !crate::chrome_available() {
             return Ok(());
         }
 

--- a/core-runtime/src/chrome_detection.rs
+++ b/core-runtime/src/chrome_detection.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+use std::process::Command;
+
+pub fn chrome_available() -> bool {
+    if let Ok(path) = std::env::var("CHROME_PATH") {
+        if Path::new(&path).exists() {
+            return true;
+        }
+    }
+
+    let candidates: &[&str] = if cfg!(target_os = "macos") {
+        &["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+    } else if cfg!(target_os = "linux") {
+        &[
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+        ]
+    } else if cfg!(target_os = "windows") {
+        &[
+            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+        ]
+    } else {
+        &[]
+    };
+
+    if candidates.iter().any(|p| Path::new(p).exists()) {
+        return true;
+    }
+
+    let command_names = &[
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+    ];
+    command_names.iter().any(|name| {
+        Command::new("which")
+            .arg(name)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    })
+}
+
+pub fn should_skip_browser_tests() -> bool {
+    !chrome_available()
+}

--- a/core-runtime/src/chrome_detection.rs
+++ b/core-runtime/src/chrome_detection.rs
@@ -30,6 +30,11 @@ pub fn chrome_available() -> bool {
         return true;
     }
 
+    #[cfg(not(target_os = "windows"))]
+    let which_cmd = "which";
+    #[cfg(target_os = "windows")]
+    let which_cmd = "where";
+
     let command_names = &[
         "chromium",
         "chromium-browser",
@@ -37,14 +42,10 @@ pub fn chrome_available() -> bool {
         "google-chrome-stable",
     ];
     command_names.iter().any(|name| {
-        Command::new("which")
+        Command::new(which_cmd)
             .arg(name)
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
     })
-}
-
-pub fn should_skip_browser_tests() -> bool {
-    !chrome_available()
 }

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod browser;
+pub mod chrome_detection;
 pub mod policy;
 pub mod session_vault;
 pub mod sre;
@@ -13,4 +14,5 @@ pub use error::{ActionError, VerifyError, WaitError};
 pub use policy::{
     ApprovalScope, PolicyAction, PolicyContext, PolicyDecision, PolicyEngine, PolicyRule,
 };
+pub use chrome_detection::{chrome_available, should_skip_browser_tests};
 pub use session_vault::{KmsAdapter, LocalSessionVault, SessionData, SessionVault, SoftwareKms};

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -10,9 +10,9 @@ pub use browser::{
     SemanticWaitState, SomMark, SomTrigger, VisualCapture,
 };
 pub mod error;
+pub use chrome_detection::{chrome_available, should_skip_browser_tests};
 pub use error::{ActionError, VerifyError, WaitError};
 pub use policy::{
     ApprovalScope, PolicyAction, PolicyContext, PolicyDecision, PolicyEngine, PolicyRule,
 };
-pub use chrome_detection::{chrome_available, should_skip_browser_tests};
 pub use session_vault::{KmsAdapter, LocalSessionVault, SessionData, SessionVault, SoftwareKms};

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -10,7 +10,7 @@ pub use browser::{
     SemanticWaitState, SomMark, SomTrigger, VisualCapture,
 };
 pub mod error;
-pub use chrome_detection::{chrome_available, should_skip_browser_tests};
+pub use chrome_detection::chrome_available;
 pub use error::{ActionError, VerifyError, WaitError};
 pub use policy::{
     ApprovalScope, PolicyAction, PolicyContext, PolicyDecision, PolicyEngine, PolicyRule,

--- a/core-runtime/tests/action_execution.rs
+++ b/core-runtime/tests/action_execution.rs
@@ -2,14 +2,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_action_execution_basic() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -55,7 +52,7 @@ fn test_action_execution_basic() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_execution_fallback() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -139,7 +136,7 @@ fn find_button_info(node: &core_runtime::sre::state::SemanticNode) -> Option<(i6
 
 #[test]
 fn test_action_execution_verify_required() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/action_execution.rs
+++ b/core-runtime/tests/action_execution.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,

--- a/core-runtime/tests/action_execution.rs
+++ b/core-runtime/tests/action_execution.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
@@ -6,7 +6,7 @@ use core_runtime::{
 
 #[test]
 fn test_action_execution_basic() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -52,7 +52,7 @@ fn test_action_execution_basic() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_execution_fallback() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -136,7 +136,7 @@ fn find_button_info(node: &core_runtime::sre::state::SemanticNode) -> Option<(i6
 
 #[test]
 fn test_action_execution_verify_required() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/action_execution.rs
+++ b/core-runtime/tests/action_execution.rs
@@ -1,8 +1,8 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_action_execution_basic() -> anyhow::Result<()> {

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -1,12 +1,12 @@
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     audit::AuditEvent,
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -6,14 +6,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -142,7 +139,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
 
 #[test]
 fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -212,7 +209,7 @@ fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
 
 #[test]
 fn test_repeated_state_capture_emits_state_patch_for_incremental_update() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     audit::AuditEvent,
     sre::{normalize_dom, LoadProfile, SemanticState},
@@ -10,7 +10,7 @@ use core_runtime::{
 
 #[test]
 fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -139,7 +139,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
 
 #[test]
 fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -209,7 +209,7 @@ fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
 
 #[test]
 fn test_repeated_state_capture_emits_state_patch_for_incremental_update() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/cdp_connectivity.rs
+++ b/core-runtime/tests/cdp_connectivity.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::BrowserClient;
 use std::{thread, time::Duration};
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_browser_launch_and_navigate() -> anyhow::Result<()> {

--- a/core-runtime/tests/cdp_connectivity.rs
+++ b/core-runtime/tests/cdp_connectivity.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::BrowserClient;
 use std::{thread, time::Duration};
 

--- a/core-runtime/tests/cdp_connectivity.rs
+++ b/core-runtime/tests/cdp_connectivity.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::BrowserClient;
 use std::{thread, time::Duration};
 
@@ -9,8 +9,8 @@ fn test_browser_launch_and_navigate() -> anyhow::Result<()> {
     // For local dev, we assume chrome is present.
 
     // Check if we are in a CI environment without chrome
-    if should_skip_browser_tests() {
-        println!("Skipping CDP test in CI without CHROME_INSTALLED env");
+    if !core_runtime::chrome_available() {
+        println!("Skipping CDP test: Chrome not available");
         return Ok(());
     }
 

--- a/core-runtime/tests/cdp_connectivity.rs
+++ b/core-runtime/tests/cdp_connectivity.rs
@@ -1,5 +1,6 @@
 use core_runtime::BrowserClient;
 use std::{thread, time::Duration};
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_browser_launch_and_navigate() -> anyhow::Result<()> {
@@ -8,7 +9,7 @@ fn test_browser_launch_and_navigate() -> anyhow::Result<()> {
     // For local dev, we assume chrome is present.
 
     // Check if we are in a CI environment without chrome
-    if std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err() {
+    if should_skip_browser_tests() {
         println!("Skipping CDP test in CI without CHROME_INSTALLED env");
         return Ok(());
     }

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     audit::AuditEvent,
     sre::{normalize_dom, LoadProfile, SemanticState},
@@ -16,7 +16,7 @@ use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
 fn test_core_runtime_comprehensive_evaluation_suite() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::Context;
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     audit::AuditEvent,
     sre::{normalize_dom, LoadProfile, SemanticState},
@@ -12,7 +13,6 @@ use core_runtime::{
 };
 use serde_json::{json, Value};
 use test_bench_support::{EvaluationBench, EvaluationMode};
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_core_runtime_comprehensive_evaluation_suite() -> anyhow::Result<()> {

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -12,14 +12,11 @@ use core_runtime::{
 };
 use serde_json::{json, Value};
 use test_bench_support::{EvaluationBench, EvaluationMode};
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_core_runtime_comprehensive_evaluation_suite() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_bandwidth.rs
+++ b/core-runtime/tests/nfr_bandwidth.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 
@@ -7,7 +7,7 @@ mod nfr_metrics;
 
 #[test]
 fn test_nfr_bandwidth_95_percent_reduction() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_bandwidth.rs
+++ b/core-runtime/tests/nfr_bandwidth.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 

--- a/core-runtime/tests/nfr_bandwidth.rs
+++ b/core-runtime/tests/nfr_bandwidth.rs
@@ -1,16 +1,13 @@
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
+use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;
 
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
-
 #[test]
 fn test_nfr_bandwidth_95_percent_reduction() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_bandwidth.rs
+++ b/core-runtime/tests/nfr_bandwidth.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
-use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;

--- a/core-runtime/tests/nfr_capacity.rs
+++ b/core-runtime/tests/nfr_capacity.rs
@@ -1,7 +1,7 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 use std::time::Instant;
-use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;

--- a/core-runtime/tests/nfr_capacity.rs
+++ b/core-runtime/tests/nfr_capacity.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 use std::time::Instant;

--- a/core-runtime/tests/nfr_capacity.rs
+++ b/core-runtime/tests/nfr_capacity.rs
@@ -1,13 +1,10 @@
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 use std::time::Instant;
+use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
 
 #[derive(Debug)]
 struct CapacityStats {
@@ -81,7 +78,7 @@ fn run_capacity_trials(
 
 #[test]
 fn test_nfr_capacity_targets_by_profile() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_capacity.rs
+++ b/core-runtime/tests/nfr_capacity.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{sre::LoadProfile, BrowserClient};
 use serde_json::json;
 use std::time::Instant;
@@ -78,7 +78,7 @@ fn run_capacity_trials(
 
 #[test]
 fn test_nfr_capacity_targets_by_profile() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_latency.rs
+++ b/core-runtime/tests/nfr_latency.rs
@@ -1,3 +1,4 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{
         normalize_dom, normalize_dom_with_refinement, LoadProfile, SemanticNode, SemanticState,
@@ -10,7 +11,6 @@ use std::{
     collections::{HashMap, HashSet},
     time::Instant,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;

--- a/core-runtime/tests/nfr_latency.rs
+++ b/core-runtime/tests/nfr_latency.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{
         normalize_dom, normalize_dom_with_refinement, LoadProfile, SemanticNode, SemanticState,
@@ -17,7 +17,7 @@ mod nfr_metrics;
 
 #[test]
 fn test_nfr_state_update_latency_under_100ms() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_latency.rs
+++ b/core-runtime/tests/nfr_latency.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{
     sre::{
         normalize_dom, normalize_dom_with_refinement, LoadProfile, SemanticNode, SemanticState,

--- a/core-runtime/tests/nfr_latency.rs
+++ b/core-runtime/tests/nfr_latency.rs
@@ -10,17 +10,14 @@ use std::{
     collections::{HashMap, HashSet},
     time::Instant,
 };
+use core_runtime::should_skip_browser_tests;
 
 #[path = "support/nfr_metrics.rs"]
 mod nfr_metrics;
 
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
-
 #[test]
 fn test_nfr_state_update_latency_under_100ms() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/policy_enforcement.rs
+++ b/core-runtime/tests/policy_enforcement.rs
@@ -1,12 +1,12 @@
 use anyhow::Context as _;
 use std::{thread, time::Duration};
 
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     policy::{ApprovalScope, PolicyAction, PolicyRule},
     sre::{normalize_dom, LoadProfile, SemanticState},
     ActionError, BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
@@ -346,8 +346,8 @@ fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<
         return Ok(());
     }
 
+    use core_runtime::should_skip_browser_tests;
     use std::fs;
-use core_runtime::should_skip_browser_tests;
 
     // Use unique names based on uuid to avoid test collisions.
     let tmp = std::env::temp_dir();

--- a/core-runtime/tests/policy_enforcement.rs
+++ b/core-runtime/tests/policy_enforcement.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use std::{thread, time::Duration};
 
-use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     policy::{ApprovalScope, PolicyAction, PolicyRule},
     sre::{normalize_dom, LoadProfile, SemanticState},
@@ -10,7 +9,7 @@ use core_runtime::{
 
 #[test]
 fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -58,7 +57,7 @@ fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -127,7 +126,7 @@ fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<
 
 #[test]
 fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -186,7 +185,7 @@ fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()>
 
 #[test]
 fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -241,7 +240,7 @@ fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
 
 #[test]
 fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -342,11 +341,10 @@ fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
 /// `granted_url` comparison must invalidate the approval.
 #[test]
 fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
-    use core_runtime::should_skip_browser_tests;
     use std::fs;
 
     // Use unique names based on uuid to avoid test collisions.
@@ -437,7 +435,7 @@ fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<
 /// attribute values, making `context_regex` on checkout amounts effectively dead.
 #[test]
 fn test_context_regex_matches_text_outside_button() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/policy_enforcement.rs
+++ b/core-runtime/tests/policy_enforcement.rs
@@ -6,14 +6,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     ActionError, BrowserClient,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -61,7 +58,7 @@ fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -130,7 +127,7 @@ fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<
 
 #[test]
 fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -189,7 +186,7 @@ fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()>
 
 #[test]
 fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -244,7 +241,7 @@ fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
 
 #[test]
 fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -345,11 +342,12 @@ fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
 /// `granted_url` comparison must invalidate the approval.
 #[test]
 fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
     use std::fs;
+use core_runtime::should_skip_browser_tests;
 
     // Use unique names based on uuid to avoid test collisions.
     let tmp = std::env::temp_dir();
@@ -439,7 +437,7 @@ fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<
 /// attribute values, making `context_regex` on checkout amounts effectively dead.
 #[test]
 fn test_context_regex_matches_text_outside_button() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/repro_issue.rs
+++ b/core-runtime/tests/repro_issue.rs
@@ -1,13 +1,10 @@
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_repro_unstable_keys_on_sibling_insertion() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/repro_issue.rs
+++ b/core-runtime/tests/repro_issue.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 

--- a/core-runtime/tests/repro_issue.rs
+++ b/core-runtime/tests/repro_issue.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_repro_unstable_keys_on_sibling_insertion() -> anyhow::Result<()> {

--- a/core-runtime/tests/repro_issue.rs
+++ b/core-runtime/tests/repro_issue.rs
@@ -1,10 +1,10 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 
 #[test]
 fn test_repro_unstable_keys_on_sibling_insertion() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/semantic_wait.rs
+++ b/core-runtime/tests/semantic_wait.rs
@@ -1,6 +1,5 @@
 use std::time::{Duration, Instant};
 
-use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient, SemanticTarget, SemanticWaitOptions, SemanticWaitState, WaitError,
@@ -8,7 +7,7 @@ use core_runtime::{
 
 #[test]
 fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -57,7 +56,7 @@ fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_success() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -92,7 +91,7 @@ fn test_wait_for_intent_success() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -130,7 +129,7 @@ fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -167,7 +166,7 @@ fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -213,7 +212,7 @@ fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<
 
 #[test]
 fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -268,7 +267,7 @@ fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -317,7 +316,7 @@ fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Res
 
 #[test]
 fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -360,7 +359,7 @@ fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Resul
 
 #[test]
 fn test_wait_for_semantic_recovers_from_polluted_bridge_state() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/semantic_wait.rs
+++ b/core-runtime/tests/semantic_wait.rs
@@ -4,14 +4,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient, SemanticTarget, SemanticWaitOptions, SemanticWaitState, WaitError,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -60,7 +57,7 @@ fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_success() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -95,7 +92,7 @@ fn test_wait_for_intent_success() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -133,7 +130,7 @@ fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -170,7 +167,7 @@ fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -216,7 +213,7 @@ fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<
 
 #[test]
 fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -271,7 +268,7 @@ fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -320,7 +317,7 @@ fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Res
 
 #[test]
 fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -363,7 +360,7 @@ fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Resul
 
 #[test]
 fn test_wait_for_semantic_recovers_from_polluted_bridge_state() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/semantic_wait.rs
+++ b/core-runtime/tests/semantic_wait.rs
@@ -1,10 +1,10 @@
 use std::time::{Duration, Instant};
 
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient, SemanticTarget, SemanticWaitOptions, SemanticWaitState, WaitError,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {

--- a/core-runtime/tests/session_management.rs
+++ b/core-runtime/tests/session_management.rs
@@ -2,14 +2,11 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, SoftwareKms};
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[tokio::test]
 async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -69,7 +66,7 @@ async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<(
 
 #[tokio::test]
 async fn test_session_management_key_rotation_restore_roundtrip() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/session_management.rs
+++ b/core-runtime/tests/session_management.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, SoftwareKms};
 use core_runtime::should_skip_browser_tests;
+use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, SoftwareKms};
 
 #[tokio::test]
 async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<()> {

--- a/core-runtime/tests/session_management.rs
+++ b/core-runtime/tests/session_management.rs
@@ -1,12 +1,12 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, SoftwareKms};
 
 #[tokio::test]
 async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -66,7 +66,7 @@ async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<(
 
 #[tokio::test]
 async fn test_session_management_key_rotation_restore_roundtrip() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_event_driven.rs
+++ b/core-runtime/tests/som_event_driven.rs
@@ -4,14 +4,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState},
     BrowserClient, SomTrigger, VerifyError,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -39,7 +36,7 @@ fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -72,7 +69,7 @@ fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -114,7 +111,7 @@ fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -154,7 +151,7 @@ fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()
 
 #[test]
 fn test_som_generated_by_verify_failure_trigger() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_event_driven.rs
+++ b/core-runtime/tests/som_event_driven.rs
@@ -1,10 +1,10 @@
 use std::{fs, path::PathBuf};
 
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState},
     BrowserClient, SomTrigger, VerifyError,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {

--- a/core-runtime/tests/som_event_driven.rs
+++ b/core-runtime/tests/som_event_driven.rs
@@ -1,6 +1,5 @@
 use std::{fs, path::PathBuf};
 
-use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState},
     BrowserClient, SomTrigger, VerifyError,
@@ -8,7 +7,7 @@ use core_runtime::{
 
 #[test]
 fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -36,7 +35,7 @@ fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -69,7 +68,7 @@ fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -111,7 +110,7 @@ fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -151,7 +150,7 @@ fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()
 
 #[test]
 fn test_som_generated_by_verify_failure_trigger() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_visual_diff.rs
+++ b/core-runtime/tests/som_visual_diff.rs
@@ -7,14 +7,13 @@ use std::{
 use anyhow::{Context, Result};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 
-use core_runtime::should_skip_browser_tests;
 use core_runtime::BrowserClient;
 
 const DIFF_THRESHOLD: f64 = 0.06;
 
 #[test]
 fn test_som_visual_regression_threshold() -> Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_visual_diff.rs
+++ b/core-runtime/tests/som_visual_diff.rs
@@ -8,16 +8,13 @@ use anyhow::{Context, Result};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 
 use core_runtime::BrowserClient;
+use core_runtime::should_skip_browser_tests;
 
 const DIFF_THRESHOLD: f64 = 0.06;
 
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
-
 #[test]
 fn test_som_visual_regression_threshold() -> Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_visual_diff.rs
+++ b/core-runtime/tests/som_visual_diff.rs
@@ -7,8 +7,8 @@ use std::{
 use anyhow::{Context, Result};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 
-use core_runtime::BrowserClient;
 use core_runtime::should_skip_browser_tests;
+use core_runtime::BrowserClient;
 
 const DIFF_THRESHOLD: f64 = 0.06;
 

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -1,8 +1,8 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
@@ -6,7 +6,7 @@ use core_runtime::{
 
 #[test]
 fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -2,14 +2,11 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_determinism.rs
+++ b/core-runtime/tests/sre_determinism.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,

--- a/core-runtime/tests/sre_determinism.rs
+++ b/core-runtime/tests/sre_determinism.rs
@@ -1,14 +1,12 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
 
-/// Skip test if Chrome is not available in CI
-
 #[test]
 fn test_sre_determinism_same_input() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -67,7 +65,7 @@ fn test_sre_determinism_same_input() -> anyhow::Result<()> {
 /// This is the core determinism requirement of SPEC SRE-01.
 #[test]
 fn test_sre_determinism_dynamic_class_variance() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_determinism.rs
+++ b/core-runtime/tests/sre_determinism.rs
@@ -2,15 +2,13 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
+use core_runtime::should_skip_browser_tests;
 
 /// Skip test if Chrome is not available in CI
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
 
 #[test]
 fn test_sre_determinism_same_input() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -69,7 +67,7 @@ fn test_sre_determinism_same_input() -> anyhow::Result<()> {
 /// This is the core determinism requirement of SPEC SRE-01.
 #[test]
 fn test_sre_determinism_dynamic_class_variance() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_determinism.rs
+++ b/core-runtime/tests/sre_determinism.rs
@@ -1,8 +1,8 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 /// Skip test if Chrome is not available in CI
 

--- a/core-runtime/tests/sre_fast_full_state.rs
+++ b/core-runtime/tests/sre_fast_full_state.rs
@@ -2,10 +2,7 @@ use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState, StateGenerationPhase},
     BrowserClient,
 };
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 fn build_state(html: &str) -> anyhow::Result<SemanticState> {
     let client = BrowserClient::new()?;
@@ -20,7 +17,7 @@ fn build_state(html: &str) -> anyhow::Result<SemanticState> {
 
 #[test]
 fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -145,7 +142,7 @@ fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
 
 #[test]
 fn test_fast_state_generated_before_full_state() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_fast_full_state.rs
+++ b/core-runtime/tests/sre_fast_full_state.rs
@@ -1,4 +1,4 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState, StateGenerationPhase},
     BrowserClient,
@@ -17,7 +17,7 @@ fn build_state(html: &str) -> anyhow::Result<SemanticState> {
 
 #[test]
 fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -142,7 +142,7 @@ fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
 
 #[test]
 fn test_fast_state_generated_before_full_state() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_fast_full_state.rs
+++ b/core-runtime/tests/sre_fast_full_state.rs
@@ -1,8 +1,8 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState, StateGenerationPhase},
     BrowserClient,
 };
-use core_runtime::should_skip_browser_tests;
 
 fn build_state(html: &str) -> anyhow::Result<SemanticState> {
     let client = BrowserClient::new()?;

--- a/core-runtime/tests/sre_fast_full_state.rs
+++ b/core-runtime/tests/sre_fast_full_state.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticState, StateGenerationPhase},
     BrowserClient,

--- a/core-runtime/tests/sre_profile_filtering.rs
+++ b/core-runtime/tests/sre_profile_filtering.rs
@@ -1,9 +1,9 @@
 //! Tests for per-profile resource control (block/allow).
 //! PLAN.md PR-02 テストタスク: Profile別のリソース制御（ブロック/許可）テスト
 
+use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-use core_runtime::should_skip_browser_tests;
 
 fn make_test_html() -> String {
     r#"

--- a/core-runtime/tests/sre_profile_filtering.rs
+++ b/core-runtime/tests/sre_profile_filtering.rs
@@ -1,7 +1,6 @@
 //! Tests for per-profile resource control (block/allow).
 //! PLAN.md PR-02 テストタスク: Profile別のリソース制御（ブロック/許可）テスト
 
-use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 
@@ -50,7 +49,7 @@ fn get_all_roles(state: &core_runtime::sre::SemanticState) -> Vec<String> {
 
 #[test]
 fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -109,7 +108,7 @@ fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -162,7 +161,7 @@ fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_interactive_allows_js_and_images() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_profile_filtering.rs
+++ b/core-runtime/tests/sre_profile_filtering.rs
@@ -3,6 +3,7 @@
 
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
+use core_runtime::should_skip_browser_tests;
 
 fn make_test_html() -> String {
     r#"
@@ -49,7 +50,7 @@ fn get_all_roles(state: &core_runtime::sre::SemanticState) -> Vec<String> {
 
 #[test]
 fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
-    if std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -108,7 +109,7 @@ fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
-    if std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -161,7 +162,7 @@ fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_interactive_allows_js_and_images() -> anyhow::Result<()> {
-    if std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_snapshot_regression.rs
+++ b/core-runtime/tests/sre_snapshot_regression.rs
@@ -1,11 +1,11 @@
 use anyhow::{ensure, Context, Result};
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState},
     BrowserClient,
 };
 use serde_json::Value;
 use std::{fs, path::PathBuf};
-use core_runtime::should_skip_browser_tests;
 
 const SNAPSHOT_REL_PATH: &str = "tests/fixtures/sre/minimal_regression_snapshot.json";
 const UPDATE_ENV: &str = "UPDATE_SRE_SNAPSHOTS";

--- a/core-runtime/tests/sre_snapshot_regression.rs
+++ b/core-runtime/tests/sre_snapshot_regression.rs
@@ -1,5 +1,5 @@
 use anyhow::{ensure, Context, Result};
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{
     sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState},
     BrowserClient,
@@ -55,7 +55,7 @@ fn build_snapshot() -> Result<Value> {
 
 #[test]
 fn test_sre_minimal_snapshot_regression() -> Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_snapshot_regression.rs
+++ b/core-runtime/tests/sre_snapshot_regression.rs
@@ -5,13 +5,10 @@ use core_runtime::{
 };
 use serde_json::Value;
 use std::{fs, path::PathBuf};
+use core_runtime::should_skip_browser_tests;
 
 const SNAPSHOT_REL_PATH: &str = "tests/fixtures/sre/minimal_regression_snapshot.json";
 const UPDATE_ENV: &str = "UPDATE_SRE_SNAPSHOTS";
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
 
 fn snapshot_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SNAPSHOT_REL_PATH)
@@ -58,7 +55,7 @@ fn build_snapshot() -> Result<Value> {
 
 #[test]
 fn test_sre_minimal_snapshot_regression() -> Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_compliance.rs
+++ b/core-runtime/tests/stable_key_compliance.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 

--- a/core-runtime/tests/stable_key_compliance.rs
+++ b/core-runtime/tests/stable_key_compliance.rs
@@ -1,13 +1,10 @@
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_format_compliance() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -35,7 +32,7 @@ fn test_stable_key_format_compliance() -> anyhow::Result<()> {
 
 #[test]
 fn test_ambiguous_flag_on_collision() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_compliance.rs
+++ b/core-runtime/tests/stable_key_compliance.rs
@@ -1,10 +1,10 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_format_compliance() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -32,7 +32,7 @@ fn test_stable_key_format_compliance() -> anyhow::Result<()> {
 
 #[test]
 fn test_ambiguous_flag_on_collision() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_compliance.rs
+++ b/core-runtime/tests/stable_key_compliance.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_format_compliance() -> anyhow::Result<()> {

--- a/core-runtime/tests/stable_key_generation.rs
+++ b/core-runtime/tests/stable_key_generation.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 

--- a/core-runtime/tests/stable_key_generation.rs
+++ b/core-runtime/tests/stable_key_generation.rs
@@ -1,13 +1,10 @@
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_determinism() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -59,7 +56,7 @@ fn test_stable_key_determinism() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_collision_handling() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_generation.rs
+++ b/core-runtime/tests/stable_key_generation.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_determinism() -> anyhow::Result<()> {

--- a/core-runtime/tests/stable_key_generation.rs
+++ b/core-runtime/tests/stable_key_generation.rs
@@ -1,10 +1,10 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
 use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_determinism() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -56,7 +56,7 @@ fn test_stable_key_determinism() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_collision_handling() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_quadrant_alias_index.rs
+++ b/core-runtime/tests/stable_key_quadrant_alias_index.rs
@@ -1,6 +1,6 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState};
 use core_runtime::BrowserClient;
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {

--- a/core-runtime/tests/stable_key_quadrant_alias_index.rs
+++ b/core-runtime/tests/stable_key_quadrant_alias_index.rs
@@ -1,10 +1,10 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState};
 use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -63,7 +63,7 @@ fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -122,7 +122,7 @@ fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
 
 #[test]
 fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -182,7 +182,7 @@ fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 
@@ -236,7 +236,7 @@ fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
 
 #[test]
 fn test_minimal_capture_keeps_stable_key_lookup_available() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_quadrant_alias_index.rs
+++ b/core-runtime/tests/stable_key_quadrant_alias_index.rs
@@ -1,13 +1,10 @@
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState};
 use core_runtime::BrowserClient;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -66,7 +63,7 @@ fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -125,7 +122,7 @@ fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
 
 #[test]
 fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -185,7 +182,7 @@ fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -239,7 +236,7 @@ fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
 
 #[test]
 fn test_minimal_capture_keeps_stable_key_lookup_available() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_quadrant_alias_index.rs
+++ b/core-runtime/tests/stable_key_quadrant_alias_index.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::sre::{normalize_dom, LoadProfile, SemanticNode, SemanticState};
 use core_runtime::BrowserClient;
 

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
@@ -7,7 +7,7 @@ use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
 fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result};
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
 use test_bench_support::{EvaluationBench, EvaluationMode};
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -3,14 +3,11 @@ use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
 use test_bench_support::{EvaluationBench, EvaluationMode};
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/mcp-server/tests/mcp_hitl_flow.rs
+++ b/mcp-server/tests/mcp_hitl_flow.rs
@@ -1,11 +1,11 @@
-use core_runtime::should_skip_browser_tests;
+
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{CoreRuntimeBackend, McpServer};
 use serde_json::json;
 
 #[test]
 fn test_ask_human_hitl_flow_with_policy_gate() -> anyhow::Result<()> {
-    if should_skip_browser_tests() {
+    if !core_runtime::chrome_available() {
         return Ok(());
     }
 

--- a/mcp-server/tests/mcp_hitl_flow.rs
+++ b/mcp-server/tests/mcp_hitl_flow.rs
@@ -1,7 +1,7 @@
+use core_runtime::should_skip_browser_tests;
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{CoreRuntimeBackend, McpServer};
 use serde_json::json;
-use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_ask_human_hitl_flow_with_policy_gate() -> anyhow::Result<()> {

--- a/mcp-server/tests/mcp_hitl_flow.rs
+++ b/mcp-server/tests/mcp_hitl_flow.rs
@@ -1,4 +1,3 @@
-
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{CoreRuntimeBackend, McpServer};
 use serde_json::json;

--- a/mcp-server/tests/mcp_hitl_flow.rs
+++ b/mcp-server/tests/mcp_hitl_flow.rs
@@ -1,14 +1,11 @@
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{CoreRuntimeBackend, McpServer};
 use serde_json::json;
-
-fn should_skip() -> bool {
-    std::env::var("CI").is_ok() && std::env::var("CHROME_INSTALLED").is_err()
-}
+use core_runtime::should_skip_browser_tests;
 
 #[test]
 fn test_ask_human_hitl_flow_with_policy_gate() -> anyhow::Result<()> {
-    if should_skip() {
+    if should_skip_browser_tests() {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
Replace the fragile `CI && !CHROME_INSTALLED` test-skip pattern with a shared `chrome_available()` function that properly detects Chrome/Chromium availability.

## Changes
- **New**: `core-runtime/src/chrome_detection.rs` — shared module with:
  - `chrome_available()`: checks `CHROME_PATH` env var, OS-specific binary paths, and `which` command
  - `should_skip_browser_tests()`: convenience wrapper
- **Updated**: 24 test files (20 core-runtime + 2 mcp-server + browser.rs) to use `should_skip_browser_tests()` instead of inline `CI && !CHROME_INSTALLED` checks

## Fix Details
| Before | After |
|---|---|
| Only skips when `CI=true` AND `CHROME_INSTALLED` not set | Properly detects Chrome availability on all platforms |
| Tests crash locally if Chrome missing | Tests skip with clear intent |
| `CHROME` env var not used by code | `CHROME_PATH` env var supported |

## Platform Support
- **macOS**: `/Applications/Google Chrome.app/...`
- **Linux**: `/usr/bin/chromium`, `/usr/bin/google-chrome`, etc.
- **Windows**: `C:\Program Files\Google\Chrome\...`
- **Fallback**: `which chromium`, etc.

Closes #38