### PR TITLE
[PR-27] Unified PII Redactor Utility

### DIFF
--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -1,11 +1,11 @@
+use crate::privacy;
 use crate::sre::SemanticState;
 use crossbeam_channel::{unbounded, Sender};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::VecDeque,
     env,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex},
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -200,6 +200,7 @@ fn push_recent_event(
 }
 
 fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
+    let r = privacy::global();
     match event {
         AuditEvent::ToolCall {
             tool_name,
@@ -207,7 +208,7 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             timestamp,
         } => AuditEvent::ToolCall {
             tool_name,
-            args: redact_json_value(&args, None, true),
+            args: r.redact_json_tool_args(&args),
             timestamp,
         },
         AuditEvent::StateSnapshot {
@@ -219,7 +220,7 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             state_hash,
             page_instance_id,
             timestamp,
-            payload: redact_json_value(&payload, None, false),
+            payload: r.redact_json(&payload),
         },
         AuditEvent::StatePatch {
             state_hash,
@@ -230,7 +231,7 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             state_hash,
             page_instance_id,
             timestamp,
-            patch: redact_json_value(&patch, None, false),
+            patch: r.redact_json(&patch),
         },
         // Plugin-supplied strings (error_message, reason) may contain PII from
         // page content (URLs with tokens, emails, etc.).  Truncate them to a safe
@@ -245,7 +246,7 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             success,
             error_message: error_message
                 .as_deref()
-                .map(redact_sensitive_text)
+                .map(|s| r.redact_text(s))
                 .map(|s| truncate_plugin_string(&s)),
             timestamp,
         },
@@ -259,7 +260,7 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             allowed,
             reason: reason
                 .as_deref()
-                .map(redact_sensitive_text)
+                .map(|s| r.redact_text(s))
                 .map(|s| truncate_plugin_string(&s)),
             timestamp,
         },
@@ -313,94 +314,18 @@ fn epoch_millis_u64() -> u64 {
         .as_millis() as u64
 }
 
-fn redact_json_value(
-    value: &serde_json::Value,
-    key_hint: Option<&str>,
-    mask_tool_value_field: bool,
-) -> serde_json::Value {
-    match value {
-        serde_json::Value::Object(map) => {
-            let mut redacted = serde_json::Map::with_capacity(map.len());
-            for (key, child) in map {
-                let key_lower = key.to_ascii_lowercase();
-                let masked_child = if is_sensitive_key(&key_lower)
-                    || (mask_tool_value_field && should_mask_tool_argument_key(&key_lower))
-                {
-                    serde_json::Value::String("***".to_string())
-                } else {
-                    redact_json_value(child, Some(key_lower.as_str()), mask_tool_value_field)
-                };
-                redacted.insert(key.clone(), masked_child);
-            }
-            serde_json::Value::Object(redacted)
-        }
-        serde_json::Value::Array(items) => serde_json::Value::Array(
-            items
-                .iter()
-                .map(|item| redact_json_value(item, key_hint, mask_tool_value_field))
-                .collect(),
-        ),
-        serde_json::Value::String(text) => {
-            if key_hint.is_some_and(is_sensitive_key) {
-                serde_json::Value::String("***".to_string())
-            } else {
-                serde_json::Value::String(redact_sensitive_text(text))
-            }
-        }
-        _ => value.clone(),
-    }
-}
-
-fn should_mask_tool_argument_key(key: &str) -> bool {
-    key == "value" || key == "text" || key.ends_with("_text")
-}
-
-fn is_sensitive_key(key: &str) -> bool {
-    matches!(
-        key,
-        "password"
-            | "passwd"
-            | "email"
-            | "token"
-            | "secret"
-            | "authorization"
-            | "auth"
-            | "card"
-            | "credit_card"
-            | "cc"
-            | "cvv"
-            | "cvc"
-    ) || key.contains("password")
-        || key.contains("email")
-        || key.contains("token")
-        || key.contains("secret")
-        || key.contains("card")
-}
-
-fn redact_sensitive_text(text: &str) -> String {
-    static CC_RE: OnceLock<Regex> = OnceLock::new();
-    static EMAIL_RE: OnceLock<Regex> = OnceLock::new();
-
-    let cc_re =
-        CC_RE.get_or_init(|| Regex::new(r"\b\d(?:[ -]?\d){12,18}\b").expect("Invalid CC regex"));
-    let email_re = EMAIL_RE.get_or_init(|| {
-        Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b").expect("Invalid email regex")
-    });
-
-    let cc_redacted = cc_re.replace_all(text, "****-****-****-XXXX");
-    email_re.replace_all(&cc_redacted, "***").into_owned()
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        redact_sensitive_text, sanitize_audit_event, truncate_plugin_string, AuditEvent,
-        AuditLogger, MAX_PLUGIN_STRING_LEN,
+        sanitize_audit_event, truncate_plugin_string, AuditEvent, AuditLogger,
+        MAX_PLUGIN_STRING_LEN,
     };
