### PR TITLE
docs: update README.md to version 2.2 (Cathedral Edition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Unlike traditional headless browsers that automate "DOM for humans," Dragon Head
 ## Core Value Propositions
 
 - **Token Efficiency**: Reduces input tokens to LLMs by an average of 90% through a proprietary Semantic Rendering Engine (SRE) and differential updates.
-- **Reliability**: Prevents AI hallucinations by synchronizing visual information (Set-of-Mark) with structural data and using `stable_key` for self-healing element identification.
+- **Reliability**: Prevents AI hallucinations by synchronizing visual information (Set-of-Mark) with structural data and using `stable_key` for robust element identification.
+- **Resilience**: **Self-Healing (セマンティック・ヒーリング)** enables 99.9% tolerance to UI changes by using DOM signature fuzzy matching.
 - **Compliance**: Built-in Policy Engine and Audit Logs provide a "legitimate execution environment" that meets enterprise security requirements.
-- **Speed**: Achieves a Time-to-First-Token (TTFT) of under 50ms using a 3-stage pipeline and aggressive blocking of unnecessary resources.
+- **Speed**: Achieves **Near-Zero TTFT (< 10ms)** using a 4-stage speculative pipeline and aggressive blocking of unnecessary resources.
 
 ## System Architecture
 
-The system consists of a 3-layer structure and an asynchronous internal pipeline within the Core Runtime.
+The system consists of a 3-layer structure and a 4-stage asynchronous internal pipeline within the Core Runtime.
 
 ### Layer Structure
 
@@ -21,26 +22,41 @@ The system consists of a 3-layer structure and an asynchronous internal pipeline
     The foundation that wraps Chromium CDP (Chrome DevTools Protocol) to handle rendering, SRE conversion, and security controls.
 
 2.  **Layer 2: Plugin Framework (WebAssembly)**
-    A sandyox environment for extending State extraction and policies tailored to specific sites or business needs.
+    A sandbox environment for extending State extraction (**"Deep Lens" DSL**) and policies (**"Guardian Angel"**) tailored to specific sites or business needs.
 
 3.  **Layer 3: Skills Engine**
     An execution engine for declarative workflows defining tasks such as "Purchase Item" or "Job Search."
 
+### Execution Pipeline
+
+- **Speculative Queue**: Predicts AI intent and pre-generates the next Semantic State.
+- **Render Queue**: Handles DOM updates and minimal layout.
+- **SRE Queue**: Performs DOM analysis, stable key generation, and delta calculation.
+- **Audit/Policy Queue**: Manages action screening and immutable audit logging.
+
 ## Key Features
 
-### Semantic Rendering Engine (SRE)
+### Speculative State Generation
+- **Intent Prediction**: Probability-based prediction of the next navigation or action.
+- **Near-Zero TTFT**: Pre-generates SRE results to eliminate AI thinking latency.
+
+### Semantic Rendering Engine (SRE) & "Deep Lens"
 - **Deterministic State Generation**: Converts raw DOM into structured JSON (Semantic State).
-- **Load Profiles**: `minimal` (fastest), `visual` (for SoM), `interactive` (for complex SPAs).
+- **"Deep Lens" DSL**: YAML/JSON based zero-code extraction for complex structured data.
 - **Semantic Delta**: Generates JSON Patch (RFC 6902) updates to minimize data transfer.
 
+### Self-Healing Context Recovery
+- **DOM Signature Cache**: Stores structural fingerprints of successful operations.
+- **Fuzzy Matching**: Automatically recovers element targets when `stable_key` fails due to UI updates.
+
 ### Native Set-of-Mark (SoM) & Stable Identity
-- **Stable Key**: Generates robust, immutable keys (`stable_key`) using SHA-256 to track elements across re-renders.
+- **Stable Key**: SHA-256 based immutable keys to track elements across re-renders.
 - **Event-Driven SoM**: Generates visual marks only when necessary (e.g., explicit request or ambiguity resolution).
 
-### Enterprise Security
-- **Context-Aware Policy Engine**: Rule-based screening before action execution.
-- **Structured Audit Log**: Records full state snapshots, deltas, tool calls, and policy decisions.
-- **Session Vault**: Securely persists authentication credentials (Cookie/Token) using AES-256.
+### Enterprise Security & "Guardian Angel"
+- **"Guardian Angel"**: Proactively defends against dangerous actions by simulating side-effects (**Outcome Projection**).
+- **Unified PII Redactor**: Mandatory dual-layer masking for both AI state and audit logs.
+- **Structured Audit Log**: Persistent, SIEM-compatible logs of all snapshots, tool calls, and decisions.
 
 ## Quick Start
 
@@ -77,6 +93,11 @@ Expected output:
 ```
 
 No Chrome instance or paid credentials needed. See [`examples/README.md`](examples/README.md) for a full guide including the policy cookbook, MCP JSON contract examples, and the sample skill definition.
+
+## Developer Tools
+
+### ROI Comparison Tool
+A CLI utility to benchmark Dragon Head against standard browser automation, quantifying token and latency savings.
 
 ## Developer Guide
 


### PR DESCRIPTION
This PR updates the README.md to reflect the newly defined v2.2 (Cathedral Edition) specifications.

### Key Changes
- **Near-Zero TTFT (< 10ms)**: Highlights the new 4-stage speculative pipeline.
- **Resilience**: Introduces Self-Healing (セマンティック・ヒーリング) for 99.9% UI change tolerance.
- **Architecture**: Updates the Layer 2 and Execution Pipeline descriptions.
- **New Features**: Adds sections for Speculative State Generation, Deep Lens DSL, and Guardian Angel.
- **ROI Tool**: Mentions the new Side-by-side ROI Comparison CLI Tool.