### PR TITLE
[codex] Add gstack review QA workflow docs and skill fixture

### DIFF
--- a/docs/IMPROVE.md
+++ b/docs/IMPROVE.md
@@ -1,0 +1,272 @@
+# Dragon Head Improvement Discovery Prompt
+
+このプロンプトは、gstack の skills を最大限使って `dragon-head` の新機能アイデア、改善案、技術的負債、検証ギャップ、プロダクト機会を洗い出すためのものです。目的は実装ではなく、次に投資すべき改善テーマを根拠付きで発見し、優先順位をつけることです。
+
+## Prompt
+
+あなたは `dragon-head`（Neural-Browser Runtime）の改善発見チームです。gstack skills を使って、プロダクト、技術設計、UI/UX、DX、QA、セキュリティ、リリース運用の観点から、このリポジトリの次の新機能候補と改善案を洗い出してください。
+
+### 0. 作業モード
+
+- 実装はしない。
+- コード変更はしない。
+- 必要なら読み取り専用のコマンドだけ実行する。
+- 既存の未追跡ファイルや作業中の変更は尊重し、巻き戻さない。
+- 改善案は必ずリポジトリ内の根拠に結びつける。
+- 推測は「仮説」と明記し、確認方法も添える。
+
+### 1. 初期コンテキスト収集
+
+まず以下を読む。
+
+- `README.md`
+- `docs/SPEC.md`
+- `docs/PLAN.md`
+- `docs/PROMPT.md`
+- `docs/testing.md`
+- `docs/VERIFICATION.md` があれば読む
+- `docs/REGISTERED_ISSUES.md` があれば読む
+- `Cargo.toml`
+- 各 workspace crate の `src` と `tests` の概要
+
+次に、以下の観点で現在地を要約する。
+
+- Dragon Head が解こうとしている主要課題
+- 既に実装済みと見なされている機能
+- 仕様上の強い約束、特に TTFT、Semantic State、Stable Key、Policy、Audit、Plugin、Skills、Marketplace
+- 仕様と実装の間にありそうなズレ
+- テストや検証で担保されていること、まだ弱そうなこと
+
+### 2. gstack skill orchestration
+
+以下の gstack skills を、必要に応じて順に使う。各 skill の結果はそのまま結論にしない。重複、矛盾、過剰スコープを統合して、最終的な改善バックログに落とす。
+
+#### Product discovery
+
+Use `gstack-office-hours`.
+
+目的:
+- Dragon Head の現在の価値仮説を問い直す。
+- 「AI-native browser runtime」という表現の裏にある、本当に刺さるユーザー課題を具体化する。
+- 最小 wedge と、より大きな事業機会を分ける。
+
+出力:
+- 想定ユーザー
+- 最も痛い未解決課題
+- 現在の仕様が強い領域
+- 仕様にはあるが価値が弱い、または順番が早すぎる領域
+- 新機能アイデア 5-10 個
+
+#### Strategic product review
+
+Use `gstack-plan-ceo-review`.
+
+目的:
+- 10-star product になり得る方向を探す。
+- 単なる「runtime 機能追加」ではなく、ユーザーが明確に乗り換えたくなる体験を考える。
+- Scope Expansion、Selective Expansion、Hold Scope、Reduction の4モードで候補を見る。
+
+特に検討する問い:
+- Dragon Head は library、MCP server、hosted runtime、enterprise control plane、marketplace のどれを最初に勝たせるべきか。
+- Semantic State の差別化は、どの developer workflow で最も強く表れるか。
+- 競合が Playwright / browser-use / browser automation MCP だとしたら、何が決定的に違うべきか。
+
+#### Engineering architecture review
+
+Use `gstack-plan-eng-review`.
+
+目的:
+- 現在の Rust workspace と仕様を照合し、次の設計投資を見つける。
+- Core Runtime、MCP Server、Plugin Host、Skills Engine、Marketplace の境界を確認する。
+- 高リスクな未実装、過小設計、テスト不足を抽出する。
+
+重点領域:
+- Semantic Rendering Engine の determinism と delta correctness
+- Stable Key の互換性、衝突処理、DOM再レンダリング耐性
+- Async pipeline の backpressure と failure handling
+- Policy Engine と Audit Log の再現性
+- Wasm Plugin sandbox と capability enforcement
+- MCP protocol compatibility と schema evolution
+- Skills Engine の verify -> policy_check -> act -> post_check 強制
+
+#### DX review
+
+Use `gstack-plan-devex-review` and `gstack-devex-review`.
+
+目的:
+- 新規開発者、plugin author、MCP client integrator、enterprise evaluator が迷う箇所を見つける。
+- README、docs、examples、errors、test fixtures、CLI/API の使いやすさを評価する。
+
+検討する改善例:
+- `examples/` や quickstart の不足
+- Semantic State fixture viewer
+- MCP tool contract examples
+- Plugin authoring template
+- Policy rule cookbook
+- Audit log replay tool
+- Benchmark dashboard
+- Troubleshooting guide
+
+#### QA and verification
+
+Use `gstack-qa-only`.
+
+目的:
+- 実装を変更せず、検証観点だけを洗い出す。
+- テストの穴、flaky リスク、性能回帰リスク、CI必須化漏れを特定する。
+
+確認対象:
+- `cargo test --workspace` で担保される範囲
+- integration / e2e / perf / security / schema compatibility の境界
+- docs の完了表示と実際の検証証跡の整合
+- fixture の代表性
+- negative tests と abuse tests の不足
+
+#### Security review
+
+Use `gstack-cso`.
+
+目的:
+- AI agent が web を操作する runtime としての abuse path を洗い出す。
+- Enterprise Security を機能名だけでなく、実際の trust boundary と攻撃経路で評価する。
+
+重点脅威:
+- prompt injection 経由の unsafe action
+- policy bypass
+- audit log tampering
+- session vault leakage
+- plugin sandbox escape
+- malicious marketplace package
+- credential exfiltration
+- replay / race / TOCTOU
+- cross-session data leakage
+
+#### Browser and benchmark opportunities
+
+Use `gstack-browse` and `gstack-benchmark` only if there is a runnable demo, local web target, docs site, or browser-visible artifact to inspect.
+
+目的:
+- 実際の developer-facing surface がある場合、体験と性能を観察する。
+- ない場合は「browser-observable demo が不足している」という改善候補にする。
+
+#### Release and operational maturity
+
+Use `gstack-document-release`, `gstack-health`, and `gstack-retro` as read-only planning aids.
+
+目的:
+- docs と実装状態のズレを見つける。
+- プロジェクト運用上、次に整えるべきレポート、ダッシュボード、リリース証跡を洗い出す。
+
+### 3. Required final output
+
+最終出力は日本語で、以下の構成にする。
+
+## Executive Summary
+
+- Dragon Head の現在の強み
+- 最も大きい未回収の機会
+- 次にやるべき改善テーマ上位3つ
+
+## Improvement Backlog
+
+表で出す。
+
+| Rank | Theme | Type | User | Why now | Evidence | Proposed deliverable | Effort | Risk | Validation |
+|---:|---|---|---|---|---|---|---|---|---|
+
+Type は以下から選ぶ。
+
+- Product
+- Core Runtime
+- MCP/API
+- Plugin
+- Skills
+- Marketplace
+- Security
+- Performance
+- DX
+- QA
+- Docs
+- Ops
+
+最低 15 件、できれば 25 件程度出す。
+
+## Top 5 Deep Dives
+
+上位5件について、各項目を詳述する。
+
+- Problem
+- User story
+- Current repo evidence
+- Proposed design
+- Acceptance criteria
+- Test strategy
+- Security considerations
+- Rollout plan
+- What to explicitly not build yet
+
+## Missing Evidence
+
+判断に必要だが、現在の repo からは確認できなかった情報を列挙する。
+
+## Suggested Next PRs
+
+実装可能な PR 単位に分割する。
+
+各 PR は以下を含める。
+
+- PR title
+- Scope
+- Files likely touched
+- Tests
+- Exit criteria
+- Dependencies
+
+## gstack Skill Notes
+
+使った gstack skills と、それぞれが何を発見したかを短く記録する。
+
+### 4. Ranking rules
+
+優先順位は次の順で評価する。
+
+1. ユーザー価値が明確か
+2. Dragon Head らしい差別化に直結するか
+3. 既存アーキテクチャと自然に接続できるか
+4. テスト可能か
+5. セキュリティ・信頼性を悪化させないか
+6. MVP後の採用・評価・販売に効くか
+
+Effort は `S` / `M` / `L` / `XL`、Risk は `Low` / `Medium` / `High` で表す。
+
+### 5. Quality bar
+
+- 「便利そう」ではなく、誰がなぜ必要とするかを書く。
+- 「AIでいい感じに」は禁止。入力、出力、失敗時挙動、検証方法を明記する。
+- 既存仕様の焼き直しだけで終わらない。仕様にないが自然に伸ばせる案を含める。
+- Security / Audit / Policy は必ず abuse case から考える。
+- Performance 案は測定条件を必ず書く。
+- DX 案は first 15 minutes experience を基準に評価する。
+- Marketplace 案は supply side と demand side の両方を書く。
+
+### 6. First prompt to run
+
+以下をそのまま Codex に渡して開始する。
+
+```text
+Use the installed gstack skills to run an improvement discovery pass for this repository.
+
+Do not implement or edit code. Read README.md, docs/SPEC.md, docs/PLAN.md, docs/PROMPT.md, docs/testing.md, docs/VERIFICATION.md if present, docs/REGISTERED_ISSUES.md if present, Cargo.toml, and the workspace crate layout.
+
+Use gstack-office-hours, gstack-plan-ceo-review, gstack-plan-eng-review, gstack-plan-devex-review, gstack-devex-review, gstack-qa-only, gstack-cso, gstack-health, and gstack-retro as planning/review aids. Use gstack-browse and gstack-benchmark only if there is a runnable browser-facing target.
+
+Produce a Japanese report with:
+1. Executive Summary
+2. Improvement Backlog with at least 15 ranked items
+3. Top 5 Deep Dives
+4. Missing Evidence
+5. Suggested Next PRs
+6. gstack Skill Notes
+
+Tie every recommendation to repo evidence or mark it as a hypothesis with a validation method.
+```

