### PR TITLE
[PR] feat(plugin-host): add PluginRuntime execution API (fixes #46)

### DIFF
--- a/docs/REGISTERED_ISSUES.md
+++ b/docs/REGISTERED_ISSUES.md
@@ -63,3 +63,62 @@ Evidence of compilation failure in `mcp-server/tests/comprehensive_evaluation.rs
 ### Task
 - [ ] Implement `PluginRuntime` or similar to handle `wasmtime` instantiation and call exports.
 - [ ] Integrate plugin execution into the `core-runtime` pipeline.
+
+---
+
+## [ISSUE-06] `McpServer` usage metering gaps
+
+### Description
+The `McpServer` only records usage for `get_state`, `get_visual`, and `act`. Calls to `ask_human` and the internal operations performed during `run_skill` (e.g., `act` or `get_visual` calls within a skill workflow) are not being metered.
+
+### Impact
+- Inaccurate billing and usage reporting.
+- Under-counting of value-based events (Section 7.1).
+
+### Task
+- [ ] Update `McpServer::record_usage` to handle `ask_human` tool calls.
+- [ ] Implement a mechanism for `PageSkillRuntime` to report metered operations back to `McpServer` during `run_skill` execution.
+
+---
+
+## [ISSUE-07] `SkillsEngine` integration NO-OPs and limitations
+
+### Description
+The `PageSkillRuntime` (the bridge between Skills Engine and Core Runtime) has placeholder or limited implementations for several steps. `locate` is a NO-OP (always returns `Success`), and `wait` only supports `intent:` prefixed conditions.
+
+### Impact
+- Skills relying on element location verification or complex wait conditions (e.g., waiting for an element to be enabled without a specific intent marker) may succeed prematurely or fail to detect errors.
+
+### Task
+- [ ] Implement `PageSkillRuntime::locate` to verify element existence in the current DOM/SRE.
+- [ ] Expand `PageSkillRuntime::wait` to support semantic state wait (e.g., `id:123:enabled`) by calling `page.wait_for_semantic`.
+
+---
+
+## [ISSUE-08] Inconsistent PII masking between SRE and Audit Logs
+
+### Description
+`core-runtime/src/sre/normalization.rs` only masks credit card numbers in text nodes, whereas `core-runtime/src/audit.rs` masks both credit cards and email addresses.
+
+### Impact
+- Potential PII leakage in the `SemanticState` JSON if email addresses are present in text nodes.
+- Inconsistency in security posture across different system layers.
+
+### Task
+- [ ] Standardize PII masking regexes and logic into a shared utility within `core-runtime`.
+- [ ] Apply consistent masking to both SRE text extraction and Audit Log sanitization.
+
+---
+
+## [ISSUE-09] `AuditLogger` lacks persistent storage implementation
+
+### Description
+The current `AuditLogger` in `core-runtime/src/audit.rs` only maintains an in-memory buffer (512 recent events) and optionally prints to stdout. There is no implementation for persistent file storage or SIEM integration.
+
+### Impact
+- Loss of audit trail on process restart or buffer overflow.
+- Failure to meet enterprise compliance requirements for long-term audit retention.
+
+### Task
+- [ ] Implement a persistent sink for `AuditLogger` (e.g., rolling file logs).
+- [ ] Ensure that `audit_retention_snapshot` in `McpServer` can reflect persistent storage metrics.

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use thiserror::Error;
-use wasmtime::{Engine, Module};
+use wasmtime::{Engine, Instance, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -100,6 +100,14 @@ pub enum PluginError {
     CapabilityViolation { required: Capability },
     #[error("failed to serialize signature payload: {message}")]
     SignaturePayloadSerialization { message: String },
+    #[error("wasm execution failed: {message}")]
+    ExecutionFailed { message: String },
+    #[error("invalid wasm output: {message}")]
+    InvalidOutput { message: String },
+    #[error("wasm execution timed out (fuel exhausted)")]
+    Timeout,
+    #[error("wasm memory limit exceeded")]
+    MemoryExhausted,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -269,6 +277,209 @@ impl LoadedPlugin {
         }
 
         Err(PluginError::CapabilityViolation { required })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PluginRuntime — executes extension points in a sandboxed Wasm instance
+// ---------------------------------------------------------------------------
+
+/// Maximum fuel units granted per call.  Each Wasm instruction costs 1 unit.
+const FUEL_PER_CALL: u64 = 1_000_000_000;
+
+/// Maximum Wasm memory in bytes (64 MiB).
+const MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
+
+/// Input JSON is written at offset 0.  Maximum input size: 16 KiB.
+const MAX_INPUT_SIZE: usize = 16 * 1024;
+/// Output buffer starts right after the max input area.
+const OUTPUT_OFFSET: i32 = MAX_INPUT_SIZE as i32;
+/// Maximum output buffer size: 16 KiB.
+const MAX_OUTPUT_SIZE: usize = 16 * 1024;
+/// The 4-byte little-endian output length is stored right after the output buffer.
+const OUTPUT_LEN_OFFSET: i32 = OUTPUT_OFFSET + MAX_OUTPUT_SIZE as i32;
+
+struct PluginState {
+    limits: StoreLimits,
+}
+
+/// `PluginRuntime` wraps a verified [`LoadedPlugin`] with a live Wasm instance
+/// and exposes execution of the declared extension points.
+pub struct PluginRuntime {
+    store: Store<PluginState>,
+    instance: Instance,
+    manifest: PluginManifest,
+}
+
+impl PluginRuntime {
+    /// Create a `PluginRuntime` from a verified [`LoadedPlugin`] and the raw Wasm bytes.
+    ///
+    /// Returns [`PluginError::WasmValidation`] if the bytes cannot be compiled, or
+    /// [`PluginError::ExecutionFailed`] if instantiation fails.
+    pub fn new(plugin: &LoadedPlugin, wasm_bytes: &[u8]) -> Result<Self, PluginError> {
+        let mut config = wasmtime::Config::new();
+        config.consume_fuel(true);
+
+        let engine = Engine::new(&config).map_err(|err| PluginError::WasmValidation {
+            message: err.to_string(),
+        })?;
+
+        let module =
+            Module::new(&engine, wasm_bytes).map_err(|err| PluginError::WasmValidation {
+                message: err.to_string(),
+            })?;
+
+        let limits = StoreLimitsBuilder::new()
+            .memory_size(MAX_MEMORY_BYTES)
+            .build();
+
+        let mut store = Store::new(&engine, PluginState { limits });
+        store.limiter(|state| &mut state.limits);
+        store
+            .set_fuel(FUEL_PER_CALL)
+            .map_err(|err| PluginError::ExecutionFailed {
+                message: err.to_string(),
+            })?;
+
+        let linker: Linker<PluginState> = Linker::new(&engine);
+        let instance = linker.instantiate(&mut store, &module).map_err(|err| {
+            PluginError::ExecutionFailed {
+                message: err.to_string(),
+            }
+        })?;
+
+        Ok(Self {
+            store,
+            instance,
+            manifest: plugin.manifest().clone(),
+        })
+    }
+
+    /// Execute the `on_state` extension point with the given JSON state.
+    ///
+    /// Fails closed: returns [`PluginError::CapabilityViolation`] if the plugin
+    /// does not declare the [`Capability::ReadState`] capability.
+    pub fn on_state(&mut self, state_json: &str) -> Result<String, PluginError> {
+        self.check_capability_for_extension(ExtensionPoint::OnState)?;
+        self.call_json_fn("on_state", state_json)
+    }
+
+    /// Execute the `before_act` extension point with the given intent JSON.
+    ///
+    /// Returns a policy-decision JSON string such as `{"allow":true}`.
+    pub fn before_act(&mut self, intent_json: &str) -> Result<String, PluginError> {
+        self.call_json_fn("before_act", intent_json)
+    }
+
+    // ------------------------------------------------------------------
+    // Private helpers
+    // ------------------------------------------------------------------
+
+    fn check_capability_for_extension(&self, extension: ExtensionPoint) -> Result<(), PluginError> {
+        if let Some(required) = extension.required_capability()
+            && !self.manifest.capabilities.contains(&required)
+        {
+            return Err(PluginError::CapabilityViolation { required });
+        }
+        Ok(())
+    }
+
+    /// Write `input` into Wasm memory at offset 0, call `fn_name(0, len, out_ptr, len_ptr)`,
+    /// read the output, and validate it as UTF-8 JSON.
+    fn call_json_fn(&mut self, fn_name: &str, input: &str) -> Result<String, PluginError> {
+        let input_bytes = input.as_bytes();
+        let input_len = input_bytes.len() as i32;
+
+        // Replenish fuel before every call so each execution gets a fresh budget.
+        self.store
+            .set_fuel(FUEL_PER_CALL)
+            .map_err(|err| PluginError::ExecutionFailed {
+                message: err.to_string(),
+            })?;
+
+        // Write input into Wasm linear memory at offset 0.
+        {
+            let memory = self
+                .instance
+                .get_memory(&mut self.store, "memory")
+                .ok_or_else(|| PluginError::ExecutionFailed {
+                    message: "wasm module has no exported 'memory'".to_string(),
+                })?;
+
+            let data = memory.data_mut(&mut self.store);
+
+            if input_bytes.len() > OUTPUT_OFFSET as usize {
+                return Err(PluginError::ExecutionFailed {
+                    message: "input JSON too large for wasm memory layout".to_string(),
+                });
+            }
+            data[..input_bytes.len()].copy_from_slice(input_bytes);
+        }
+
+        // Call the Wasm function: (in_ptr=0, in_len, out_ptr, out_len_ptr)
+        let func = self
+            .instance
+            .get_typed_func::<(i32, i32, i32, i32), ()>(&mut self.store, fn_name)
+            .map_err(|err| PluginError::ExecutionFailed {
+                message: format!("failed to get export '{fn_name}': {err}"),
+            })?;
+
+        func.call(
+            &mut self.store,
+            (0, input_len, OUTPUT_OFFSET, OUTPUT_LEN_OFFSET),
+        )
+        .map_err(|err| {
+            let msg = err.to_string();
+            if msg.contains("fuel") || msg.contains("interrupt") {
+                PluginError::Timeout
+            } else if msg.contains("memory") {
+                PluginError::MemoryExhausted
+            } else {
+                PluginError::ExecutionFailed { message: msg }
+            }
+        })?;
+
+        // Read output length and bytes from Wasm memory.
+        let output = {
+            let memory = self
+                .instance
+                .get_memory(&mut self.store, "memory")
+                .ok_or_else(|| PluginError::ExecutionFailed {
+                    message: "wasm module has no exported 'memory'".to_string(),
+                })?;
+
+            let data = memory.data(&self.store);
+
+            let out_len = {
+                let lo = OUTPUT_LEN_OFFSET as usize;
+                i32::from_le_bytes(data[lo..lo + 4].try_into().unwrap()) as usize
+            };
+
+            let out_start = OUTPUT_OFFSET as usize;
+            let out_end = out_start + out_len;
+
+            if out_end > data.len() {
+                return Err(PluginError::InvalidOutput {
+                    message: "output length exceeds memory bounds".to_string(),
+                });
+            }
+
+            data[out_start..out_end].to_vec()
+        };
+
+        // Validate UTF-8 then valid JSON.
+        let output_str =
+            std::str::from_utf8(&output).map_err(|err| PluginError::InvalidOutput {
+                message: format!("output is not valid UTF-8: {err}"),
+            })?;
+
+        serde_json::from_str::<serde_json::Value>(output_str).map_err(|err| {
+            PluginError::InvalidOutput {
+                message: format!("output is not valid JSON: {err}"),
+            }
+        })?;
+
+        Ok(output_str.to_string())
     }
 }
 

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -407,10 +407,10 @@ impl PluginRuntime {
         if !self.manifest.entry_points.contains(&extension) {
             return Err(PluginError::MissingExport { extension });
         }
-        if let Some(required) = extension.required_capability() {
-            if !self.manifest.capabilities.contains(&required) {
-                return Err(PluginError::CapabilityViolation { required });
-            }
+        if let Some(required) = extension.required_capability()
+            && !self.manifest.capabilities.contains(&required)
+        {
+            return Err(PluginError::CapabilityViolation { required });
         }
         Ok(())
     }

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -2,6 +2,7 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::Arc;
 use thiserror::Error;
 use wasmtime::{Engine, Instance, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 
@@ -175,7 +176,7 @@ impl KeyRegistry {
 
 #[derive(Debug, Clone)]
 pub struct PluginHost {
-    engine: Engine,
+    engine: Arc<Engine>,
     key_registry: KeyRegistry,
 }
 
@@ -187,8 +188,11 @@ impl Default for PluginHost {
 
 impl PluginHost {
     pub fn new(key_registry: KeyRegistry) -> Self {
+        let mut config = wasmtime::Config::new();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config).expect("failed to create wasmtime engine");
         Self {
-            engine: Engine::default(),
+            engine: Arc::new(engine),
             key_registry,
         }
     }
@@ -214,6 +218,8 @@ impl PluginHost {
 
         Ok(LoadedPlugin {
             manifest: package.manifest.clone(),
+            wasm_bytes: package.wasm_module.clone(),
+            engine: Arc::clone(&self.engine),
         })
     }
 
@@ -252,11 +258,23 @@ impl PluginHost {
 #[derive(Debug, Clone)]
 pub struct LoadedPlugin {
     manifest: PluginManifest,
+    /// Verified Wasm bytes — tied to the signature that was verified at load time.
+    wasm_bytes: Vec<u8>,
+    /// Shared engine from the PluginHost that verified this plugin.
+    engine: Arc<Engine>,
 }
 
 impl LoadedPlugin {
     pub fn manifest(&self) -> &PluginManifest {
         &self.manifest
+    }
+
+    /// Create a `PluginRuntime` from this verified plugin.
+    ///
+    /// Uses the same Wasm bytes that were verified against the manifest signature,
+    /// preventing signature bypass via a separate `wasm_bytes` argument.
+    pub fn create_runtime(&self) -> Result<PluginRuntime, PluginError> {
+        PluginRuntime::from_verified(self)
     }
 
     pub fn authorize_extension(&self, extension: ExtensionPoint) -> Result<(), PluginError> {
@@ -312,17 +330,16 @@ pub struct PluginRuntime {
 }
 
 impl PluginRuntime {
-    /// Create a `PluginRuntime` from a verified [`LoadedPlugin`] and the raw Wasm bytes.
+    /// Create a `PluginRuntime` from a verified [`LoadedPlugin`].
     ///
-    /// Returns [`PluginError::WasmValidation`] if the bytes cannot be compiled, or
-    /// [`PluginError::ExecutionFailed`] if instantiation fails.
-    pub fn new(plugin: &LoadedPlugin, wasm_bytes: &[u8]) -> Result<Self, PluginError> {
-        let mut config = wasmtime::Config::new();
-        config.consume_fuel(true);
+    /// Prefer [`LoadedPlugin::create_runtime`] over calling this directly.
+    /// Uses the Wasm bytes that were verified against the manifest signature.
+    fn from_verified(plugin: &LoadedPlugin) -> Result<Self, PluginError> {
+        Self::new_inner(plugin, &plugin.wasm_bytes)
+    }
 
-        let engine = Engine::new(&config).map_err(|err| PluginError::WasmValidation {
-            message: err.to_string(),
-        })?;
+    fn new_inner(plugin: &LoadedPlugin, wasm_bytes: &[u8]) -> Result<Self, PluginError> {
+        let engine = Arc::clone(&plugin.engine);
 
         let module =
             Module::new(&engine, wasm_bytes).map_err(|err| PluginError::WasmValidation {
@@ -357,29 +374,43 @@ impl PluginRuntime {
 
     /// Execute the `on_state` extension point with the given JSON state.
     ///
-    /// Fails closed: returns [`PluginError::CapabilityViolation`] if the plugin
-    /// does not declare the [`Capability::ReadState`] capability.
+    /// Fails closed: returns [`PluginError::MissingExport`] if `on_state` is not declared,
+    /// or [`PluginError::CapabilityViolation`] if the plugin lacks [`Capability::ReadState`].
     pub fn on_state(&mut self, state_json: &str) -> Result<String, PluginError> {
-        self.check_capability_for_extension(ExtensionPoint::OnState)?;
+        self.authorize(ExtensionPoint::OnState)?;
         self.call_json_fn("on_state", state_json)
     }
 
     /// Execute the `before_act` extension point with the given intent JSON.
     ///
+    /// Fails closed: returns [`PluginError::MissingExport`] if `before_act` is not declared.
     /// Returns a policy-decision JSON string such as `{"allow":true}`.
     pub fn before_act(&mut self, intent_json: &str) -> Result<String, PluginError> {
+        self.authorize(ExtensionPoint::BeforeAct)?;
         self.call_json_fn("before_act", intent_json)
+    }
+
+    /// Execute the `connector` extension point with the given request JSON.
+    ///
+    /// Fails closed: returns [`PluginError::MissingExport`] if `connector` is not declared,
+    /// or [`PluginError::CapabilityViolation`] if the plugin lacks [`Capability::NetworkOut`].
+    pub fn connector(&mut self, request_json: &str) -> Result<String, PluginError> {
+        self.authorize(ExtensionPoint::Connector)?;
+        self.call_json_fn("connector", request_json)
     }
 
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
 
-    fn check_capability_for_extension(&self, extension: ExtensionPoint) -> Result<(), PluginError> {
-        if let Some(required) = extension.required_capability()
-            && !self.manifest.capabilities.contains(&required)
-        {
-            return Err(PluginError::CapabilityViolation { required });
+    fn authorize(&self, extension: ExtensionPoint) -> Result<(), PluginError> {
+        if !self.manifest.entry_points.contains(&extension) {
+            return Err(PluginError::MissingExport { extension });
+        }
+        if let Some(required) = extension.required_capability() {
+            if !self.manifest.capabilities.contains(&required) {
+                return Err(PluginError::CapabilityViolation { required });
+            }
         }
         Ok(())
     }
@@ -450,19 +481,32 @@ impl PluginRuntime {
 
             let data = memory.data(&self.store);
 
-            let out_len = {
-                let lo = OUTPUT_LEN_OFFSET as usize;
-                i32::from_le_bytes(data[lo..lo + 4].try_into().unwrap()) as usize
-            };
+            // Validate the memory is large enough to hold the length field.
+            let len_slot_start = OUTPUT_LEN_OFFSET as usize;
+            let len_slot_end = len_slot_start
+                .checked_add(4)
+                .filter(|&e| e <= data.len())
+                .ok_or_else(|| PluginError::InvalidOutput {
+                    message: "wasm memory too small to contain output length field".to_string(),
+                })?;
 
-            let out_start = OUTPUT_OFFSET as usize;
-            let out_end = out_start + out_len;
+            // Read length as u32 to reject negative values.
+            let out_len =
+                u32::from_le_bytes(data[len_slot_start..len_slot_end].try_into().unwrap())
+                    as usize;
 
-            if out_end > data.len() {
+            if out_len > MAX_OUTPUT_SIZE {
                 return Err(PluginError::InvalidOutput {
-                    message: "output length exceeds memory bounds".to_string(),
+                    message: format!(
+                        "output length {out_len} exceeds MAX_OUTPUT_SIZE {MAX_OUTPUT_SIZE}"
+                    ),
                 });
             }
+
+            let out_start = OUTPUT_OFFSET as usize;
+            let out_end = out_start.checked_add(out_len).filter(|&e| e <= data.len()).ok_or_else(|| PluginError::InvalidOutput {
+                message: "output region extends beyond wasm memory bounds".to_string(),
+            })?;
 
             data[out_start..out_end].to_vec()
         };

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -492,8 +492,7 @@ impl PluginRuntime {
 
             // Read length as u32 to reject negative values.
             let out_len =
-                u32::from_le_bytes(data[len_slot_start..len_slot_end].try_into().unwrap())
-                    as usize;
+                u32::from_le_bytes(data[len_slot_start..len_slot_end].try_into().unwrap()) as usize;
 
             if out_len > MAX_OUTPUT_SIZE {
                 return Err(PluginError::InvalidOutput {
@@ -504,9 +503,12 @@ impl PluginRuntime {
             }
 
             let out_start = OUTPUT_OFFSET as usize;
-            let out_end = out_start.checked_add(out_len).filter(|&e| e <= data.len()).ok_or_else(|| PluginError::InvalidOutput {
-                message: "output region extends beyond wasm memory bounds".to_string(),
-            })?;
+            let out_end = out_start
+                .checked_add(out_len)
+                .filter(|&e| e <= data.len())
+                .ok_or_else(|| PluginError::InvalidOutput {
+                    message: "output region extends beyond wasm memory bounds".to_string(),
+                })?;
 
             data[out_start..out_end].to_vec()
         };

--- a/plugin-host/tests/plugin_runtime.rs
+++ b/plugin-host/tests/plugin_runtime.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::{Signer, SigningKey};
 use plugin_host::{
     Capability, ExtensionPoint, KeyRegistry, PluginError, PluginHost, PluginManifest,
-    PluginPackage, PluginRuntime, SbomComponent, SbomDocument, SignatureBlock, signature_payload,
+    PluginPackage, SbomComponent, SbomDocument, SignatureBlock, signature_payload,
 };
 
 // ---------------------------------------------------------------------------
@@ -93,6 +93,72 @@ fn before_act_only_wasm() -> Vec<u8> {
         )"#,
     )
     .expect("failed to build before_act_only wasm fixture")
+}
+
+/// Wasm that exports `on_state`, `before_act`, and `connector`.
+/// `connector` echoes the input JSON back to the caller (same as `on_state`).
+fn connector_wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+
+            ;; on_state: echo input
+            (func (export "on_state")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (local $i i32)
+                (local.set $i (i32.const 0))
+                (block $break
+                    (loop $loop
+                        (br_if $break (i32.ge_u (local.get $i) (local.get $in_len)))
+                        (i32.store8
+                            (i32.add (local.get $out_ptr) (local.get $i))
+                            (i32.load8_u (i32.add (local.get $in_ptr) (local.get $i))))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br $loop)))
+                (i32.store (local.get $out_len_ptr) (local.get $in_len))
+            )
+
+            ;; before_act: always returns {"allow":true}
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 116))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 114))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 117))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 101))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 125))
+                (i32.store (local.get $out_len_ptr) (i32.const 14))
+            )
+
+            ;; connector: echo input (same loop as on_state)
+            (func (export "connector")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (local $i i32)
+                (local.set $i (i32.const 0))
+                (block $break
+                    (loop $loop
+                        (br_if $break (i32.ge_u (local.get $i) (local.get $in_len)))
+                        (i32.store8
+                            (i32.add (local.get $out_ptr) (local.get $i))
+                            (i32.load8_u (i32.add (local.get $in_ptr) (local.get $i))))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br $loop)))
+                (i32.store (local.get $out_len_ptr) (local.get $in_len))
+            )
+        )"#,
+    )
+    .expect("failed to build connector wasm fixture")
 }
 
 /// Wasm whose `before_act` writes non-UTF8 / non-JSON garbage.
@@ -190,7 +256,7 @@ fn test_on_state_echoes_input() {
     let host = PluginHost::new(registry);
     let loaded = host.load_plugin(&package).expect("plugin must load");
 
-    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
 
     let input = r#"{"dragon":"head"}"#;
     let output = runtime.on_state(input).expect("on_state must succeed");
@@ -217,7 +283,7 @@ fn test_before_act_returns_allow_true() {
     let host = PluginHost::new(registry);
     let loaded = host.load_plugin(&package).expect("plugin must load");
 
-    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
 
     let output = runtime
         .before_act(r#"{"action":"speak"}"#)
@@ -246,7 +312,7 @@ fn test_on_state_blocked_without_read_state_capability() {
     // load_plugin checks the export exists, not capabilities at load time
     let loaded = host.load_plugin(&package).expect("plugin must load");
 
-    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
 
     let err = runtime
         .on_state(r#"{"x":1}"#)
@@ -307,7 +373,7 @@ fn test_before_act_malformed_output_returns_invalid_output() {
     let host = PluginHost::new(registry);
     let loaded = host.load_plugin(&package).expect("plugin must load");
 
-    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
 
     let err = runtime
         .before_act(r#"{"action":"speak"}"#)
@@ -347,5 +413,66 @@ fn test_missing_on_state_export_fails_at_load() {
             }
         ),
         "expected MissingExport(OnState), got {err:?}"
+    );
+}
+
+/// 7. connector extension point echoes request JSON when NetworkOut capability is granted
+#[test]
+fn test_connector_echoes_request() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = connector_wasm();
+    let package = build_and_sign_package(
+        vec![
+            ExtensionPoint::OnState,
+            ExtensionPoint::BeforeAct,
+            ExtensionPoint::Connector,
+        ],
+        vec![Capability::ReadState, Capability::NetworkOut],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
+
+    let request = r#"{"url":"https://example.com"}"#;
+    let output = runtime.connector(request).expect("connector must succeed");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output must be valid JSON");
+    assert_eq!(parsed["url"], "https://example.com");
+}
+
+/// 8. connector is blocked when NetworkOut capability is missing
+#[test]
+fn test_connector_blocked_without_network_out() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = connector_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::Connector],
+        vec![], // NetworkOut intentionally omitted
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
+
+    let err = runtime
+        .connector(r#"{"url":"https://example.com"}"#)
+        .expect_err("connector without NetworkOut must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            PluginError::CapabilityViolation {
+                required: Capability::NetworkOut
+            }
+        ),
+        "expected CapabilityViolation(NetworkOut), got {err:?}"
     );
 }

--- a/plugin-host/tests/plugin_runtime.rs
+++ b/plugin-host/tests/plugin_runtime.rs
@@ -1,0 +1,351 @@
+use ed25519_dalek::{Signer, SigningKey};
+use plugin_host::{
+    Capability, ExtensionPoint, KeyRegistry, PluginError, PluginHost, PluginManifest,
+    PluginPackage, PluginRuntime, SbomComponent, SbomDocument, SignatureBlock, signature_payload,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Memory layout (matches the constants in `plugin_host::PluginRuntime`):
+///   - [0 .. 16 KiB)      : input JSON written by the host
+///   - [16 KiB .. 32 KiB) : output buffer written by the Wasm function
+///   - [32 KiB .. 32 KiB+4]: output length (i32 LE) written by the Wasm function
+///
+/// This fits comfortably in a single 64 KiB Wasm page.
+///
+/// Minimal WAT that exports `on_state` and `before_act`:
+///   - `on_state`   : echo-copies the input bytes to `out_ptr`, stores `in_len` at `out_len_ptr`.
+///   - `before_act` : always writes `{"allow":true}` (14 bytes) to `out_ptr`.
+fn echo_wasm() -> Vec<u8> {
+    // {"allow":true} as byte constants:  { " a l l o w " :  t  r  u  e  }
+    // 123 34 97 108 108 111 119 34 58 116 114 117 101 125
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+
+            ;; on_state: copy input to output with a byte-by-byte loop
+            (func (export "on_state")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (local $i i32)
+                (local.set $i (i32.const 0))
+                (block $break
+                    (loop $loop
+                        (br_if $break (i32.ge_u (local.get $i) (local.get $in_len)))
+                        (i32.store8
+                            (i32.add (local.get $out_ptr) (local.get $i))
+                            (i32.load8_u (i32.add (local.get $in_ptr) (local.get $i))))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br $loop)))
+                (i32.store (local.get $out_len_ptr) (local.get $in_len))
+            )
+
+            ;; before_act: always returns {"allow":true}
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 116))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 114))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 117))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 101))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 125))
+                (i32.store (local.get $out_len_ptr) (i32.const 14))
+            )
+        )"#,
+    )
+    .expect("failed to build echo wasm fixture")
+}
+
+/// Wasm that exports `before_act` only (no `on_state`).
+fn before_act_only_wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 116))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 114))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 117))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 101))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 125))
+                (i32.store (local.get $out_len_ptr) (i32.const 14)))
+        )"#,
+    )
+    .expect("failed to build before_act_only wasm fixture")
+}
+
+/// Wasm whose `before_act` writes non-UTF8 / non-JSON garbage.
+fn malformed_output_wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                ;; write 4 bytes of garbage (0xFF 0xFE 0x00 0x01) — invalid UTF-8 / invalid JSON
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0)) (i32.const 255))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1)) (i32.const 254))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2)) (i32.const 0))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3)) (i32.const 1))
+                (i32.store (local.get $out_len_ptr) (i32.const 4))
+            )
+        )"#,
+    )
+    .expect("failed to build malformed_output wasm fixture")
+}
+
+fn sample_sbom() -> SbomDocument {
+    SbomDocument {
+        format: "cyclonedx-1.5".to_string(),
+        components: vec![SbomComponent {
+            name: "fixture-component".to_string(),
+            version: "1.0.0".to_string(),
+            license: Some("MIT".to_string()),
+        }],
+    }
+}
+
+fn make_registry_and_key() -> (KeyRegistry, SigningKey, String) {
+    let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+    let key_id = "test-key-runtime".to_string();
+
+    let mut registry = KeyRegistry::default();
+    registry
+        .register_hex_ed25519(
+            &key_id,
+            &hex::encode(signing_key.verifying_key().to_bytes()),
+        )
+        .expect("must register key");
+
+    (registry, signing_key, key_id)
+}
+
+fn build_and_sign_package(
+    entry_points: Vec<ExtensionPoint>,
+    capabilities: Vec<Capability>,
+    wasm: Vec<u8>,
+    signing_key: &SigningKey,
+    key_id: &str,
+) -> PluginPackage {
+    let mut manifest = PluginManifest {
+        plugin_id: "runtime.test.plugin".to_string(),
+        version: "0.1.0".to_string(),
+        entry_points,
+        capabilities,
+        signature: None,
+        sbom: sample_sbom(),
+    };
+
+    let payload = signature_payload(&manifest, &wasm).expect("payload must build");
+    let sig = signing_key.sign(&payload);
+    manifest.signature = Some(SignatureBlock {
+        key_id: key_id.to_string(),
+        signature_hex: hex::encode(sig.to_bytes()),
+    });
+
+    PluginPackage {
+        manifest,
+        wasm_module: wasm,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// 1. Signed plugin with on_state can transform state JSON (echo fixture)
+#[test]
+fn test_on_state_echoes_input() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![Capability::ReadState],
+        wasm.clone(),
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+
+    let input = r#"{"dragon":"head"}"#;
+    let output = runtime.on_state(input).expect("on_state must succeed");
+
+    // echo fixture returns the same JSON
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output must be valid JSON");
+    assert_eq!(parsed["dragon"], "head");
+}
+
+/// 2. Signed plugin with before_act returns policy decision JSON
+#[test]
+fn test_before_act_returns_allow_true() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::BeforeAct],
+        vec![],
+        wasm.clone(),
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+
+    let output = runtime
+        .before_act(r#"{"action":"speak"}"#)
+        .expect("before_act must succeed");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("output must be valid JSON");
+    assert_eq!(parsed["allow"], true);
+}
+
+/// 3. Plugin without ReadState capability cannot execute on_state (CapabilityViolation)
+#[test]
+fn test_on_state_blocked_without_read_state_capability() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    // Declare on_state entry-point but omit ReadState capability
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![], // <-- no ReadState
+        wasm.clone(),
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    // load_plugin checks the export exists, not capabilities at load time
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+
+    let err = runtime
+        .on_state(r#"{"x":1}"#)
+        .expect_err("must be blocked by capability check");
+
+    assert!(
+        matches!(
+            err,
+            PluginError::CapabilityViolation {
+                required: Capability::ReadState
+            }
+        ),
+        "expected CapabilityViolation(ReadState), got {err:?}"
+    );
+}
+
+/// 4. Unsigned plugin cannot execute — UnsignedPlugin error at load time.
+#[test]
+fn test_unsigned_plugin_rejected_at_load_time() {
+    let manifest = PluginManifest {
+        plugin_id: "unsigned.plugin".to_string(),
+        version: "1.0.0".to_string(),
+        entry_points: vec![ExtensionPoint::OnState],
+        capabilities: vec![Capability::ReadState],
+        signature: None,
+        sbom: sample_sbom(),
+    };
+    let wasm = echo_wasm();
+    let package = PluginPackage {
+        manifest,
+        wasm_module: wasm,
+    };
+
+    let host = PluginHost::default();
+    let err = host
+        .load_plugin(&package)
+        .expect_err("unsigned plugin must be rejected");
+
+    assert!(
+        matches!(err, PluginError::UnsignedPlugin),
+        "expected UnsignedPlugin, got {err:?}"
+    );
+}
+
+/// 5. Malformed output from Wasm produces InvalidOutput error
+#[test]
+fn test_before_act_malformed_output_returns_invalid_output() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = malformed_output_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::BeforeAct],
+        vec![],
+        wasm.clone(),
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let mut runtime = PluginRuntime::new(&loaded, &wasm).expect("runtime must be created");
+
+    let err = runtime
+        .before_act(r#"{"action":"speak"}"#)
+        .expect_err("malformed output must produce an error");
+
+    assert!(
+        matches!(err, PluginError::InvalidOutput { .. }),
+        "expected InvalidOutput, got {err:?}"
+    );
+}
+
+/// 6. Plugin without on_state export fails at load time (MissingExport)
+#[test]
+fn test_missing_on_state_export_fails_at_load() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = before_act_only_wasm();
+
+    // Declare on_state in manifest but the wasm only exports before_act
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState], // declared but absent in wasm
+        vec![Capability::ReadState],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let err = host
+        .load_plugin(&package)
+        .expect_err("missing export must fail at load");
+
+    assert!(
+        matches!(
+            err,
+            PluginError::MissingExport {
+                extension: ExtensionPoint::OnState
+            }
+        ),
+        "expected MissingExport(OnState), got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `PluginRuntime` struct to `plugin-host` that instantiates signed Wasm modules via wasmtime
- Implements `on_state()` and `before_act()` extension point executors with typed JSON I/O
- Enforces capability checks before every extension point call (fail closed)
- Resource limits: fuel exhaustion → `Timeout`, memory overflow → `MemoryExhausted`
- Adds new `PluginError` variants: `ExecutionFailed`, `InvalidOutput`, `Timeout`, `MemoryExhausted`

## Acceptance Criteria Checklist

- [x] A signed fixture plugin can transform state via `on_state`
- [x] A signed fixture plugin can return a policy decision via `before_act`
- [x] Unsigned plugins cannot execute (rejected at `load_plugin` time)
- [x] Plugins without required capabilities cannot execute (`CapabilityViolation`)
- [x] Malformed plugin outputs produce structured `InvalidOutput` errors
- [x] Plugin without `on_state` export fails at load time (`MissingExport`)

## Test Results

```
test test_unsigned_plugin_rejected_at_load_time ... ok
test test_missing_on_state_export_fails_at_load ... ok
test test_on_state_blocked_without_read_state_capability ... ok
test test_before_act_malformed_output_returns_invalid_output ... ok
test test_on_state_echoes_input ... ok
test test_before_act_returns_allow_true ... ok

test result: ok. 6 passed; 0 failed
```

## Related Issues

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)