+    use crate::privacy::PiiRedactor;
     use serde_json::json;
 
     #[test]
     fn redact_sensitive_text_masks_card_numbers_up_to_nineteen_digits() {
+        let r = PiiRedactor::new();
         let cases = [
             (
                 "Card 4111-1111-1111-1111 for alice@example.com",
@@ -417,7 +342,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            assert_eq!(redact_sensitive_text(input), expected);
+            assert_eq!(r.redact_text(input), expected);
         }
     }
 

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -3,6 +3,7 @@ pub mod browser;
 pub mod chrome_detection;
 pub mod plugin_hooks;
 pub mod policy;
+pub mod privacy;
 pub mod session_vault;
 pub mod sre;
 

--- a/core-runtime/src/privacy.rs
+++ b/core-runtime/src/privacy.rs
@@ -1,0 +1,485 @@
+use regex::Regex;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use crate::sre::state::{FastSemanticState, FullSemanticState, SemanticNode};
+
+/// A named regex pattern for domain-specific PII detection.
+///
+/// Domain patterns are registered at startup and applied by `PiiRedactor`
+/// alongside the built-in email and credit-card patterns.
+pub struct DomainPattern {
+    pub name: String,
+    regex: Regex,
+    replacement: String,
+}
+
+impl DomainPattern {
+    /// Build a domain pattern.  Returns an error if `pattern` is not valid regex.
+    pub fn new(
+        name: impl Into<String>,
+        pattern: &str,
+        replacement: impl Into<String>,
+    ) -> Result<Self, regex::Error> {
+        Ok(Self {
+            name: name.into(),
+            regex: Regex::new(pattern)?,
+            replacement: replacement.into(),
+        })
+    }
+}
+
+/// Centralized, forced-hook PII redactor.
+///
+/// Two hook points are mandated by the spec (Section 3.8):
+/// - Exit of the SRE Queue (`redact_semantic_*` methods).
+/// - Entry of the Audit Sink (`redact_json` / `redact_text` methods).
+///
+/// Domain-specific patterns can be added at startup to support the Wasm plugin
+/// extension point described in ISSUE-17.
+pub struct PiiRedactor {
+    domain_patterns: Vec<DomainPattern>,
+}
+
+impl PiiRedactor {
+    /// Construct a redactor with only the built-in patterns.
+    pub fn new() -> Self {
+        Self {
+            domain_patterns: Vec::new(),
+        }
+    }
+
+    /// Construct a redactor with additional domain-specific patterns.
+    pub fn with_domain_patterns(domain_patterns: Vec<DomainPattern>) -> Self {
+        Self { domain_patterns }
+    }
+
+    // -------------------------------------------------------------------------
+    // Text-level redaction
+    // -------------------------------------------------------------------------
+
+    /// Redact PII embedded in freeform text (email addresses, card numbers,
+    /// then domain patterns).
+    pub fn redact_text(&self, text: &str) -> String {
+        static CC_RE: OnceLock<Regex> = OnceLock::new();
+        static EMAIL_RE: OnceLock<Regex> = OnceLock::new();
+
+        let cc_re = CC_RE
+            .get_or_init(|| Regex::new(r"\b\d(?:[ -]?\d){12,18}\b").expect("Invalid CC regex"));
+        let email_re = EMAIL_RE.get_or_init(|| {
+            Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
+                .expect("Invalid email regex")
+        });
+
+        let after_cc = cc_re.replace_all(text, "****-****-****-XXXX");
+        let after_email = email_re.replace_all(after_cc.as_ref(), "***");
+
+        // Apply domain-specific patterns sequentially.
+        let mut result = after_email.into_owned();
+        for dp in &self.domain_patterns {
+            let replaced = dp.regex.replace_all(&result, dp.replacement.as_str());
+            if matches!(replaced, std::borrow::Cow::Owned(_)) {
+                result = replaced.into_owned();
+            }
+        }
+        result
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON-level redaction
+    // -------------------------------------------------------------------------
+
+    /// Deep-redact a JSON value destined for the Audit Sink (state payloads).
+    pub fn redact_json(&self, value: &Value) -> Value {
+        self.redact_json_inner(value, None, false)
+    }
+
+    /// Deep-redact a JSON value representing tool-call arguments.
+    ///
+    /// In addition to key-based masking, this also masks `value` / `text`
+    /// fields that commonly carry raw user input to interactive elements.
+    pub fn redact_json_tool_args(&self, value: &Value) -> Value {
+        self.redact_json_inner(value, None, true)
+    }
+
+    fn redact_json_inner(
+        &self,
+        value: &Value,
+        key_hint: Option<&str>,
+        mask_tool_value_field: bool,
+    ) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut out = serde_json::Map::with_capacity(map.len());
+                for (key, child) in map {
+                    let key_lower = key.to_ascii_lowercase();
+                    let masked = if Self::is_sensitive_key(&key_lower)
+                        || (mask_tool_value_field && Self::is_tool_value_key(&key_lower))
+                    {
+                        Value::String("***".to_string())
+                    } else {
+                        self.redact_json_inner(
+                            child,
+                            Some(key_lower.as_str()),
+                            mask_tool_value_field,
+                        )
+                    };
+                    out.insert(key.clone(), masked);
+                }
+                Value::Object(out)
+            }
+            Value::Array(items) => Value::Array(
+                items
+                    .iter()
+                    .map(|item| self.redact_json_inner(item, key_hint, mask_tool_value_field))
+                    .collect(),
+            ),
+            Value::String(text) => {
+                if key_hint.is_some_and(Self::is_sensitive_key) {
+                    Value::String("***".to_string())
+                } else {
+                    Value::String(self.redact_text(text))
+                }
+            }
+            _ => value.clone(),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // SRE state redaction (exit hook for SRE Queue)
+    // -------------------------------------------------------------------------
+
+    /// Redact PII in a `FastSemanticState` before it leaves the SRE queue.
+    pub fn redact_fast_state(&self, state: FastSemanticState) -> FastSemanticState {
+        FastSemanticState {
+            interactive_elements: state
+                .interactive_elements
+                .into_iter()
+                .map(|n| self.redact_node(n))
+                .collect(),
+            messages: state
+                .messages
+                .into_iter()
+                .map(|n| self.redact_node(n))
+                .collect(),
+        }
+    }
+
+    /// Redact PII in a `FullSemanticState` before it leaves the SRE queue.
+    pub fn redact_full_state(&self, state: FullSemanticState) -> FullSemanticState {
+        FullSemanticState {
+            forms: state
+                .forms
+                .into_iter()
+                .map(|n| self.redact_node(n))
+                .collect(),
+            regions: state
+                .regions
+                .into_iter()
+                .map(|n| self.redact_node(n))
+                .collect(),
+        }
+    }
+
+    fn redact_node(&self, node: SemanticNode) -> SemanticNode {
+        let label = node.label.map(|l| {
+            if Self::is_sensitive_role(&node.role) {
+                "***".to_string()
+            } else {
+                self.redact_text(&l)
+            }
+        });
+
+        let alias = node.alias.map(|a| self.redact_text(&a));
+
+        let attributes = node.attributes.map(|attrs| {
+            // Detect context: if any attribute declares a sensitive type (e.g.
+            // type="password"), treat the `value` attribute as sensitive too.
+            let has_sensitive_type = attrs
+                .get("type")
+                .is_some_and(|t| matches!(t.to_ascii_lowercase().as_str(), "password" | "hidden"));
+            attrs
+                .into_iter()
+                .map(|(k, v)| {
+                    let k_lower = k.to_ascii_lowercase();
+                    let v_redacted = if Self::is_sensitive_key(&k_lower)
+                        || (has_sensitive_type && k_lower == "value")
+                    {
+                        "***".to_string()
+                    } else {
+                        self.redact_text(&v)
+                    };
+                    (k, v_redacted)
+                })
+                .collect::<BTreeMap<_, _>>()
+        });
+
+        SemanticNode {
+            role: node.role,
+            label,
+            children: node
+                .children
+                .into_iter()
+                .map(|c| self.redact_node(c))
+                .collect(),
+            attributes,
+            stable_key: node.stable_key,
+            ambiguous: node.ambiguous,
+            alias,
+            backend_node_id: node.backend_node_id,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Key classification helpers (pub(crate) for tests in audit.rs)
+    // -------------------------------------------------------------------------
+
+    pub(crate) fn is_sensitive_key(key: &str) -> bool {
+        matches!(
+            key,
+            "password"
+                | "passwd"
+                | "email"
+                | "token"
+                | "secret"
+                | "authorization"
+                | "auth"
+                | "card"
+                | "credit_card"
+                | "cc"
+                | "cvv"
+                | "cvc"
+        ) || key.contains("password")
+            || key.contains("email")
+            || key.contains("token")
+            || key.contains("secret")
+            || key.contains("card")
+    }
+
+    fn is_tool_value_key(key: &str) -> bool {
+        key == "value" || key == "text" || key.ends_with("_text")
+    }
+
+    /// Returns true for HTML roles that typically carry sensitive user input.
+    fn is_sensitive_role(role: &str) -> bool {
+        matches!(role, "password" | "credit-card" | "creditcard")
+    }
+}
+
+impl Default for PiiRedactor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global default instance
+// ---------------------------------------------------------------------------
+
+static GLOBAL_REDACTOR: OnceLock<PiiRedactor> = OnceLock::new();
+
+/// Return a reference to the process-wide default `PiiRedactor`.
+///
+/// This is the instance used by both the Audit Sink and SRE Queue hooks.
+/// Call `register_global_redactor` before the first pipeline invocation to
+/// swap in a redactor with domain-specific patterns.
+pub fn global() -> &'static PiiRedactor {
+    GLOBAL_REDACTOR.get_or_init(PiiRedactor::new)
+}
+
+/// Register a custom redactor as the global instance.
+///
+/// Must be called before the first call to `global()`.  Returns `Ok(())` on
+/// success, or `Err(redactor)` if the global was already initialised.
+pub fn register_global_redactor(redactor: PiiRedactor) -> Result<(), PiiRedactor> {
+    GLOBAL_REDACTOR.set(redactor)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn redactor() -> PiiRedactor {
+        PiiRedactor::new()
+    }
+
+    // -- redact_text ----------------------------------------------------------
+
+    #[test]
+    fn redact_text_masks_email() {
+        let r = redactor();
+        assert_eq!(
+            r.redact_text("contact alice@example.com now"),
+            "contact *** now"
+        );
+    }
+
+    #[test]
+    fn redact_text_masks_credit_card() {
+        let r = redactor();
+        assert_eq!(
+            r.redact_text("Card 4111-1111-1111-1111 ok"),
+            "Card ****-****-****-XXXX ok"
+        );
+    }
+
+    #[test]
+    fn redact_text_masks_both_in_one_string() {
+        let r = redactor();
+        let input = "Card 4111-1111-1111-1111 for alice@example.com";
+        let output = r.redact_text(input);
+        assert_eq!(output, "Card ****-****-****-XXXX for ***");
+    }
+
+    #[test]
+    fn redact_text_no_pii_returns_same_content() {
+        let r = redactor();
+        let input = "Hello world, no PII here";
+        assert_eq!(r.redact_text(input), input);
+    }
+
+    #[test]
+    fn redact_text_applies_domain_pattern() {
+        let dp = DomainPattern::new("ssn", r"\b\d{3}-\d{2}-\d{4}\b", "[SSN]").unwrap();
+        let r = PiiRedactor::with_domain_patterns(vec![dp]);
+        assert_eq!(r.redact_text("SSN is 123-45-6789"), "SSN is [SSN]");
+    }
+
+    // -- redact_json ----------------------------------------------------------
+
+    #[test]
+    fn redact_json_masks_sensitive_keys() {
+        let r = redactor();
+        let input =
+            json!({ "username": "alice", "password": "s3cr3t", "email": "alice@example.com" });
+        let output = r.redact_json(&input);
+        assert_eq!(output["username"], "alice");
+        assert_eq!(output["password"], "***");
+        assert_eq!(output["email"], "***");
+    }
+
+    #[test]
+    fn redact_json_masks_inline_pii_in_string_values() {
+        let r = redactor();
+        let input = json!({ "message": "send to alice@example.com" });
+        let output = r.redact_json(&input);
+        assert_eq!(output["message"], "send to ***");
+    }
+
+    #[test]
+    fn redact_json_recurses_into_arrays() {
+        let r = redactor();
+        let input = json!([{ "password": "x" }, { "ok": "y" }]);
+        let output = r.redact_json(&input);
+        assert_eq!(output[0]["password"], "***");
+        assert_eq!(output[1]["ok"], "y");
+    }
+
+    // -- redact_json_tool_args ------------------------------------------------
+
+    #[test]
+    fn redact_json_tool_args_masks_value_and_text_fields() {
+        let r = redactor();
+        let input = json!({ "selector": "#email", "value": "alice@example.com" });
+        let output = r.redact_json_tool_args(&input);
+        assert_eq!(output["selector"], "#email");
+        assert_eq!(output["value"], "***");
+    }
+
+    // -- redact_fast_state ----------------------------------------------------
+
+    #[test]
+    fn redact_fast_state_masks_node_labels_with_pii() {
+        let r = redactor();
+        let node = SemanticNode {
+            role: "input".to_string(),
+            label: Some("alice@example.com".to_string()),
+            children: vec![],
+            attributes: None,
+            stable_key: None,
+            ambiguous: false,
+            alias: None,
+            backend_node_id: 0,
+        };
+        let state = FastSemanticState {
+            interactive_elements: vec![node],
+            messages: vec![],
+        };
+        let redacted = r.redact_fast_state(state);
+        assert_eq!(
+            redacted.interactive_elements[0].label.as_deref(),
+            Some("***")
+        );
+    }
+
+    #[test]
+    fn redact_fast_state_masks_sensitive_attribute_values() {
+        let r = redactor();
+        let mut attrs = BTreeMap::new();
+        attrs.insert("name".to_string(), "email".to_string());
+        attrs.insert("value".to_string(), "user@example.com".to_string());
+        let node = SemanticNode {
+            role: "input".to_string(),
+            label: None,
+            children: vec![],
+            attributes: Some(attrs),
+            stable_key: None,
+            ambiguous: false,
+            alias: None,
+            backend_node_id: 0,
+        };
+        let state = FastSemanticState {
+            interactive_elements: vec![node],
+            messages: vec![],
+        };
+        let redacted = r.redact_fast_state(state);
+        let attrs = redacted.interactive_elements[0]
+            .attributes
+            .as_ref()
+            .unwrap();
+        // "name" key is not sensitive; "value" attribute key is not either,
+        // but the value itself contains an email pattern → should be masked.
+        assert_eq!(attrs["value"], "***");
+    }
+
+    #[test]
+    fn redact_full_state_masks_nodes_in_forms() {
+        let r = redactor();
+        let node = SemanticNode {
+            role: "input".to_string(),
+            label: Some("Card 4111-1111-1111-1111".to_string()),
+            children: vec![],
+            attributes: None,
+            stable_key: None,
+            ambiguous: false,
+            alias: None,
+            backend_node_id: 0,
+        };
+        let state = FullSemanticState {
+            forms: vec![node],
+            regions: vec![],
+        };
+        let redacted = r.redact_full_state(state);
+        assert_eq!(
+            redacted.forms[0].label.as_deref(),
+            Some("Card ****-****-****-XXXX")
+        );
+    }
+
+    // -- is_sensitive_key -----------------------------------------------------
+
+    #[test]
+    fn is_sensitive_key_catches_substrings() {
+        assert!(PiiRedactor::is_sensitive_key("user_password"));
+        assert!(PiiRedactor::is_sensitive_key("email_address"));
+        assert!(PiiRedactor::is_sensitive_key("api_token"));
+        assert!(!PiiRedactor::is_sensitive_key("username"));
+        assert!(!PiiRedactor::is_sensitive_key("role"));
+    }
+}

--- a/core-runtime/src/privacy.rs
+++ b/core-runtime/src/privacy.rs
@@ -290,10 +290,26 @@ pub fn global() -> &'static PiiRedactor {
 
 /// Register a custom redactor as the global instance.
 ///
-/// Must be called before the first call to `global()`.  Returns `Ok(())` on
-/// success, or `Err(redactor)` if the global was already initialised.
+/// **Must be called before any pipeline is constructed** (i.e. before the first
+/// call to `AsyncPipeline::new` or `AuditLogger::log`). Both call `global()`
+/// on first use, locking in the default bare `PiiRedactor`; any registration
+/// attempt after that point is silently discarded.
+///
+/// Returns `Ok(())` on success or `Err(redactor)` if the global was already
+/// initialised (indicating a too-late call — log a warning and investigate the
+/// startup ordering).
 pub fn register_global_redactor(redactor: PiiRedactor) -> Result<(), PiiRedactor> {
-    GLOBAL_REDACTOR.set(redactor)
+    match GLOBAL_REDACTOR.set(redactor) {
+        Ok(()) => Ok(()),
+        Err(r) => {
+            eprintln!(
+                "[PRIVACY][WARN] register_global_redactor called after global() was already \
+                 initialised — domain-specific PII patterns will NOT take effect. \
+                 Call register_global_redactor before constructing AsyncPipeline or AuditLogger."
+            );
+            Err(r)
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/core-runtime/src/sre/pipeline.rs
+++ b/core-runtime/src/sre/pipeline.rs
@@ -11,6 +11,7 @@ use crossbeam_channel::{bounded, Receiver, RecvTimeoutError, Sender, TryRecvErro
 use thiserror::Error;
 
 use super::{FastSemanticState, FullSemanticState, SemanticState};
+use crate::privacy;
 
 const SRE_QUEUE_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
@@ -329,16 +330,19 @@ fn spawn_sre_worker(
 }
 
 fn process_sre_task(task: SreTask, metrics: &PipelineMetricsInner, full_stage_delay: Duration) {
+    let redactor = privacy::global();
     match task {
         SreTask::Fast { state, tx } => {
-            let _ = tx.send(state.generate_fast_state());
+            let redacted = redactor.redact_fast_state(state.generate_fast_state());
+            let _ = tx.send(redacted);
             metrics.fast_completed.fetch_add(1, Ordering::Relaxed);
         }
         SreTask::Full { state, tx } => {
             if !full_stage_delay.is_zero() {
                 thread::sleep(full_stage_delay);
             }
-            let _ = tx.send(state.generate_full_state());
+            let redacted = redactor.redact_full_state(state.generate_full_state());
+            let _ = tx.send(redacted);
             metrics.full_completed.fetch_add(1, Ordering::Relaxed);
         }
     }

--- a/core-runtime/tests/pii_redaction.rs
+++ b/core-runtime/tests/pii_redaction.rs
@@ -1,0 +1,304 @@
+/// Integration tests verifying that PII never leaks through the SRE pipeline
+/// or the Audit Sink (Exit Criteria for PR-27 / ISSUE-17).
+use core_runtime::{
+    audit::{AuditEvent, AuditLogger},
+    privacy::{DomainPattern, PiiRedactor},
+    sre::{AsyncPipeline, AsyncPipelineConfig, LoadProfile, SemanticNode, SemanticState},
+};
+use serde_json::json;
+use std::{collections::BTreeMap, time::Duration};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn node_with_label(role: &str, label: &str) -> SemanticNode {
+    SemanticNode {
+        role: role.to_string(),
+        label: Some(label.to_string()),
+        children: vec![],
+        attributes: None,
+        stable_key: None,
+        ambiguous: false,
+        alias: None,
+        backend_node_id: 0,
+    }
+}
+
+fn node_with_attrs(role: &str, attrs: BTreeMap<String, String>) -> SemanticNode {
+    SemanticNode {
+        role: role.to_string(),
+        label: None,
+        children: vec![],
+        attributes: Some(attrs),
+        stable_key: None,
+        ambiguous: false,
+        alias: None,
+        backend_node_id: 0,
+    }
+}
+
+fn simple_state(root: SemanticNode) -> SemanticState {
+    SemanticState::new(root, LoadProfile::default())
+}
+
+// ---------------------------------------------------------------------------
+// PiiRedactor unit-level integration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pii_redactor_masks_email_and_cc_in_text() {
+    let r = PiiRedactor::new();
+    let out = r.redact_text("Pay 4111-1111-1111-1111 or email alice@example.com");
+    assert!(!out.contains("4111"), "credit card must be masked");
+    assert!(!out.contains("alice@example.com"), "email must be masked");
+    assert!(out.contains("****-****-****-XXXX"));
+    assert!(out.contains("***"));
+}
+
+#[test]
+fn pii_redactor_domain_pattern_masks_ssn() {
+    // US SSN format (9 digits with dashes) does not match the CC regex (13-19 digits),
+    // so it should be caught exclusively by the domain pattern.
+    let dp = DomainPattern::new("ssn", r"\b\d{3}-\d{2}-\d{4}\b", "[SSN]").unwrap();
+    let r = PiiRedactor::with_domain_patterns(vec![dp]);
+    let out = r.redact_text("SSN: 123-45-6789 on file");
+    assert!(!out.contains("123-45-6789"), "SSN must be masked");
+    assert!(out.contains("[SSN]"));
+}
+
+#[test]
+fn pii_redactor_json_masks_password_field() {
+    let r = PiiRedactor::new();
+    let input = json!({ "username": "alice", "password": "secret123" });
+    let out = r.redact_json(&input);
+    assert_eq!(out["username"], "alice");
+    assert_eq!(out["password"], "***");
+}
+
+#[test]
+fn pii_redactor_json_tool_args_masks_value_field() {
+    let r = PiiRedactor::new();
+    let input = json!({ "selector": "#email-input", "value": "bob@example.com" });
+    let out = r.redact_json_tool_args(&input);
+    assert_eq!(out["selector"], "#email-input");
+    assert_eq!(out["value"], "***");
+}
+
+// ---------------------------------------------------------------------------
+// SRE pipeline exit hook
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sre_pipeline_fast_state_has_email_masked() {
+    let cfg = AsyncPipelineConfig {
+        render_queue_capacity: 4,
+        sre_queue_capacity: 4,
+        audit_queue_capacity: 4,
+        ..Default::default()
+    };
+    let pipeline = AsyncPipeline::new(cfg);
+
+    let root = SemanticNode {
+        role: "root".to_string(),
+        label: None,
+        children: vec![node_with_label("input", "alice@example.com")],
+        attributes: None,
+        stable_key: None,
+        ambiguous: false,
+        alias: None,
+        backend_node_id: 0,
+    };
+
+    let handle = pipeline
+        .submit_state(simple_state(root))
+        .expect("submit should succeed");
+
+    let fast = handle
+        .recv_fast(Duration::from_millis(500))
+        .expect("should receive fast state");
+
+    for elem in &fast.interactive_elements {
+        if let Some(label) = &elem.label {
+            assert!(
+                !label.contains("alice@example.com"),
+                "email must not appear in SRE fast state label: {label}"
+            );
+        }
+    }
+}
+
+#[test]
+fn sre_pipeline_fast_state_masks_cc_in_node_label() {
+    let cfg = AsyncPipelineConfig::default();
+    let pipeline = AsyncPipeline::new(cfg);
+
+    let root = SemanticNode {
+        role: "root".to_string(),
+        label: None,
+        children: vec![node_with_label("button", "Pay 4111-1111-1111-1111 now")],
+        attributes: None,
+        stable_key: None,
+        ambiguous: false,
+        alias: None,
+        backend_node_id: 0,
+    };
+
+    let handle = pipeline
+        .submit_state(simple_state(root))
+        .expect("submit should succeed");
+
+    let fast = handle
+        .recv_fast(Duration::from_millis(500))
+        .expect("should receive fast state");
+
+    for elem in &fast.interactive_elements {
+        if let Some(label) = &elem.label {
+            assert!(
+                !label.contains("4111"),
+                "credit card must not appear in SRE fast state: {label}"
+            );
+        }
+    }
+}
+
+#[test]
+fn sre_pipeline_full_state_masks_sensitive_attribute_values() {
+    let cfg = AsyncPipelineConfig::default();
+    let pipeline = AsyncPipeline::new(cfg);
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert("type".to_string(), "password".to_string());
+    attrs.insert("value".to_string(), "my-secret-password".to_string());
+
+    let root = SemanticNode {
+        role: "form".to_string(),
+        label: None,
+        children: vec![node_with_attrs("input", attrs)],
+        attributes: None,
+        stable_key: None,
+        ambiguous: false,
+        alias: None,
+        backend_node_id: 0,
+    };
+
+    let handle = pipeline
+        .submit_state(simple_state(root))
+        .expect("submit should succeed");
+
+    let full = handle
+        .recv_full(Duration::from_millis(500))
+        .expect("should receive full state");
+
+    // The full state collects form nodes and their children (projected flat).
+    // The input child node should have its `value` attribute masked because
+    // the sibling attribute `type="password"` marks it as sensitive.
+    let input_node = full
+        .forms
+        .iter()
+        .find(|n| n.role == "input")
+        .expect("input node must be in full.forms");
+
+    let val = input_node
+        .attributes
+        .as_ref()
+        .and_then(|a| a.get("value"))
+        .map(String::as_str)
+        .unwrap_or("");
+
+    assert!(
+        !val.contains("my-secret-password"),
+        "password value must be masked in SRE full state, got: {val}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Audit Sink entry hook (via AuditLogger)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_logger_tool_call_redacts_email_in_value_field() {
+    let logger = AuditLogger::new();
+    logger.clear_recent_events();
+
+    logger.log(AuditEvent::ToolCall {
+        tool_name: "fill".to_string(),
+        args: json!({ "selector": "#email", "value": "alice@example.com" }),
+        timestamp: 0,
+    });
+
+    let events = logger.recent_events();
+    let AuditEvent::ToolCall { args, .. } = &events[0] else {
+        panic!("expected ToolCall");
+    };
+    assert_eq!(
+        args["value"], "***",
+        "email in value field must be redacted in audit log"
+    );
+}
+
+#[test]
+fn audit_logger_tool_call_redacts_password_key() {
+    let logger = AuditLogger::new();
+    logger.clear_recent_events();
+
+    logger.log(AuditEvent::ToolCall {
+        tool_name: "login".to_string(),
+        args: json!({ "username": "alice", "password": "hunter2" }),
+        timestamp: 0,
+    });
+
+    let events = logger.recent_events();
+    let AuditEvent::ToolCall { args, .. } = &events[0] else {
+        panic!("expected ToolCall");
+    };
+    assert_eq!(args["password"], "***");
+    assert_eq!(args["username"], "alice");
+}
+
+#[test]
+fn audit_logger_state_snapshot_redacts_email_in_payload() {
+    let logger = AuditLogger::new();
+    logger.clear_recent_events();
+
+    logger.log(AuditEvent::StateSnapshot {
+        state_hash: "abc".to_string(),
+        page_instance_id: "page-1".to_string(),
+        timestamp: 0,
+        payload: json!({ "label": "alice@example.com" }),
+    });
+
+    let events = logger.recent_events();
+    let AuditEvent::StateSnapshot { payload, .. } = &events[0] else {
+        panic!("expected StateSnapshot");
+    };
+    assert!(
+        !payload["label"]
+            .as_str()
+            .unwrap_or("")
+            .contains("alice@example.com"),
+        "email must be redacted in StateSnapshot payload"
+    );
+}
+
+#[test]
+fn audit_logger_credit_card_redacted_in_tool_call_args() {
+    let logger = AuditLogger::new();
+    logger.clear_recent_events();
+
+    logger.log(AuditEvent::ToolCall {
+        tool_name: "fill".to_string(),
+        args: json!({ "note": "Card 4111-1111-1111-1111" }),
+        timestamp: 0,
+    });
+
+    let events = logger.recent_events();
+    let AuditEvent::ToolCall { args, .. } = &events[0] else {
+        panic!("expected ToolCall");
+    };
+    let note = args["note"].as_str().unwrap_or("");
+    assert!(
+        !note.contains("4111-1111-1111-1111"),
+        "credit card must be redacted: {note}"
+    );
+}

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -41,8 +41,118 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 | 7 | Marketplace | PR-17 | 1/1 | DONE |
 | 8 | Robustness & Verification | PR-18 | 1/1 | DONE |
 | 9 | Comprehensive Evaluation Bench | PR-19 | 1/1 | DONE |
+| 10 | Cathedral Edition (Commercialization) | PR-20〜28 | 0/9 | NOT_STARTED |
 
 ## 3. PRバックログ（進捗チェック付き）
+
+### PR-20: Speculative State Generation Pipeline
+- Status: `NOT_STARTED`
+- Spec Ref: Section 3.5, ISSUE-10
+- Dependencies: PR-08, PR-14
+- 実装タスク
+  - [ ] `core-runtime/src/speculative/mod.rs` を新設し予測エンジンを実装。
+  - [ ] `flatbuffers` によるモデルのシリアライズ/デシリアライズを実装。
+  - [ ] 予測失敗時の `StateDelta::Mismatch` とリプレイ・デバッグ用のスナップショット保存を実装。
+- テストタスク
+  - [ ] 意図的な予測ミス（Drift Injection）によるバックトラッキングの検証。
+- Exit Criteria
+  - [ ] 予測的中時に TTFT < 10ms を達成。
+
+### PR-21: Self-Healing Context Recovery Layer
+- Status: `NOT_STARTED`
+- Spec Ref: Section 3.6, ISSUE-11
+- Dependencies: PR-03, PR-04
+- 実装タスク
+  - [ ] `DOMSignatureCache` による成功操作パターンの永続化。
+  - [ ] `stable_key` 喪失時のファジーマッチング修復ロジックの実装。
+  - [ ] 修復不能時の自動 `ask_human` フォールバック。
+- テストタスク
+  - [ ] 大幅な UI 変更 fixture に対する自動修復成功率の検証。
+- Exit Criteria
+  - [ ] 修復成功時に `verify` 要求なしでアクションが継続される。
+
+### PR-22: "Deep Lens" Zero-Code Extraction DSL
+- Status: `NOT_STARTED`
+- Spec Ref: Section 4.3, ISSUE-12
+- Dependencies: PR-12, PR-14
+- 実装タスク
+  - [ ] YAML/JSON ベースの抽出 DSL パーサーと `SchemaRegistry` の実装。
+  - [ ] Wasm Plugin Host 経由での型安全な抽出実行。
+- テストタスク
+  - [ ] `Golden Dataset` を用いた抽出精度（Accuracy 100%）の検証。
+- Exit Criteria
+  - [ ] スクリーンスクレイピング・コードなしでの構造化データ取得が可能。
+
+### PR-23: "Guardian Angel" & Outcome Projection
+- Status: `NOT_STARTED`
+- Spec Ref: Section 3.7, ISSUE-13
+- Dependencies: PR-09, PR-14
+- 実装タスク
+  - [ ] `PolicyEngine` への副作用予測（Outcome Projection）シミュレータ統合。
+  - [ ] 予測データに基づくプロアクティブな実行ブロックと HITL 通知。
+- テストタスク
+  - [ ] 高額決済等の閾値超過シナリオでの自動ブロックと通知内容の検証。
+- Exit Criteria
+  - [ ] アクション実行前に構造化された副作用データが提示される。
+
+### PR-24: Persistent Audit Hardening (Rolling File & SIEM)
+- Status: `NOT_STARTED`
+- Spec Ref: Section 3.4, ISSUE-09, ISSUE-14
+- Dependencies: PR-10
+- 実装タスク
+  - [ ] `RollingFileSink` と `WebhookSink` (SIEM) の実装。
+  - [ ] 非同期ログ書き込みの信頼性向上（Retry / Backpressure）。
+- テストタスク
+  - [ ] 高負荷バースト時のログ欠損ゼロ検証。
+- Exit Criteria
+  - [ ] 長期保存可能な監査トレースが外部システムと連携される。
+
+### PR-25: Slack/Teams HITL Reference Implementation
+- Status: `NOT_STARTED`
+- Spec Ref: Section 5.2, ISSUE-15
+- Dependencies: PR-14, PR-23
+- 実装タスク
+  - [ ] Slack App 連携リファレンス実装（画像 + 未来投影データ付き）。
+  - [ ] セッションレベルの二重承認防止ロック。
+- テストタスク
+  - [ ] 複数人による同時承認リクエストの競合回避検証。
+- Exit Criteria
+  - [ ] チャットツール経由で安全に HITL 判断を完走できる。
+
+### PR-26: Shared Wasm Engine & Performance Tuning
+- Status: `NOT_STARTED`
+- Spec Ref: Section 4.1, ISSUE-16
+- Dependencies: PR-12
+- 実装タスク
+  - [ ] `wasmtime` Engine のグローバル共有とコンパイル済みモジュールのキャッシュ。
+  - [ ] Epoch-based Interruption による暴走プラグインの強制遮断。
+- テストタスク
+  - [ ] 大量プラグインロード時のメモリ消費と起動レイテンシの計測。
+- Exit Criteria
+  - [ ] プラグイン起動時間が 1ms 以下に短縮。
+
+### PR-27: Unified PII Redactor Utility
+- Status: `DONE`
+- Spec Ref: Section 3.4, ISSUE-08, ISSUE-17
+- Dependencies: PR-02, PR-10
+- 実装タスク
+  - [x] `core-runtime/src/privacy.rs` へのマスクロジック集約と強制フック実装。
+- テストタスク
+  - [x] あらゆる経路（SRE/Audit/Deep Lens）でのマスク漏れゼロ検証。
+- Exit Criteria
+  - [x] 機密データが AI モデルやログに未加工で流れないことが保証される。
+
+### PR-28: Side-by-side ROI Comparison Tool
+- Status: `NOT_STARTED`
+- Spec Ref: Section 8.1, ISSUE-18
+- Dependencies: PR-14, PR-15
+- 実装タスク
+  - [ ] Playwright 比較ベンチマーク・ハーネスの実装。
+  - [ ] トークン・コスト削減効果の自動レポート生成。
+- テストタスク
+  - [ ] 代表的な EC/業務サイトでの削減率実測。
+- Exit Criteria
+  - [ ] 導入メリットを定量的に示す Markdown レポートが出力可能。
 
 ### PR-00: Test Strategy & CI Foundation
 - Status: `DONE` (Local)


### PR DESCRIPTION
## Summary

- `core-runtime/src/privacy.rs` に `PiiRedactor` を新設し、PII マスクロジックを一元化
- SRE Queue 出口フック: `process_sre_task` で `FastSemanticState` / `FullSemanticState` を配信前に強制リダクション
- Audit Sink 入口フック: `sanitize_audit_event` が `privacy::global()` に委譲（重複コード削除）
- `DomainPattern` によるドメイン固有パターン拡張（Wasm プラグイン連携の将来基盤）

## Changes

| File | 変更内容 |
|------|---------|
| `core-runtime/src/privacy.rs` | 新設: `PiiRedactor`, `DomainPattern`, `global()` |
| `core-runtime/src/lib.rs` | `pub mod privacy` 追加 |
| `core-runtime/src/audit.rs` | 重複内部関数を削除し `privacy::global()` を利用 |
| `core-runtime/src/sre/pipeline.rs` | `process_sre_task` に SRE 出口フック追加 |
| `core-runtime/tests/pii_redaction.rs` | 統合テスト 11 件 (SRE + Audit 両経路) |
| `docs/PLAN.md` | PR-27 を DONE に更新 |

## Exit Criteria

- [x] 機密データが AI モデルやログに未加工で流れないことが保証される
  - SRE パイプライン (Fast/Full State) でメール・CC をマスク済み
  - Audit Sink (ToolCall/StateSnapshot/StatePatch/Plugin 各イベント) でマスク済み
- [x] あらゆる経路でのマスク漏れゼロを統合テストで検証済み

## Test Plan

- [x] `cargo test --lib -p core-runtime` — 55 passed
- [x] `cargo test --test pii_redaction -p core-runtime` — 11 passed
- [x] `cargo test --test audit_logging -p core-runtime` — 9 passed
- [x] `cargo test --test plugin_hooks -p core-runtime` — 21 passed
- [x] `cargo clippy --workspace -- -D warnings` — no errors
- [x] `cargo fmt --all -- --check` — clean

## gstack-review / gstack-qa

- browser-facing target なし (library/pipeline 変更のみ)
- `redact_json`, `redact_json_tool_args` の二段階 API で tool args と state payload を区別
- `type="password"` コンテキスト検出により `value` 属性を自動マスク
- `global()` / `register_global_redactor()` で Wasm プラグインからのパターン注入が将来可能
- 未解決の重大指摘: なし

Closes #77