--- a/docs/PROMPT.md
+++ b/docs/PROMPT.md
@@ -54,7 +54,43 @@
 ### 3.3 回帰テスト・ベンチマーク (Regression & NFR)
 - `docs/PLAN.md` の「CIタスク」や「Exit Criteria」に含まれる特定の検証項目（TTFT計測など）を手動で実行し、結果を記録する。
 
-## 4. ドキュメント更新 (Documentation)
+## 4. gstack Review → QA ゲート
+
+ローカル検証が通った後、コミット前に gstack skills を使って **review → qa** の順で追加検証を行います。ここで見つかった問題は修正し、該当テストを追加または更新してから、再度 `3. 品質保証` へ戻ります。
+
+### 4.1 Pre-landing Review
+- `gstack-review` を使い、base branch との差分を pre-landing review する。
+- 重点観点:
+  - 仕様・`docs/PLAN.md` の Exit Criteria とのズレ
+  - Rust workspace / crate 境界の崩れ
+  - Policy / Audit / Session Vault / Plugin / MCP など trust boundary の破れ
+  - テスト不足、回帰リスク、NFR への悪影響
+  - 不要な scope creep や関連しない変更
+- P1/P2 相当の指摘は必ず修正する。修正後は関連テストを再実行し、必要なら `gstack-review` を再実行する。
+
+### 4.2 QA
+- `gstack-qa` を使い、実装した機能をユーザー視点で QA する。
+- runnable な browser-facing target、MCP server、demo、fixture viewer、examples がある場合:
+  - 実際に起動して主要フローを操作する。
+  - 失敗、表示崩れ、エラー応答、ログ、artifact を確認する。
+  - `gstack-browse` / `gstack-benchmark` が適用できる場合は、`gstack-qa` の中で活用する。
+- browser-facing target がない backend / library / schema-only 変更の場合:
+  - `gstack-qa-only` 相当の report-only 観点で、contract test、negative test、schema compatibility、fixture coverage、CI gate 漏れを確認する。
+  - 必要に応じて `gstack-health` で品質ゲートの抜けを確認する。
+- QA で bug を見つけた場合:
+  1. 最小修正を行う。
+  2. 再現テストまたは回帰テストを追加する。
+  3. `cargo test` / 対象テスト / lint を再実行する。
+  4. `gstack-review` → `gstack-qa` を再実行し、未解決の重大指摘がないことを確認する。
+
+### 4.3 記録
+- PR本文に以下を記録する。
+  - `gstack-review` の結果概要と未解決事項の有無
+  - `gstack-qa` / `gstack-qa-only` の対象、実行観点、結果
+  - 追加で実行した `gstack-browse` / `gstack-benchmark` / `gstack-health` があれば、その結果
+  - 修正した review / QA 指摘と、それを担保するテスト
+
+## 5. ドキュメント更新 (Documentation)
 
 コード以外の成果物を同期します。
 
@@ -62,7 +98,7 @@
 - **SPEC.md 更新**: 実装中に仕様の微修正が必要になった場合、`SPEC.md` に反映する。
 - **README/CHANGELOG**: 必要に応じて更新する。
 
-## 5. PR作成と最終確認 (Finalization)
+## 6. PR作成と最終確認 (Finalization)
 
 全てのチェックが完了したら、変更をプッシュしPRを作成します。
 
@@ -80,9 +116,10 @@
       - 関連Issue/Specへのリンク
       - `docs/PLAN.md` の「Exit Criteria」達成状況
       - 実施したテスト結果のスクリーンショットやログ
