### PR TITLE
[#49] Use actual viewport dimensions for stable_key quadrant calculation

### DIFF
--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -139,6 +139,7 @@ pub struct BrowserClient {
     inner: Browser,
     vault: Arc<dyn SessionVault>,
     plugin_hooks: Arc<PluginHookConfig>,
+    viewport_size: Option<(u32, u32)>,
 }
 
 impl BrowserClient {
@@ -175,6 +176,19 @@ impl BrowserClient {
         Self::new_with_vault_and_path(vault, chrome_path)
     }
 
+    /// Create a `BrowserClient` with an explicit window size.
+    ///
+    /// Used in tests to verify that different viewport dimensions produce
+    /// different stable_key quadrant assignments for the same element.
+    pub fn new_with_window_size(width: u32, height: u32) -> Result<Self> {
+        use rand::RngCore;
+        let mut key = [0u8; 32];
+        rand::rng().fill_bytes(&mut key);
+        let kms = Box::new(SoftwareKms::new(key, "default-key".to_string()));
+        let vault = Arc::new(LocalSessionVault::new(kms));
+        Self::new_with_vault_and_size(vault, width, height)
+    }
+
     pub fn new_with_vault(vault: Arc<dyn SessionVault>) -> Result<Self> {
         Self::new_with_vault_and_path(vault, None)
     }
@@ -203,11 +217,33 @@ impl BrowserClient {
             inner: browser,
             vault,
             plugin_hooks: Arc::new(plugin_hooks),
+            viewport_size: None,
+        })
+    }
+
+    fn new_with_vault_and_size(
+        vault: Arc<dyn SessionVault>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self> {
+        let mut builder = LaunchOptions::default_builder();
+        builder.headless(true).window_size(Some((width, height)));
+        let options = builder.build().context("Failed to build launch options")?;
+
+        let browser = Browser::new(options).context("Failed to launch browser")?;
+        Ok(Self {
+            inner: browser,
+            vault,
+            plugin_hooks: Arc::new(PluginHookConfig::default()),
+            viewport_size: Some((width, height)),
         })
     }
 
     pub fn new_page(&self) -> Result<PageSession> {
         let tab = self.inner.new_tab().context("Failed to create new tab")?;
+        if let Some((width, height)) = self.viewport_size {
+            apply_viewport_size(&tab, width, height)?;
+        }
         Ok(PageSession {
             inner: tab,
             som_pipeline: Arc::new(Mutex::new(SomPipelineState::default())),
@@ -222,6 +258,29 @@ impl BrowserClient {
             plugin_hooks: Arc::clone(&self.plugin_hooks),
         })
     }
+}
+
+fn apply_viewport_size(tab: &headless_chrome::Tab, width: u32, height: u32) -> Result<()> {
+    use headless_chrome::protocol::cdp::Emulation::SetDeviceMetricsOverride;
+
+    tab.call_method(SetDeviceMetricsOverride {
+        width,
+        height,
+        device_scale_factor: 1.0,
+        mobile: false,
+        scale: None,
+        screen_width: Some(width),
+        screen_height: Some(height),
+        position_x: None,
+        position_y: None,
+        dont_set_visible_size: None,
+        screen_orientation: None,
+        viewport: None,
+        display_feature: None,
+        device_posture: None,
+    })
+    .context("Failed to set viewport dimensions")?;
+    Ok(())
 }
 
 pub struct PageSession {

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -18,8 +18,8 @@ use crate::{
     policy::{ApprovalScope, PolicyAction, PolicyContext, PolicyEngine, PolicyRule},
     session_vault::{CookieData, LocalSessionVault, SessionData, SessionVault, SoftwareKms},
     sre::{
-        normalize_dom, normalize_dom_with_refinement, LoadProfile, SemanticNode, SemanticState,
-        SubtreeRefinementConfig,
+        normalize_dom_with_viewport, normalize_dom_with_viewport_and_refinement, LoadProfile,
+        SemanticNode, SemanticState, SubtreeRefinementConfig, ViewportDimensions,
     },
 };
 
@@ -1348,6 +1348,38 @@ impl PageSession {
         }
     }
 
+    /// Retrieve the actual browser viewport dimensions via JavaScript.
+    ///
+    /// Falls back to the default 800×600 constants if the CDP call fails, so that
+    /// captures remain functional even when the browser context is unavailable.
+    fn get_viewport_dimensions(&self) -> ViewportDimensions {
+        let script = "JSON.stringify({width: window.innerWidth, height: window.innerHeight})";
+        let Ok(value) = self.evaluate_script_value(script, false) else {
+            return ViewportDimensions::default();
+        };
+        let Some(json_str) = value.as_str() else {
+            return ViewportDimensions::default();
+        };
+        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str) else {
+            return ViewportDimensions::default();
+        };
+        let width = parsed
+            .get("width")
+            .and_then(|v| v.as_f64())
+            .filter(|&w| w > 0.0);
+        let height = parsed
+            .get("height")
+            .and_then(|v| v.as_f64())
+            .filter(|&h| h > 0.0);
+        match (width, height) {
+            (Some(w), Some(h)) => ViewportDimensions {
+                width: w,
+                height: h,
+            },
+            _ => ViewportDimensions::default(),
+        }
+    }
+
     fn capture_state_with_refinement(
         &self,
         profile: LoadProfile,
@@ -1356,13 +1388,15 @@ impl PageSession {
         cached_paths: Option<&HashMap<String, Vec<usize>>>,
     ) -> Result<SemanticState> {
         let root = self.get_document_node()?;
+        let viewport = self.get_viewport_dimensions();
         let normalized_dirty_paths = normalize_dirty_paths(dirty_paths);
         let sem_root = if let (Some(cached_root), Some(cached_paths)) = (cached_root, cached_paths)
         {
             if !normalized_dirty_paths.is_empty() && !cached_paths.is_empty() {
-                normalize_dom_with_refinement(
+                normalize_dom_with_viewport_and_refinement(
                     profile,
                     &root,
+                    viewport,
                     SubtreeRefinementConfig {
                         dirty_paths: &normalized_dirty_paths,
                         cached_paths,
@@ -1370,10 +1404,10 @@ impl PageSession {
                     },
                 )?
             } else {
-                normalize_dom(profile, &root)?
+                normalize_dom_with_viewport(profile, &root, viewport)?
             }
         } else {
-            normalize_dom(profile, &root)?
+            normalize_dom_with_viewport(profile, &root, viewport)?
         };
         self.replace_stable_key_index(&sem_root);
         Ok(SemanticState::new(sem_root, profile))
@@ -1440,7 +1474,8 @@ impl PageSession {
 
     fn capture_som(&self, trigger: SomTrigger) -> Result<VisualCapture> {
         let root = self.get_document_node()?;
-        let semantic_root = normalize_dom(LoadProfile::Visual, &root)?;
+        let viewport = self.get_viewport_dimensions();
+        let semantic_root = normalize_dom_with_viewport(LoadProfile::Visual, &root, viewport)?;
 
         let mut marks = Vec::new();
         self.collect_som_marks(&semantic_root, &mut marks);

--- a/core-runtime/src/sre/mod.rs
+++ b/core-runtime/src/sre/mod.rs
@@ -4,7 +4,10 @@ pub mod profile;
 pub mod stable_key;
 pub mod state;
 
-pub use normalization::{normalize_dom, normalize_dom_with_refinement, SubtreeRefinementConfig};
+pub use normalization::{
+    normalize_dom, normalize_dom_with_refinement, normalize_dom_with_viewport,
+    normalize_dom_with_viewport_and_refinement, SubtreeRefinementConfig, ViewportDimensions,
+};
 pub use pipeline::{
     AsyncPipeline, AsyncPipelineConfig, AsyncPipelineMetrics, AuditEvent, AuditEventKind,
     LayeredStateHandle, PipelineReceiveError, PipelineSubmitError, QueueKind, SreStage,

--- a/core-runtime/src/sre/normalization.rs
+++ b/core-runtime/src/sre/normalization.rs
@@ -68,12 +68,24 @@ pub fn normalize_dom_with_refinement(
 }
 
 /// Normalize DOM with both explicit viewport dimensions and subtree refinement.
+///
+/// When `viewport` differs from the default (800×600), cached subtrees are **not**
+/// reused even for nodes that are not marked dirty.  Cached stable keys were
+/// computed against the old viewport, so reusing them after a resize (or mobile
+/// emulation) would produce stale quadrant values.  Bypassing the cache in that
+/// case is a safe conservative fix: a full re-parse is triggered whenever the
+/// viewport is non-default.
 pub fn normalize_dom_with_viewport_and_refinement(
     profile: LoadProfile,
     node: &Node,
     viewport: ViewportDimensions,
     refinement: SubtreeRefinementConfig<'_>,
 ) -> Result<SemanticNode> {
+    if viewport != ViewportDimensions::default() {
+        // Viewport-sensitive path: skip the refinement cache entirely so that
+        // all stable keys are recomputed with the current viewport dimensions.
+        return normalize_dom_internal(profile, node, viewport, None);
+    }
     normalize_dom_internal(profile, node, viewport, Some(&refinement))
 }
 

--- a/core-runtime/src/sre/normalization.rs
+++ b/core-runtime/src/sre/normalization.rs
@@ -13,8 +13,39 @@ use std::{
 const DEFAULT_VIEWPORT_WIDTH_PX: f64 = 800.0;
 const DEFAULT_VIEWPORT_HEIGHT_PX: f64 = 600.0;
 
+/// Explicit viewport dimensions used for quadrant calculation.
+/// When provided to `normalize_dom_with_viewport`, the actual browser dimensions
+/// are used instead of the default 800×600 fallback constants.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ViewportDimensions {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl Default for ViewportDimensions {
+    fn default() -> Self {
+        Self {
+            width: DEFAULT_VIEWPORT_WIDTH_PX,
+            height: DEFAULT_VIEWPORT_HEIGHT_PX,
+        }
+    }
+}
+
 pub fn normalize_dom(profile: LoadProfile, node: &Node) -> Result<SemanticNode> {
-    normalize_dom_internal(profile, node, None)
+    normalize_dom_internal(profile, node, ViewportDimensions::default(), None)
+}
+
+/// Normalize DOM using explicit viewport dimensions for accurate quadrant calculation.
+///
+/// When the real browser viewport is known (e.g. retrieved via CDP), pass it here so
+/// that `stable_key` quadrant values reflect actual on-screen positions rather than
+/// the 800×600 default fallback.
+pub fn normalize_dom_with_viewport(
+    profile: LoadProfile,
+    node: &Node,
+    viewport: ViewportDimensions,
+) -> Result<SemanticNode> {
+    normalize_dom_internal(profile, node, viewport, None)
 }
 
 pub struct SubtreeRefinementConfig<'a> {
@@ -28,17 +59,40 @@ pub fn normalize_dom_with_refinement(
     node: &Node,
     refinement: SubtreeRefinementConfig<'_>,
 ) -> Result<SemanticNode> {
-    normalize_dom_internal(profile, node, Some(&refinement))
+    normalize_dom_internal(
+        profile,
+        node,
+        ViewportDimensions::default(),
+        Some(&refinement),
+    )
+}
+
+/// Normalize DOM with both explicit viewport dimensions and subtree refinement.
+pub fn normalize_dom_with_viewport_and_refinement(
+    profile: LoadProfile,
+    node: &Node,
+    viewport: ViewportDimensions,
+    refinement: SubtreeRefinementConfig<'_>,
+) -> Result<SemanticNode> {
+    normalize_dom_internal(profile, node, viewport, Some(&refinement))
 }
 
 fn normalize_dom_internal(
     profile: LoadProfile,
     node: &Node,
+    viewport: ViewportDimensions,
     refinement: Option<&SubtreeRefinementConfig<'_>>,
 ) -> Result<SemanticNode> {
     let mut key_generator = StableKeyGenerator::new();
     // Start traversal with root path
-    let internal_node = traverse_node(profile, node, &mut key_generator, "root", refinement)?;
+    let internal_node = traverse_node(
+        profile,
+        node,
+        &mut key_generator,
+        "root",
+        viewport,
+        refinement,
+    )?;
     Ok(internal_node.unwrap_or_default())
 }
 
@@ -83,6 +137,7 @@ fn traverse_node(
     node: &Node,
     key_gen: &mut StableKeyGenerator,
     parent_path: &str,
+    viewport: ViewportDimensions,
     refinement: Option<&SubtreeRefinementConfig<'_>>,
 ) -> Result<Option<SemanticNode>> {
     // Basic filtering based on node type
@@ -187,7 +242,7 @@ fn traverse_node(
         // For now, let's use the loop index.
         for child in child_nodes {
             if let Some(normalized_child) =
-                traverse_node(profile, child, key_gen, &current_path, refinement)?
+                traverse_node(profile, child, key_gen, &current_path, viewport, refinement)?
             {
                 children.push(normalized_child);
             }
@@ -207,7 +262,7 @@ fn traverse_node(
         .or_else(|| attributes.get("id").map(|s| s.as_str()))
         .or(text_hint.as_deref());
 
-    let quadrant = resolve_quadrant(&attributes, &node_name, label_hint, parent_path);
+    let quadrant = resolve_quadrant(&attributes, &node_name, label_hint, parent_path, viewport);
     let alias = build_alias(&node_name, label_hint, &attributes);
 
     let (stable_key, ambiguous) =
@@ -308,6 +363,7 @@ fn resolve_quadrant(
     role: &str,
     label_hint: Option<&str>,
     dom_signature: &str,
+    viewport: ViewportDimensions,
 ) -> String {
     if let Some(raw) = attributes.get("data-quadrant") {
         if let Some(normalized) = normalize_quadrant_token(raw) {
@@ -315,7 +371,7 @@ fn resolve_quadrant(
         }
     }
 
-    if let Some(quadrant) = resolve_quadrant_from_coordinates(attributes) {
+    if let Some(quadrant) = resolve_quadrant_from_coordinates(attributes, viewport) {
         return quadrant;
     }
 
@@ -333,44 +389,47 @@ fn normalize_quadrant_token(raw: &str) -> Option<String> {
     }
 }
 
-fn resolve_quadrant_from_coordinates(attributes: &BTreeMap<String, String>) -> Option<String> {
-    let x_ratio = extract_x_ratio(attributes)?;
-    let y_ratio = extract_y_ratio(attributes)?;
+fn resolve_quadrant_from_coordinates(
+    attributes: &BTreeMap<String, String>,
+    viewport: ViewportDimensions,
+) -> Option<String> {
+    let x_ratio = extract_x_ratio(attributes, viewport.width)?;
+    let y_ratio = extract_y_ratio(attributes, viewport.height)?;
     Some(quadrant_from_ratios(x_ratio, y_ratio))
 }
 
-fn extract_x_ratio(attributes: &BTreeMap<String, String>) -> Option<f64> {
+fn extract_x_ratio(attributes: &BTreeMap<String, String>, viewport_width: f64) -> Option<f64> {
     if let Some(style) = attributes.get("style") {
         if let Some(left) =
-            extract_css_numeric(style, "left").and_then(|v| v.to_ratio(DEFAULT_VIEWPORT_WIDTH_PX))
+            extract_css_numeric(style, "left").and_then(|v| v.to_ratio(viewport_width))
         {
             return Some(left);
         }
         if let Some(right) =
-            extract_css_numeric(style, "right").and_then(|v| v.to_ratio(DEFAULT_VIEWPORT_WIDTH_PX))
+            extract_css_numeric(style, "right").and_then(|v| v.to_ratio(viewport_width))
         {
             return Some((1.0 - right).clamp(0.0, 1.0));
         }
     }
 
-    extract_coordinate_attribute(attributes, &["data-x", "x"], DEFAULT_VIEWPORT_WIDTH_PX)
+    extract_coordinate_attribute(attributes, &["data-x", "x"], viewport_width)
 }
 
-fn extract_y_ratio(attributes: &BTreeMap<String, String>) -> Option<f64> {
+fn extract_y_ratio(attributes: &BTreeMap<String, String>, viewport_height: f64) -> Option<f64> {
     if let Some(style) = attributes.get("style") {
         if let Some(top) =
-            extract_css_numeric(style, "top").and_then(|v| v.to_ratio(DEFAULT_VIEWPORT_HEIGHT_PX))
+            extract_css_numeric(style, "top").and_then(|v| v.to_ratio(viewport_height))
         {
             return Some(top);
         }
-        if let Some(bottom) = extract_css_numeric(style, "bottom")
-            .and_then(|v| v.to_ratio(DEFAULT_VIEWPORT_HEIGHT_PX))
+        if let Some(bottom) =
+            extract_css_numeric(style, "bottom").and_then(|v| v.to_ratio(viewport_height))
         {
             return Some((1.0 - bottom).clamp(0.0, 1.0));
         }
     }
 
-    extract_coordinate_attribute(attributes, &["data-y", "y"], DEFAULT_VIEWPORT_HEIGHT_PX)
+    extract_coordinate_attribute(attributes, &["data-y", "y"], viewport_height)
 }
 
 fn extract_coordinate_attribute(

--- a/core-runtime/tests/stable_key_compatibility.rs
+++ b/core-runtime/tests/stable_key_compatibility.rs
@@ -1,4 +1,83 @@
 use core_runtime::sre::StableKeyGenerator;
+use core_runtime::sre::{
+    normalize_dom, normalize_dom_with_viewport, LoadProfile, ViewportDimensions,
+};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Helper builders (mirror normalization.rs test helpers)
+// ---------------------------------------------------------------------------
+
+fn make_document_node(
+    node_id: u32,
+    children: Vec<headless_chrome::protocol::cdp::DOM::Node>,
+) -> headless_chrome::protocol::cdp::DOM::Node {
+    serde_json::from_value(json!({
+        "nodeId": node_id,
+        "backendNodeId": node_id,
+        "nodeType": 9,
+        "nodeName": "#document",
+        "localName": "",
+        "nodeValue": "",
+        "childNodeCount": children.len(),
+        "children": children
+    }))
+    .unwrap()
+}
+
+fn make_element_node(
+    node_id: u32,
+    tag: &str,
+    attributes: Vec<(&str, &str)>,
+    children: Vec<headless_chrome::protocol::cdp::DOM::Node>,
+) -> headless_chrome::protocol::cdp::DOM::Node {
+    let mut flat_attrs: Vec<String> = Vec::with_capacity(attributes.len() * 2);
+    for (key, value) in attributes {
+        flat_attrs.push(key.to_string());
+        flat_attrs.push(value.to_string());
+    }
+    serde_json::from_value(json!({
+        "nodeId": node_id,
+        "backendNodeId": node_id,
+        "nodeType": 1,
+        "nodeName": tag.to_uppercase(),
+        "localName": tag,
+        "nodeValue": "",
+        "attributes": flat_attrs,
+        "childNodeCount": children.len(),
+        "children": children
+    }))
+    .unwrap()
+}
+
+fn make_text_node(node_id: u32, text: &str) -> headless_chrome::protocol::cdp::DOM::Node {
+    serde_json::from_value(json!({
+        "nodeId": node_id,
+        "backendNodeId": node_id,
+        "nodeType": 3,
+        "nodeName": "#text",
+        "localName": "",
+        "nodeValue": text
+    }))
+    .unwrap()
+}
+
+/// Build a minimal document with one div at a given pixel position via inline style.
+fn build_positioned_document(
+    left_px: u32,
+    top_px: u32,
+) -> headless_chrome::protocol::cdp::DOM::Node {
+    let style = format!("position:absolute;left:{}px;top:{}px", left_px, top_px);
+    let div = make_element_node(
+        104,
+        "div",
+        vec![("style", &style)],
+        vec![make_text_node(105, "Hello")],
+    );
+    let body = make_element_node(103, "body", vec![], vec![div]);
+    let html = make_element_node(102, "html", vec![], vec![body]);
+    make_document_node(101, vec![html])
+}
 
 #[test]
 fn test_stable_key_hash_compatibility_vectors() {
@@ -73,4 +152,146 @@ fn test_stable_key_hash_compatibility_non_ascii_label_vector() {
         "c64f7d577b24a91e8879f60c3a2e4b88e1b3c1fbbdac8dbc09ee6757af252286"
     );
     assert!(!ambiguous);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #49: viewport-aware quadrant tests
+// ---------------------------------------------------------------------------
+
+/// Normalization without explicit viewport must produce identical output to the
+/// pre-existing default (800×600) behavior.
+#[test]
+fn test_normalize_dom_default_viewport_unchanged() {
+    let dom = build_positioned_document(100, 100); // top-left quadrant in 800×600
+    let default_result = normalize_dom(LoadProfile::Minimal, &dom).unwrap();
+    let explicit_default = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 800.0,
+            height: 600.0,
+        },
+    )
+    .unwrap();
+
+    // The stable_key must be identical because the viewport matches the default constants.
+    let body = &default_result.children[0].children[0];
+    let body_explicit = &explicit_default.children[0].children[0];
+    assert_eq!(
+        body.children[0].stable_key, body_explicit.children[0].stable_key,
+        "explicit 800×600 viewport must produce the same stable_key as the default"
+    );
+}
+
+/// An element at (450, 350) lands in bottom-right for 800×600 (x=450>400, y=350>300),
+/// but top-right in 1920×1080 (x=450<960, y=350<540).
+#[test]
+fn test_explicit_viewport_used_for_quadrant_calculation() {
+    let dom = build_positioned_document(450, 350);
+
+    let result_desktop = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 800.0,
+            height: 600.0,
+        },
+    )
+    .unwrap();
+
+    let result_wide = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 1920.0,
+            height: 1080.0,
+        },
+    )
+    .unwrap();
+
+    let key_desktop = result_desktop.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    let key_wide = result_wide.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+
+    assert_ne!(
+        key_desktop, key_wide,
+        "different viewports should yield different quadrant → different stable_key"
+    );
+}
+
+/// Desktop (1920×1080) vs mobile (375×812): element at (450, 100).
+/// Desktop: x=450 < 960 → left, y=100 < 540 → top ⇒ top_left
+/// Mobile:  x=450 > 187.5 → right, y=100 < 406 → top ⇒ top_right
+#[test]
+fn test_desktop_vs_mobile_viewport_different_quadrant() {
+    let dom = build_positioned_document(450, 100);
+
+    let result_desktop = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 1920.0,
+            height: 1080.0,
+        },
+    )
+    .unwrap();
+
+    let result_mobile = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 375.0,
+            height: 812.0,
+        },
+    )
+    .unwrap();
+
+    let key_desktop = result_desktop.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    let key_mobile = result_mobile.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+
+    assert_ne!(
+        key_desktop, key_mobile,
+        "desktop 1920×1080 and mobile 375×812 should yield different stable_keys for a straddling coordinate"
+    );
+}
+
+/// An element at (100, 100) is in the top-left quadrant of 800×600.
+/// The stable_key from explicit 800×600 viewport must match the default.
+#[test]
+fn test_top_left_quadrant_for_small_coordinate() {
+    let dom = build_positioned_document(100, 100);
+    let result = normalize_dom_with_viewport(
+        LoadProfile::Minimal,
+        &dom,
+        ViewportDimensions {
+            width: 800.0,
+            height: 600.0,
+        },
+    )
+    .unwrap();
+
+    let default_result = normalize_dom(LoadProfile::Minimal, &dom).unwrap();
+    let key_explicit = result.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    let key_default = default_result.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    assert_eq!(
+        key_explicit, key_default,
+        "top-left coordinate with explicit 800×600 must match default behavior"
+    );
 }

--- a/core-runtime/tests/stable_key_compatibility.rs
+++ b/core-runtime/tests/stable_key_compatibility.rs
@@ -418,26 +418,31 @@ fn test_browser_backed_viewport_affects_stable_key() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // HTML fixture: a button whose style places it near the center
-    // of a 1280x720 desktop layout. On a 375x812
-    // mobile layout that same CSS position falls in a different horizontal half.
+    // HTML fixture: a button at left:300px, top:200px.
+    //
+    // Quadrant math (x_ratio = left_px / window.innerWidth):
+    //   desktop  1280×720 → 300/1280 = 0.234 < 0.5 → Left half  → Top_Left
+    //   mobile    375×812 → 300/ 375 = 0.800 ≥ 0.5 → Right half → Top_Right
+    //
+    // left:640px would be ambiguous: 640/1280 = 0.5 (boundary → Right) and
+    // 640/375 = 1.71 (also Right), so both viewports give the same quadrant.
     let fixture_html = r#"<!DOCTYPE html><html><body style="margin:0;padding:0;">
 <button id="cta"
-        style="position:absolute;left:640px;top:360px;width:120px;height:40px;">
+        style="position:absolute;left:300px;top:200px;width:120px;height:40px;">
   Buy now
 </button>
 </body></html>"#;
 
     let url = format!("data:text/html,{}", urlencoding::encode(fixture_html));
 
-    // --- desktop viewport (1280x720): button at 640px is on the center edge ---
+    // --- desktop viewport (1280×720): 300/1280 = 0.234 → Left half → Top_Left ---
     let desktop = BrowserClient::new_with_window_size(1280, 720)?;
     let desktop_page = desktop.new_page()?;
     desktop_page.navigate(&url)?;
     assert_eq!(evaluate_viewport(&desktop_page)?, (1280, 720));
     let desktop_state = desktop_page.capture_semantic_state(LoadProfile::Interactive)?;
 
-    // --- mobile viewport (375x812): same button at 640px is to the right of the viewport ---
+    // --- mobile viewport (375×812): 300/375 = 0.800 → Right half → Top_Right ---
     let mobile = BrowserClient::new_with_window_size(375, 812)?;
     let mobile_page = mobile.new_page()?;
     mobile_page.navigate(&url)?;

--- a/core-runtime/tests/stable_key_compatibility.rs
+++ b/core-runtime/tests/stable_key_compatibility.rs
@@ -1,8 +1,10 @@
 use core_runtime::sre::StableKeyGenerator;
 use core_runtime::sre::{
-    normalize_dom, normalize_dom_with_viewport, LoadProfile, ViewportDimensions,
+    normalize_dom, normalize_dom_with_viewport, normalize_dom_with_viewport_and_refinement,
+    LoadProfile, SubtreeRefinementConfig, ViewportDimensions,
 };
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
 
 // ---------------------------------------------------------------------------
 // Helper builders (mirror normalization.rs test helpers)
@@ -293,5 +295,105 @@ fn test_top_left_quadrant_for_small_coordinate() {
     assert_eq!(
         key_explicit, key_default,
         "top-left coordinate with explicit 800×600 must match default behavior"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #65: viewport change must invalidate refinement-cached subtrees
+// ---------------------------------------------------------------------------
+
+/// Helper: build a cached path index for the positioned document returned by
+/// `build_positioned_document`.  The tree is:
+///   #document > html > body > div (with style) > #text
+/// Unique paths are all of them (no duplicate roles at any level).
+fn build_positioned_path_index(
+    root: &core_runtime::sre::SemanticNode,
+) -> HashMap<String, Vec<usize>> {
+    // Manually encode the index for the four-node chain.
+    // root/#document          -> []
+    // root/#document/html     -> [0]
+    // root/#document/html/body-> [0,0]
+    // root/#document/html/body/div -> [0,0,0]
+    // (text nodes are not indexed in the semantic path index)
+    let _ = root; // suppress unused warning; index is structure-driven
+    HashMap::from([
+        ("root/#document".to_string(), vec![]),
+        ("root/#document/html".to_string(), vec![0]),
+        ("root/#document/html/body".to_string(), vec![0, 0]),
+        ("root/#document/html/body/div".to_string(), vec![0, 0, 0]),
+    ])
+}
+
+/// Regression test for PR #65: when viewport changes between captures, the
+/// refinement path must recompute stable keys for ALL nodes — not just dirty
+/// ones — because quadrant calculation depends on viewport dimensions.
+///
+/// Scenario:
+///   1. First capture at default 800×600 viewport.
+///   2. Viewport changes to 375×812 (mobile emulation).
+///   3. A second capture uses the refinement path with an EMPTY dirty-path set
+///      (i.e., no DOM mutations were observed).
+///   4. The stable key for the positioned div must equal a fresh full capture
+///      at 375×812 — NOT the cached key from the 800×600 pass.
+#[test]
+fn test_refinement_cache_invalidated_on_viewport_change() {
+    // Element at (450, 100): top-right in 800×600 but also top-right in 375×812
+    // with different x-ratio (450 > 187.5 → right).  Use an element that
+    // straddles the midpoint differently so the stable key actually differs.
+    //
+    // Use (450, 350): bottom-right in 800×600 (x>400, y>300) but top-right in
+    // 1920×1080 (x<960, y<540).  The stable key must reflect the new viewport.
+    let dom = build_positioned_document(450, 350);
+
+    // --- step 1: initial capture at default 800×600 ---
+    let initial_800 =
+        normalize_dom_with_viewport(LoadProfile::Minimal, &dom, ViewportDimensions::default())
+            .unwrap();
+    let cached_path_index = build_positioned_path_index(&initial_800);
+
+    // --- step 2: second capture via refinement path, non-default viewport ---
+    let new_viewport = ViewportDimensions {
+        width: 1920.0,
+        height: 1080.0,
+    };
+    // No dirty paths: if caching were used, ALL nodes would be served from cache.
+    let empty_dirty: HashSet<String> = HashSet::new();
+
+    let refined = normalize_dom_with_viewport_and_refinement(
+        LoadProfile::Minimal,
+        &dom,
+        new_viewport,
+        SubtreeRefinementConfig {
+            dirty_paths: &empty_dirty,
+            cached_paths: &cached_path_index,
+            cached_root: &initial_800,
+        },
+    )
+    .unwrap();
+
+    // --- step 3: expected result — full fresh capture at new viewport ---
+    let expected = normalize_dom_with_viewport(LoadProfile::Minimal, &dom, new_viewport).unwrap();
+
+    // The div is at children[0].children[0].children[0]
+    let refined_key = refined.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    let expected_key = expected.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+    let cached_key = initial_800.children[0].children[0].children[0]
+        .stable_key
+        .clone()
+        .unwrap();
+
+    assert_eq!(
+        refined_key, expected_key,
+        "refinement path with non-default viewport must produce the same key as a fresh full capture"
+    );
+    assert_ne!(
+        refined_key, cached_key,
+        "refinement path must NOT reuse the cached key from the old viewport"
     );
 }

--- a/core-runtime/tests/stable_key_compatibility.rs
+++ b/core-runtime/tests/stable_key_compatibility.rs
@@ -3,6 +3,7 @@ use core_runtime::sre::{
     normalize_dom, normalize_dom_with_viewport, normalize_dom_with_viewport_and_refinement,
     LoadProfile, SubtreeRefinementConfig, ViewportDimensions,
 };
+use core_runtime::{BrowserClient, PageSession};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
@@ -396,4 +397,100 @@ fn test_refinement_cache_invalidated_on_viewport_change() {
         refined_key, cached_key,
         "refinement path must NOT reuse the cached key from the old viewport"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Browser-backed smoke test: actual viewport from running Chrome
+// Skipped automatically if Chrome is not available (CI-friendly).
+// ---------------------------------------------------------------------------
+
+/// Smoke test: start two real Chrome instances with different window sizes
+/// (desktop 1280x720 vs mobile 375x812), load the same fixture HTML, and
+/// confirm that an element straddling a quadrant boundary gets a different
+/// stable_key in each run.
+///
+/// This is the automated equivalent of the manual smoke test:
+/// "navigate to a page with a wide viewport and confirm stable_key quadrant
+/// differs from a narrow viewport for straddling elements."
+#[test]
+fn test_browser_backed_viewport_affects_stable_key() -> anyhow::Result<()> {
+    if !core_runtime::chrome_available() {
+        return Ok(());
+    }
+
+    // HTML fixture: a button whose style places it near the center
+    // of a 1280x720 desktop layout. On a 375x812
+    // mobile layout that same CSS position falls in a different horizontal half.
+    let fixture_html = r#"<!DOCTYPE html><html><body style="margin:0;padding:0;">
+<button id="cta"
+        style="position:absolute;left:640px;top:360px;width:120px;height:40px;">
+  Buy now
+</button>
+</body></html>"#;
+
+    let url = format!("data:text/html,{}", urlencoding::encode(fixture_html));
+
+    // --- desktop viewport (1280x720): button at 640px is on the center edge ---
+    let desktop = BrowserClient::new_with_window_size(1280, 720)?;
+    let desktop_page = desktop.new_page()?;
+    desktop_page.navigate(&url)?;
+    assert_eq!(evaluate_viewport(&desktop_page)?, (1280, 720));
+    let desktop_state = desktop_page.capture_semantic_state(LoadProfile::Interactive)?;
+
+    // --- mobile viewport (375x812): same button at 640px is to the right of the viewport ---
+    let mobile = BrowserClient::new_with_window_size(375, 812)?;
+    let mobile_page = mobile.new_page()?;
+    mobile_page.navigate(&url)?;
+    assert_eq!(evaluate_viewport(&mobile_page)?, (375, 812));
+    let mobile_state = mobile_page.capture_semantic_state(LoadProfile::Interactive)?;
+
+    // Extract the stable_key for the "Buy now" button in both captures.
+    fn find_button_key(state: &core_runtime::sre::SemanticState) -> Option<String> {
+        fn search(node: &core_runtime::sre::SemanticNode) -> Option<String> {
+            if node.role.as_str() == "button" {
+                return node.stable_key.clone();
+            }
+            for child in &node.children {
+                if let Some(k) = search(child) {
+                    return Some(k);
+                }
+            }
+            None
+        }
+        search(state.root())
+    }
+
+    let desktop_key =
+        find_button_key(&desktop_state).expect("desktop capture must find the button");
+    let mobile_key = find_button_key(&mobile_state).expect("mobile capture must find the button");
+
+    assert_ne!(
+        desktop_key, mobile_key,
+        "stable_key for an element straddling a quadrant boundary must differ \
+         between desktop (1280x720) and mobile (375x812) viewports\n\
+         desktop key: {desktop_key}\n\
+         mobile  key: {mobile_key}"
+    );
+
+    Ok(())
+}
+
+fn evaluate_viewport(page: &PageSession) -> anyhow::Result<(u32, u32)> {
+    let value = page.evaluate_script(
+        "JSON.stringify({width: window.innerWidth, height: window.innerHeight})",
+    )?;
+    let raw = value
+        .value
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .ok_or_else(|| anyhow::anyhow!("viewport script did not return a JSON string"))?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw)?;
+    let width = parsed
+        .get("width")
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("viewport width was missing"))?;
+    let height = parsed
+        .get("height")
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("viewport height was missing"))?;
+    Ok((width as u32, height as u32))
 }


### PR DESCRIPTION
## Summary

Closes #49

- Added `ViewportDimensions` struct (`width: f64`, `height: f64`) with a `Default` impl that returns the existing 800×600 fallback constants — existing callers are unaffected
- Added `normalize_dom_with_viewport(profile, node, viewport)` and `normalize_dom_with_viewport_and_refinement(profile, node, viewport, refinement)` public functions that thread viewport through `traverse_node` → `resolve_quadrant` → coordinate extraction
- Removed the hardcoded `DEFAULT_VIEWPORT_WIDTH_PX`/`DEFAULT_VIEWPORT_HEIGHT_PX` from `extract_x_ratio`/`extract_y_ratio`; they now accept the viewport as a parameter
- Added `PageSession::get_viewport_dimensions()` which evaluates `window.innerWidth`/`window.innerHeight` via CDP; falls back to defaults on any error (best-effort, never panics)
- `capture_state_with_refinement` and `capture_som` now call the viewport-aware normalization paths
- Added `BrowserClient::new_with_window_size(width, height)` using CDP `Emulation.SetDeviceMetricsOverride` so `window.innerWidth` reflects the given dimensions in the running browser

## Acceptance criteria

- normalization can be run with an explicit viewport ✓
- browser-backed captures use actual viewport dimensions ✓ (`PageSession` retrieves dimensions per capture)
- tests cover desktop and mobile viewport differences ✓
- compatibility snapshot changes are intentional and documented ✓ (`normalize_dom` (no viewport) is unchanged; hash vectors in `stable_key_compatibility.rs` still pass)

## Test results

```
running 9 tests
test test_stable_key_hash_compatibility_none_label_vector ... ok
test test_stable_key_hash_compatibility_non_ascii_label_vector ... ok
test test_stable_key_hash_compatibility_vectors ... ok
test test_normalize_dom_default_viewport_unchanged ... ok
test test_desktop_vs_mobile_viewport_different_quadrant ... ok
test test_top_left_quadrant_for_small_coordinate ... ok
test test_refinement_cache_invalidated_on_viewport_change ... ok
test test_explicit_viewport_used_for_quadrant_calculation ... ok
test test_browser_backed_viewport_affects_stable_key ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured

(+ 26 lib tests pass, 0 clippy warnings, fmt clean)
```

## Test plan

- [x] Verify `cargo test -p core-runtime --test stable_key_compatibility` passes (9 tests)
- [x] Verify `cargo test -p core-runtime --lib` passes (26 tests)
- [x] Verify `cargo clippy --workspace -- -D warnings` produces no warnings
- [x] Browser-backed smoke test: `test_browser_backed_viewport_affects_stable_key` starts real Chrome at 1280×720 and 375×812, loads the same fixture HTML (button at `left:300px`), and asserts the stable_key quadrant differs (`300/1280=0.234` → Top_Left vs `300/375=0.800` → Top_Right). Viewport is set via CDP `Emulation.SetDeviceMetricsOverride` so `window.innerWidth` accurately reflects the given size.