+      - `gstack-review` → `gstack-qa` の実行結果と、未解決事項がないこと
 4.  **CI 確認**:
     - GitHub Actions のステータスを監視し、失敗した場合は即座に修正コミットを追加する。
 
 ---
-**Note to AI Agent**: このプロンプトに従ってタスクを実行する際は、**「実装 → テスト → Lint/Format → Commit → Push → PR作成」までの工程を自律的に（ユーザ承認を挟まずに）実行すること**。
+**Note to AI Agent**: このプロンプトに従ってタスクを実行する際は、**「実装 → テスト → Lint/Format → gstack-review → gstack-qa → 必要な修正 → Commit → Push → PR作成」までの工程を自律的に（ユーザ承認を挟まずに）実行すること**。
 PR作成完了後、または解決不能なエラーが発生した場合のみユーザに報告し、レビューを依頼すること。

--- a/docs/REGISTERED_ISSUES.md
+++ b/docs/REGISTERED_ISSUES.md
@@ -1,0 +1,65 @@
+# Registered Issues
+
+This document tracks identified issues and areas for improvement in Dragon Head.
+
+## [ISSUE-01] MCP `get_state` Delta implementation missing
+
+### Description
+The MCP `get_state` tool supports a `delivery: "delta"` argument as per specification, but the current implementation in `mcp-server/src/lib.rs` ignores this argument and always returns the full `ExternalSemanticState`.
+
+### Impact
+- Higher bandwidth usage for incremental updates.
+- Divergence from the specification (SRE-02).
+
+### Task
+- [ ] Update `CoreRuntimeBackend::get_state` to handle `StateDelivery::Delta`.
+- [ ] Implement conversion from `core_runtime::sre::StateUpdate` to MCP-compatible delta payload.
+
+---
+
+## [ISSUE-02] `PolicyEngine` path prefix matching is not segment-aware
+
+### Description
+`PolicyEngine` uses `starts_with` for path prefix matching without ensuring segment boundaries. For example, a rule for `/login` will incorrectly match `/logina`.
+
+### Reproduction
+Validated in `core-runtime/tests/repro_policy_bug.rs`.
+
+### Task
+- [ ] Update `CompiledPolicyRule::matches` in `core-runtime/src/policy.rs` to ensure segment-aware path matching (e.g., using exact match or ensuring next char is `/`).
+
+---
+
+## [ISSUE-03] Hardcoded viewport constants in quadrant calculation
+
+### Description
+`core-runtime/src/sre/normalization.rs` uses hardcoded `DEFAULT_VIEWPORT_WIDTH_PX` (800) and `DEFAULT_VIEWPORT_HEIGHT_PX` (600) for calculating quadrants. This leads to incorrect quadrant assignment when the actual browser viewport differs.
+
+### Impact
+- `stable_key` instability or incorrect differentiation if elements move across the hardcoded 400/300 boundaries but not the actual viewport center.
+
+### Task
+- [ ] Allow passing actual viewport dimensions to `normalize_dom`.
+- [ ] Update `PageSession` to provide current viewport size during semantic state capture.
+
+---
+
+## [ISSUE-04] `mcp-server` comprehensive evaluation test compilation instability
+
+### Description
+Evidence of compilation failure in `mcp-server/tests/comprehensive_evaluation.rs` due to `should_skip` vs `should_skip_browser_tests` mismatch. Although it recently passed, the inconsistency in helper function names across crates indicates a need for refactoring.
+
+### Task
+- [ ] Standardize browser test skip helper names across the workspace.
+- [ ] Move shared test helpers to `test-bench-support` or a dedicated internal crate.
+
+---
+
+## [ISSUE-05] `plugin-host` missing execution entry point
+
+### Description
+`plugin-host` crate provides manifest validation and signature verification but lacks a high-level API to execute the Wasm modules for the defined extension points (`on_state`, `before_act`).
+
+### Task
+- [ ] Implement `PluginRuntime` or similar to handle `wasmtime` instantiation and call exports.
+- [ ] Integrate plugin execution into the `core-runtime` pipeline.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,0 +1,228 @@
+# Verification Report
+
+Date: 2026-03-20
+
+Verified target: latest `origin/main` at commit `ab8dbe7be42925bba0759936bc65f41e163c24ac`
+
+Working branch: `codex/e2e-verification`
+
+Primary references:
+- `README.md`
+- `docs/SPEC.md`
+- `docs/testing.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/e2e.yml`
+
+Environment:
+- Host timezone: `Asia/Tokyo`
+- Workspace: `/Volumes/Storage/src/dragon-head`
+- Browser: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
+
+## Objective
+
+Run a comprehensive verification pass against the latest `main`, covering:
+- workspace quality gates
+- browser-backed integration and end-to-end tests
+- full evaluation bench scenarios across core crates
+- full non-functional regression gates
+
+## Commands Executed
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  cargo test -p core-runtime --test cdp_connectivity -- --nocapture
+
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  cargo test --workspace
+
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  cargo test --workspace --no-run
+
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  CARGO_INCREMENTAL=0 \
+  cargo test --workspace > target/verification-workspace-test.log 2>&1
+
+CARGO_INCREMENTAL=0 \
+  just evaluation-bench-full > target/verification-evaluation-bench.log 2>&1
+
+export CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+export CARGO_INCREMENTAL=0
+export NFR_BENCH_MODE=full
+export NFR_METRICS_DIR="$PWD/core-runtime/target/nfr-metrics"
+export NFR_DASHBOARD_PATH="$PWD/core-runtime/target/nfr-dashboard-full.md"
+export TTFT_LONG_ITERATIONS=400
+export TTFT_WARN_MS=40
+export TTFT_FAIL_MS=50
+export NFR_LATENCY_TRIALS=60
+export NFR_LATENCY_P95_LIMIT_MS=100
+export NFR_LATENCY_P99_LIMIT_MS=130
+export NFR_BANDWIDTH_TRIALS=10
+export NFR_BANDWIDTH_REDUCTION_MIN_PERCENT=95
+export NFR_CAPACITY_TRIALS=4
+export NFR_CAPACITY_MINIMAL_SESSIONS=75
+export NFR_CAPACITY_VISUAL_SESSIONS=20
+export NFR_CAPACITY_MIN_SUCCESS_RATE_PERCENT=100
+
+cargo test -p core-runtime --test async_pipeline \
+  test_async_pipeline_ttft_benchmark_long_gate -- --ignored \
+  >> target/verification-nfr.log 2>&1
+
+cargo test -p core-runtime --test nfr_latency \
+  >> target/verification-nfr.log 2>&1
+
+cargo test -p core-runtime --test nfr_bandwidth \
+  >> target/verification-nfr.log 2>&1
+
+cargo test -p core-runtime --test nfr_capacity \
+  >> target/verification-nfr.log 2>&1
+
+python3 scripts/nfr_dashboard.py \
+  --metrics-dir "$NFR_METRICS_DIR" \
+  --output "$NFR_DASHBOARD_PATH" \
+  >> target/verification-nfr.log 2>&1
+```
+
+## Result Summary
+
+| Area | Result | Notes |
+| --- | --- | --- |
+| Formatting | PASS | `cargo fmt --all -- --check` |
+| Lint | PASS | `cargo clippy --workspace -- -D warnings` |
+| Browser connectivity smoke test | PASS | `core-runtime/tests/cdp_connectivity.rs` |
+| Default workspace test command | FAIL | Incremental compilation fails with `dep-graph.part.bin` errors |
+| Workspace tests with `CARGO_INCREMENTAL=0` | PASS | Full workspace suite completed successfully |
+| Full evaluation bench | PASS | All 16 full scenarios passed across 5 crates |
+| Full NFR gates | FAIL | `nfr_latency` breached thresholds; other full NFR suites passed |
+
+## Functional Coverage
+
+### Workspace/browser-backed suites
+
+The full workspace run completed successfully with `CARGO_INCREMENTAL=0`, including browser-backed and system-level tests such as:
+- `cdp_connectivity`
+- `semantic_wait`
+- `session_management`
+- `audit_logging`
+- `som_event_driven`
+- `spa_stable_key_stress`
+- `som_visual_diff`
+- `policy_enforcement`
+- `policy_engine`
+- `repro_issue`
+- `mcp_hitl_flow`
+- `mcp_client_contract`
+- `mcp_protocol_compliance`
+
+### Full evaluation bench coverage
+
+`just evaluation-bench-full` passed end-to-end scenarios across the major product surfaces:
+
+| Crate | Scenario | Result |
+| --- | --- | --- |
+| `core-runtime` | `semantic_state_capture` | PASS |
+| `core-runtime` | `stable_key_recovery` | PASS |
+| `core-runtime` | `semantic_wait` | PASS |
+| `core-runtime` | `policy_hitl` | PASS |
+| `core-runtime` | `audit_redaction` | PASS |
+| `core-runtime` | `session_vault_roundtrip` | PASS |
+| `mcp-server` | `tool_flow_state_and_act` | PASS |
+| `mcp-server` | `hitl_flow` | PASS |
+| `mcp-server` | `usage_report_plan_gating` | PASS |
+| `plugin-host` | `unsigned_plugin_rejected` | PASS |
+| `plugin-host` | `signed_plugin_capability_enforcement` | PASS |
+| `skills-engine` | `skill_happy_path` | PASS |
+| `skills-engine` | `verify_failure_suppresses_act` | PASS |
+| `skills-engine` | `retry_branch_and_handoff` | PASS |
+| `marketplace` | `domain_pack_signature_verification` | PASS |
+| `marketplace` | `revenue_share_accounting` | PASS |
+
+Interpretation: latest `main` functionally exercises the intended user-facing flows across runtime capture/waiting, HITL policy gates, audit handling, session persistence, MCP server orchestration, plugin trust/capability enforcement, skill orchestration, and marketplace verification/accounting.
+
+## Non-Functional Results
+
+Full benchmark artifacts were generated under `core-runtime/target/nfr-metrics/` and summarized in `core-runtime/target/nfr-dashboard-full.md`.
+
+| NFR suite | Result | Key metrics |
+| --- | --- | --- |
+| `ttft-long` | PASS | `avg=0.067ms`, `p95=0.125ms`, `p99=0.158ms`, `max=0.182ms` |
+| `nfr-bandwidth` | PASS | `reduction_avg_pct=99.165`, `reduction_min_pct=98.961` |
+| `nfr-capacity-minimal` | PASS | `sessions_target=75`, `success_rate_min=1.000`, `capture_p95_ms=113.061` |
+| `nfr-capacity-visual` | PASS | `sessions_target=20`, `success_rate_min=1.000`, `capture_p95_ms=107.037` |
+| `nfr-latency` | FAIL | `avg_ms=112.443`, `p95_ms=124.123`, `p99_ms=220.186`, `max_ms=220.186` |
+
+The blocking NFR failure was:
+
+```text
+NFR latency benchmark mode=full trials=60 avg=112.443ms p95=124.123ms p99=220.186ms max=220.186ms limits(p95<=100ms,p99<=130ms)
+State Update Latency p95 regression: expected <= 100ms, got 124.123ms
+```
+
+## Findings And Registered Issues
+
+### 1. Default workspace verification is unstable with incremental compilation
+
+Issue: [#33](https://github.com/takurot/dragon-head/issues/33) `cargo test --workspace fails with incremental dep-graph.part.bin errors on latest main`
+
+Reproduction:
+
+```bash
+cargo test --workspace
+# or
+cargo test --workspace --no-run
+```
+
+Observed failure pattern:
+
+```text
+failed to create dependency graph at .../target/debug/incremental/.../dep-graph.part.bin: No such file or directory (os error 2)
+```
+
+Impact:
+- breaks the default local verification path on latest `main`
+- affects multiple crates during a single run
+- requires `CARGO_INCREMENTAL=0` as a workaround
+
+Workaround validated during this verification:
+
+```bash
+CARGO_INCREMENTAL=0 cargo test --workspace
+```
+
+### 2. Full latency gate regressed beyond configured limits
+
+Issue: [#32](https://github.com/takurot/dragon-head/issues/32) `Full nfr_latency benchmark fails p95/p99 thresholds on latest main`
+
+Observed metrics:
+- `p95_ms = 124.123` against `p95_ms_max = 100.0`
+- `p99_ms = 220.186` against `p99_ms_max = 130.0`
+
+Impact:
+- full NFR verification is not green on latest `main`
+- performance regression appears isolated to state update latency; other full NFR suites passed
+
+## Overall Verdict
+
+Functional E2E coverage on latest `main` is broadly healthy:
+- full evaluation bench passed
+- full workspace tests passed with incremental compilation disabled
+- browser-backed flows, policy gates, MCP flows, plugin enforcement, skills flows, and marketplace scenarios were all exercised successfully
+
+Latest `main` is not fully verification-clean because two issues remain:
+- the default workspace Rust test flow is unstable under incremental compilation
+- full latency NFR thresholds are currently not met
+
+## Artifacts
+
+- `target/verification-workspace-test.log`
+- `target/verification-evaluation-bench.log`
+- `target/evaluation-dashboard.md`
+- `target/verification-nfr.log`
+- `core-runtime/target/nfr-dashboard-full.md`
+- `core-runtime/target/nfr-metrics/ttft-long.json`
+- `core-runtime/target/nfr-metrics/nfr-latency.json`
+- `core-runtime/target/nfr-metrics/nfr-bandwidth.json`
+- `core-runtime/target/nfr-metrics/nfr-capacity-minimal.json`
+- `core-runtime/target/nfr-metrics/nfr-capacity-visual.json`

--- a/skills-engine/tests/fixtures/gstack/hackernews-frontpage/SKILL.md
+++ b/skills-engine/tests/fixtures/gstack/hackernews-frontpage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: hackernews-frontpage
+description: Scrape the Hacker News front page (titles, points, comment counts).
+host: news.ycombinator.com
+trusted: true
+source: human
+version: 1.0.0
+args: []
+triggers:
+  - scrape hacker news frontpage
+  - scrape hn frontpage
+  - get hn top stories
+  - latest hacker news stories
+---
+
+# Hacker News front-page scraper
+
+Scrapes the Hacker News (`news.ycombinator.com`) front page and returns the
+top 30 stories as JSON. Each story has its rank, title, link URL, point count,
+and comment count.
+
+## Usage
+
+```
+$ $B skill run hackernews-frontpage
+{
+  "stories": [
+    { "rank": 1, "title": "...", "url": "...", "points": 412, "comments": 87 },
+    ...
+  ],
+  "count": 30
+}
+```
+
+## How it works
+
+1. Navigates to `https://news.ycombinator.com` via the daemon.
+2. Reads the page HTML.
+3. Parses each story row (HN's stable `tr.athing` structure) into a typed
+   `Story` record.
+4. Emits a single JSON document on stdout.
+
+## Why this is the reference skill
+
+`hackernews-frontpage` is the smallest interesting browser-skill: no auth,
+stable HTML, deterministic output, file-fixture-friendly. Every Phase 1
+component (SDK, scoped tokens, three-tier lookup, spawn lifecycle) is
+exercised by `$B skill run hackernews-frontpage` and the bundled
+`script.test.ts`.
+
+When the HN HTML rotates and our selectors break, the test fails against the
+captured fixture before users notice. That's the point.

--- a/skills-engine/tests/fixtures/gstack/hackernews-frontpage/_lib/browse-client.ts
+++ b/skills-engine/tests/fixtures/gstack/hackernews-frontpage/_lib/browse-client.ts
@@ -1,0 +1,257 @@
+/**
+ * browse-client — canonical SDK that browser-skill scripts import to drive the
+ * gstack daemon over loopback HTTP.
+ *
+ * Distribution model:
+ *   This file is the canonical source. Each browser-skill ships a sibling
+ *   copy at `<skill>/_lib/browse-client.ts` (Phase 2's generator copies it
+ *   alongside every generated skill; Phase 1's bundled `hackernews-frontpage`
+ *   reference skill ships a hand-copied version). The skill imports the
+ *   sibling via relative path: `import { browse } from './_lib/browse-client'`.
+ *
+ *   Why per-skill copies and not a single global SDK: each skill is fully
+ *   portable (copy the directory anywhere, it runs), version drift is
+ *   impossible (the SDK is frozen at the version the skill was authored
+ *   against), no npm publish workflow, no fixed-path tilde imports.
+ *
+ * Auth resolution:
+ *   1. GSTACK_PORT + GSTACK_SKILL_TOKEN env vars (set by `$B skill run` when
+ *      spawning the script). The token is a per-spawn scoped capability bound
+ *      to read+write commands; it expires when the spawn ends.
+ *   2. State file fallback: read `BROWSE_STATE_FILE` env or `<git-root>/.gstack/browse.json`
+ *      and use the `port` + `token` (the daemon root token). This path exists
+ *      for developers running a skill directly via `bun run script.ts` outside
+ *      the harness — your own authority, not an agent's.
+ *
+ * Trust:
+ *   The SDK exposes only the daemon's existing HTTP surface (POST /command).
+ *   No new capabilities. The token's scopes (read+write for spawned skills,
+ *   full root for standalone debug) determine what actually executes.
+ *
+ * Zero side effects on import. Safe to import from tests or plain scripts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as cp from 'child_process';
+
+export interface BrowseClientOptions {
+  /** Override port. Default: GSTACK_PORT env or state file. */
+  port?: number;
+  /** Override token. Default: GSTACK_SKILL_TOKEN env, then state file root token. */
+  token?: string;
+  /** Tab id to target (every command can scope to a tab). Default: BROWSE_TAB env or undefined (active tab). */
+  tabId?: number;
+  /** Per-request timeout in milliseconds. Default: 30_000. */
+  timeoutMs?: number;
+  /** Override state-file path. Default: BROWSE_STATE_FILE env or <git-root>/.gstack/browse.json. */
+  stateFile?: string;
+}
+
+interface ResolvedAuth {
+  port: number;
+  token: string;
+  source: 'env' | 'state-file';
+}
+
+/** Resolve the daemon port + token. Throws a clear error if neither path works. */
+export function resolveBrowseAuth(opts: BrowseClientOptions = {}): ResolvedAuth {
+  if (opts.port !== undefined && opts.token !== undefined) {
+    return { port: opts.port, token: opts.token, source: 'env' };
+  }
+
+  // 1. Env vars (set by $B skill run when spawning).
+  const envPort = process.env.GSTACK_PORT;
+  const envToken = process.env.GSTACK_SKILL_TOKEN;
+  if (envPort && envToken) {
+    const port = opts.port ?? parseInt(envPort, 10);
+    if (!isNaN(port)) {
+      return { port, token: opts.token ?? envToken, source: 'env' };
+    }
+  }
+
+  // 2. State file fallback (developer running `bun run script.ts` directly).
+  const stateFile = opts.stateFile ?? process.env.BROWSE_STATE_FILE ?? defaultStateFile();
+  if (stateFile && fs.existsSync(stateFile)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      if (typeof data.port === 'number' && typeof data.token === 'string') {
+        return {
+          port: opts.port ?? data.port,
+          token: opts.token ?? data.token,
+          source: 'state-file',
+        };
+      }
+    } catch {
+      // fall through to error
+    }
+  }
+
+  throw new Error(
+    'browse-client: cannot find daemon port + token. Either spawn via `$B skill run` ' +
+    '(sets GSTACK_PORT + GSTACK_SKILL_TOKEN) or run from a project with a live daemon ' +
+    '(.gstack/browse.json must exist).'
+  );
+}
+
+function defaultStateFile(): string | null {
+  try {
+    const proc = cp.spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8', timeout: 2000 });
+    const root = proc.status === 0 ? proc.stdout.trim() : null;
+    const base = root || process.cwd();
+    return path.join(base, '.gstack', 'browse.json');
+  } catch {
+    return path.join(process.cwd(), '.gstack', 'browse.json');
+  }
+}
+
+export class BrowseClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = 'BrowseClientError';
+  }
+}
+
+/**
+ * Thin client over the daemon's POST /command endpoint.
+ *
+ * Convenience methods cover the common cases (goto, click, text, snapshot,
+ * etc.). For anything not exposed as a method, use `command(cmd, args)`.
+ */
+export class BrowseClient {
+  readonly port: number;
+  readonly token: string;
+  readonly tabId?: number;
+  readonly timeoutMs: number;
+
+  constructor(opts: BrowseClientOptions = {}) {
+    const auth = resolveBrowseAuth(opts);
+    this.port = auth.port;
+    this.token = auth.token;
+    this.tabId = opts.tabId ?? (process.env.BROWSE_TAB ? parseInt(process.env.BROWSE_TAB, 10) : undefined);
+    this.timeoutMs = opts.timeoutMs ?? 30_000;
+  }
+
+  // ─── Low-level dispatch ─────────────────────────────────────────
+
+  /** Send an arbitrary command; returns raw response text. Throws on non-2xx. */
+  async command(cmd: string, args: string[] = []): Promise<string> {
+    const body = JSON.stringify({
+      command: cmd,
+      args,
+      ...(this.tabId !== undefined && !isNaN(this.tabId) ? { tabId: this.tabId } : {}),
+    });
+
+    let resp: Response;
+    try {
+      resp = await fetch(`http://127.0.0.1:${this.port}/command`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.token}`,
+        },
+        body,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err: any) {
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        throw new BrowseClientError(`browse-client: command "${cmd}" timed out after ${this.timeoutMs}ms`);
+      }
+      if (err.code === 'ECONNREFUSED') {
+        throw new BrowseClientError(`browse-client: daemon not running on port ${this.port}`);
+      }
+      throw new BrowseClientError(`browse-client: ${err.message ?? err}`);
+    }
+
+    const text = await resp.text();
+    if (!resp.ok) {
+      let message = `browse-client: command "${cmd}" failed with status ${resp.status}`;
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed.error) message += `: ${parsed.error}`;
+      } catch {
+        if (text) message += `: ${text.slice(0, 200)}`;
+      }
+      throw new BrowseClientError(message, resp.status, text);
+    }
+    return text;
+  }
+
+  // ─── Navigation ─────────────────────────────────────────────────
+
+  async goto(url: string): Promise<string> { return this.command('goto', [url]); }
+  async wait(arg: string): Promise<string> { return this.command('wait', [arg]); }
+
+  // ─── Reading ────────────────────────────────────────────────────
+
+  async text(selector?: string): Promise<string> {
+    return this.command('text', selector ? [selector] : []);
+  }
+  async html(selector?: string): Promise<string> {
+    return this.command('html', selector ? [selector] : []);
+  }
+  async links(): Promise<string> { return this.command('links'); }
+  async forms(): Promise<string> { return this.command('forms'); }
+  async accessibility(): Promise<string> { return this.command('accessibility'); }
+  async attrs(selector: string): Promise<string> { return this.command('attrs', [selector]); }
+  async media(...flags: string[]): Promise<string> { return this.command('media', flags); }
+  async data(...flags: string[]): Promise<string> { return this.command('data', flags); }
+
+  // ─── Interaction ────────────────────────────────────────────────
+
+  async click(selector: string): Promise<string> { return this.command('click', [selector]); }
+  async fill(selector: string, value: string): Promise<string> { return this.command('fill', [selector, value]); }
+  async select(selector: string, value: string): Promise<string> { return this.command('select', [selector, value]); }
+  async hover(selector: string): Promise<string> { return this.command('hover', [selector]); }
+  async type(text: string): Promise<string> { return this.command('type', [text]); }
+  async press(key: string): Promise<string> { return this.command('press', [key]); }
+  async scroll(selector?: string): Promise<string> {
+    return this.command('scroll', selector ? [selector] : []);
+  }
+
+  // ─── Snapshot + screenshot ──────────────────────────────────────
+
+  /** Snapshot returns the ARIA tree. Pass flags like '-i' (interactive only), '-c' (compact). */
+  async snapshot(...flags: string[]): Promise<string> { return this.command('snapshot', flags); }
+  async screenshot(...args: string[]): Promise<string> { return this.command('screenshot', args); }
+}
+
+/**
+ * Default singleton. Lazily resolves auth on first method call so a script can
+ * import `browse` and immediately call `await browse.goto(...)` without
+ * threading through a constructor.
+ */
+class LazyBrowseClient {
+  private inner: BrowseClient | null = null;
+  private get(): BrowseClient {
+    if (!this.inner) this.inner = new BrowseClient();
+    return this.inner;
+  }
+  // Mirror the BrowseClient surface; each method delegates to a freshly resolved instance.
+  command(cmd: string, args: string[] = []) { return this.get().command(cmd, args); }
+  goto(url: string) { return this.get().goto(url); }
+  wait(arg: string) { return this.get().wait(arg); }
+  text(selector?: string) { return this.get().text(selector); }
+  html(selector?: string) { return this.get().html(selector); }
+  links() { return this.get().links(); }
+  forms() { return this.get().forms(); }
+  accessibility() { return this.get().accessibility(); }
+  attrs(selector: string) { return this.get().attrs(selector); }
+  media(...flags: string[]) { return this.get().media(...flags); }
+  data(...flags: string[]) { return this.get().data(...flags); }
+  click(selector: string) { return this.get().click(selector); }
+  fill(selector: string, value: string) { return this.get().fill(selector, value); }
+  select(selector: string, value: string) { return this.get().select(selector, value); }
+  hover(selector: string) { return this.get().hover(selector); }
+  type(text: string) { return this.get().type(text); }
+  press(key: string) { return this.get().press(key); }
+  scroll(selector?: string) { return this.get().scroll(selector); }
+  snapshot(...flags: string[]) { return this.get().snapshot(...flags); }
+  screenshot(...args: string[]) { return this.get().screenshot(...args); }
+}
+
+export const browse = new LazyBrowseClient();

--- a/skills-engine/tests/fixtures/gstack/hackernews-frontpage/fixtures/hn-2026-04-26.html
+++ b/skills-engine/tests/fixtures/gstack/hackernews-frontpage/fixtures/hn-2026-04-26.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><html lang="en" op="news"><head><meta charset="utf-8"><title>Hacker News</title></head>
+<body><center><table id="hnmain" border="0" cellpadding="0" cellspacing="0" width="85%" bgcolor="#f6f6ef">
+<tr><td>
+<table border="0" cellpadding="0" cellspacing="0" class="itemlist">
+<tr class="athing submission" id="40000001">
+  <td align="right" valign="top" class="title"><span class="rank">1.</span></td>
+  <td valign="top" class="votelinks"><center><a id="up_40000001" href="vote?id=40000001"><div class="votearrow" title="upvote"></div></a></center></td>
+  <td class="title"><span class="titleline"><a href="https://example.com/blog-post-1" rel="noreferrer">Show HN: A toy compiler in 200 lines</a> <span class="sitebit comhead"> (<a href="from?site=example.com"><span class="sitestr">example.com</span></a>)</span></span></td>
+</tr>
+<tr><td colspan="2"></td><td class="subtext"><span class="subline">
+  <span class="score" id="score_40000001">412 points</span> by <a href="user?id=alice" class="hnuser">alice</a> <span class="age" title="2026-04-26T08:15:00"><a href="item?id=40000001">3 hours ago</a></span> <span id="unv_40000001"></span> | <a href="hide?id=40000001&amp;goto=news">hide</a> | <a href="item?id=40000001">87&nbsp;comments</a>          </span></td></tr>
+<tr class="spacer" style="height:5px"></tr>
+
+<tr class="athing submission" id="40000002">
+  <td align="right" valign="top" class="title"><span class="rank">2.</span></td>
+  <td valign="top" class="votelinks"><center><a id="up_40000002" href="vote?id=40000002"><div class="votearrow" title="upvote"></div></a></center></td>
+  <td class="title"><span class="titleline"><a href="https://example.org/database-internals" rel="noreferrer">Database internals: writing an LSM tree</a> <span class="sitebit comhead"> (<a href="from?site=example.org"><span class="sitestr">example.org</span></a>)</span></span></td>
+</tr>
+<tr><td colspan="2"></td><td class="subtext"><span class="subline">
+  <span class="score" id="score_40000002">298 points</span> by <a href="user?id=bob" class="hnuser">bob</a> <span class="age" title="2026-04-26T07:42:00"><a href="item?id=40000002">4 hours ago</a></span> <span id="unv_40000002"></span> | <a href="hide?id=40000002&amp;goto=news">hide</a> | <a href="item?id=40000002">152&nbsp;comments</a>          </span></td></tr>
+<tr class="spacer" style="height:5px"></tr>
+
+<tr class="athing submission" id="40000003">
+  <td align="right" valign="top" class="title"><span class="rank">3.</span></td>
+  <td valign="top" class="votelinks"><center><a id="up_40000003" href="vote?id=40000003"><div class="votearrow" title="upvote"></div></a></center></td>
+  <td class="title"><span class="titleline"><a href="https://example.com/yc-w26-startup">Acme (YC W26) is hiring senior engineers (remote)</a> <span class="sitebit comhead"> (<a href="from?site=example.com"><span class="sitestr">example.com</span></a>)</span></span></td>
+</tr>
+<tr><td colspan="2"></td><td class="subtext"><span class="subline">
+  <span class="age" title="2026-04-26T06:00:00"><a href="item?id=40000003">5 hours ago</a></span>          </span></td></tr>
+<tr class="spacer" style="height:5px"></tr>
+
+<tr class="athing submission" id="40000004">
+  <td align="right" valign="top" class="title"><span class="rank">4.</span></td>
+  <td valign="top" class="votelinks"><center><a id="up_40000004" href="vote?id=40000004"><div class="votearrow" title="upvote"></div></a></center></td>
+  <td class="title"><span class="titleline"><a href="https://example.net/ask-hn" rel="noreferrer">Ask HN: What&#x27;s your most underrated tool?</a></span></td>
+</tr>
+<tr><td colspan="2"></td><td class="subtext"><span class="subline">
+  <span class="score" id="score_40000004">156 points</span> by <a href="user?id=carol" class="hnuser">carol</a> <span class="age" title="2026-04-26T05:30:00"><a href="item?id=40000004">6 hours ago</a></span> <span id="unv_40000004"></span> | <a href="hide?id=40000004&amp;goto=news">hide</a> | <a href="item?id=40000004">discuss</a>          </span></td></tr>
+<tr class="spacer" style="height:5px"></tr>
+
+<tr class="athing submission" id="40000005">
+  <td align="right" valign="top" class="title"><span class="rank">5.</span></td>
+  <td valign="top" class="votelinks"><center><a id="up_40000005" href="vote?id=40000005"><div class="votearrow" title="upvote"></div></a></center></td>
+  <td class="title"><span class="titleline"><a href="https://example.io/quantum&amp;chess">Why quantum &amp; chess engines disagree</a> <span class="sitebit comhead"> (<a href="from?site=example.io"><span class="sitestr">example.io</span></a>)</span></span></td>
+</tr>
+<tr><td colspan="2"></td><td class="subtext"><span class="subline">
+  <span class="score" id="score_40000005">73 points</span> by <a href="user?id=dave" class="hnuser">dave</a> <span class="age" title="2026-04-26T04:00:00"><a href="item?id=40000005">7 hours ago</a></span> <span id="unv_40000005"></span> | <a href="hide?id=40000005&amp;goto=news">hide</a> | <a href="item?id=40000005">12&nbsp;comments</a>          </span></td></tr>
+<tr class="spacer" style="height:5px"></tr>
+
+</table>
+</td></tr>
+</table></center></body></html>

--- a/skills-engine/tests/fixtures/gstack/hackernews-frontpage/script.test.ts
+++ b/skills-engine/tests/fixtures/gstack/hackernews-frontpage/script.test.ts
@@ -1,0 +1,105 @@
+/**
+ * hackernews-frontpage script tests — exercise parseStoriesFromHtml against
+ * the bundled HN fixture. No daemon, no network: the parser is a pure function
+ * over HTML, so we test it directly.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseStoriesFromHtml } from './script';
+
+const FIXTURE = fs.readFileSync(
+  path.join(__dirname, 'fixtures', 'hn-2026-04-26.html'),
+  'utf-8',
+);
+
+describe('parseStoriesFromHtml against bundled HN fixture', () => {
+  it('returns 5 stories (matching the fixture)', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories).toHaveLength(5);
+  });
+
+  it('assigns 1-based ranks in document order', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories.map(s => s.rank)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('extracts ids matching the tr.athing[id] attribute', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories.map(s => s.id)).toEqual([
+      '40000001', '40000002', '40000003', '40000004', '40000005',
+    ]);
+  });
+
+  it('extracts titles and decodes HTML entities', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories[0].title).toBe('Show HN: A toy compiler in 200 lines');
+    expect(stories[1].title).toBe('Database internals: writing an LSM tree');
+    expect(stories[3].title).toBe("Ask HN: What's your most underrated tool?");
+    expect(stories[4].title).toBe('Why quantum & chess engines disagree');
+  });
+
+  it('extracts URLs and decodes ampersands', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories[0].url).toBe('https://example.com/blog-post-1');
+    expect(stories[1].url).toBe('https://example.org/database-internals');
+    expect(stories[4].url).toBe('https://example.io/quantum&chess');
+  });
+
+  it('parses point counts as numbers', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories[0].points).toBe(412);
+    expect(stories[1].points).toBe(298);
+    expect(stories[3].points).toBe(156);
+    expect(stories[4].points).toBe(73);
+  });
+
+  it('parses comment counts as numbers', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories[0].comments).toBe(87);
+    expect(stories[1].comments).toBe(152);
+    expect(stories[4].comments).toBe(12);
+  });
+
+  it('treats "discuss" links as 0 comments', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    expect(stories[3].comments).toBe(0);
+  });
+
+  it('returns null points + null comments for job postings', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    // Story #3 is the YC-hiring row in the fixture.
+    expect(stories[2].title).toContain('YC W26');
+    expect(stories[2].points).toBeNull();
+    expect(stories[2].comments).toBeNull();
+  });
+
+  it('returns [] for empty HTML', () => {
+    expect(parseStoriesFromHtml('')).toEqual([]);
+  });
+
+  it('returns [] for HTML with no story rows', () => {
+    expect(parseStoriesFromHtml('<html><body><p>nothing here</p></body></html>')).toEqual([]);
+  });
+
+  it('does not fabricate stories from arbitrary tr.athing rows missing titleline', () => {
+    const html = '<tr class="athing" id="999"><td>nothing</td></tr>';
+    expect(parseStoriesFromHtml(html)).toEqual([]);
+  });
+});
+
+describe('output shape', () => {
+  it('every story has all required keys', () => {
+    const stories = parseStoriesFromHtml(FIXTURE);
+    for (const s of stories) {
+      expect(typeof s.rank).toBe('number');
+      expect(typeof s.id).toBe('string');
+      expect(typeof s.title).toBe('string');
+      expect(typeof s.url).toBe('string');
+      // points/comments may be null for job rows
+      expect(s.points === null || typeof s.points === 'number').toBe(true);
+      expect(s.comments === null || typeof s.comments === 'number').toBe(true);
+    }
+  });
+});

--- a/skills-engine/tests/fixtures/gstack/hackernews-frontpage/script.ts
+++ b/skills-engine/tests/fixtures/gstack/hackernews-frontpage/script.ts
@@ -1,0 +1,132 @@
+/**
+ * hackernews-frontpage — scrape the HN front page and emit JSON.
+ *
+ * Output protocol:
+ *   stdout = a single JSON document on success: { stories: Story[], count }
+ *   stderr = anything we want logged (currently nothing)
+ *   exit 0 on success, nonzero on parse / network failure.
+ *
+ * The parser logic (`parseStoriesFromHtml`) is exported so script.test.ts can
+ * exercise it against bundled HTML fixtures without spinning up the daemon.
+ */
+
+import { browse } from './_lib/browse-client';
+
+export interface Story {
+  /** 1-based rank as displayed on HN. */
+  rank: number;
+  /** HN item id (the integer in `tr.athing[id]`). */
+  id: string;
+  title: string;
+  /** Outbound URL the title links to. */
+  url: string;
+  /** null when the row has no score (job postings). */
+  points: number | null;
+  /** null when the row has no comments link (job postings). */
+  comments: number | null;
+}
+
+export interface Output {
+  stories: Story[];
+  count: number;
+}
+
+const FRONT_PAGE_URL = 'https://news.ycombinator.com/';
+
+/**
+ * Parse HN front-page HTML into Story[].
+ *
+ * HN's structure is stable: each story is a pair of rows.
+ *   <tr class="athing submission" id="<itemid>">
+ *     <td class="rank">N.</td>
+ *     <td class="title">...</td>
+ *     <td class="title"><span class="titleline"><a href="<url>">title</a> ...</span></td>
+ *   </tr>
+ *   <tr><td colspan="2"></td><td class="subtext"><span class="subline">
+ *     <span class="score" id="score_<itemid>">N points</span>
+ *     ... <a href="item?id=<itemid>">N comments</a>
+ *   </span></td></tr>
+ *
+ * Job postings ("Foo (YC X25) is hiring...") omit the score and comments —
+ * those fields come back as null.
+ */
+export function parseStoriesFromHtml(html: string): Story[] {
+  const stories: Story[] = [];
+
+  // Match each `tr.athing` row, capturing the id attribute and the row body.
+  const rowRegex = /<tr\s+[^>]*\bclass="athing[^"]*"[^>]*\bid="(\d+)"[^>]*>([\s\S]*?)<\/tr>/g;
+
+  let match: RegExpExecArray | null;
+  let rank = 0;
+  while ((match = rowRegex.exec(html)) !== null) {
+    rank++;
+    const id = match[1];
+    const rowBody = match[2];
+
+    // Title link: <span class="titleline"><a href="..." ...>title</a>
+    const titleMatch = rowBody.match(/<span\s+class="titleline"[^>]*>\s*<a\s+href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/);
+    if (!titleMatch) continue;
+    const url = decodeHtmlEntities(titleMatch[1]);
+    const title = stripTags(decodeHtmlEntities(titleMatch[2])).trim();
+
+    // The next sibling tr should hold the subtext row. Bound the lookahead
+    // to before the next story (tr.spacer marks the gap, then tr.athing).
+    // Bug if we don't bound: the score from story N+1 leaks into story N
+    // when story N is a job posting (no score of its own).
+    const subtextStart = match.index + match[0].length;
+    const tail = html.slice(subtextStart);
+    const spacerIdx = tail.search(/<tr\b[^>]*\bclass="spacer\b/);
+    const nextAthingIdx = tail.search(/<tr\b[^>]*\bclass="athing\b/);
+    const candidates = [spacerIdx, nextAthingIdx].filter(i => i >= 0);
+    const boundary = candidates.length > 0 ? Math.min(...candidates) : tail.length;
+    const subtextSlice = tail.slice(0, boundary);
+
+    let points: number | null = null;
+    let comments: number | null = null;
+
+    const scoreMatch = subtextSlice.match(/<span\s+class="score"[^>]*>(\d+)\s*points?<\/span>/);
+    if (scoreMatch) points = parseInt(scoreMatch[1], 10);
+
+    // Comment count: an anchor like `<a href="item?id=...">N comments</a>`,
+    // or `discuss` (treated as 0). Skip "hide" / "context" / "from" links.
+    const commentsMatch = subtextSlice.match(/<a\s+href="item\?id=\d+"[^>]*>(\d+)\s*(?:&nbsp;)?\s*comments?<\/a>/);
+    if (commentsMatch) {
+      comments = parseInt(commentsMatch[1], 10);
+    } else if (/discuss<\/a>/.test(subtextSlice)) {
+      comments = 0;
+    }
+
+    stories.push({ rank, id, title, url, points, comments });
+  }
+
+  return stories;
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]*>/g, '');
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ');
+}
+
+// ─── Main entry (only when run as a script, not when imported by tests) ─
+
+if (import.meta.main) {
+  await main();
+}
+
+async function main(): Promise<void> {
+  await browse.goto(FRONT_PAGE_URL);
+  const html = await browse.html();
+  const stories = parseStoriesFromHtml(html);
+  const output: Output = { stories, count: stories.length };
+  process.stdout.write(JSON.stringify(output) + '\n');
+}


### PR DESCRIPTION
## Summary

- add `docs/IMPROVE.md` for gstack-driven improvement discovery
- add `docs/REGISTERED_ISSUES.md` and `docs/VERIFICATION.md` as planning/verification records
- update `docs/PROMPT.md` so implementation now requires `gstack-review` -> `gstack-qa` before commit/push/PR
- add a `hackernews-frontpage` gstack skill fixture with parser tests for skills-engine coverage

## Validation

- `bun test skills-engine/tests/fixtures/gstack/hackernews-frontpage/script.test.ts`
- `cargo test -p skills-engine`

## Notes

- `.agents/` was intentionally not included because it contains local gstack symlinks and vendored local tool state, not portable project source.
