### PR TITLE
[codex] Add README install and MCP usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,212 @@
 # Dragon Head: Neural-Browser Runtime
 
-**Dragon Head** is an AI-Native Headless Browser Runtime designed specifically for Large Language Models (LLMs) and Vision Language Models (VLMs) to navigate and interact with the Web.
+**Last updated:** 2026-05-08
 
-Unlike traditional headless browsers that automate "DOM for humans," Dragon Head functions as middleware that converts web pages into **"Semantic State" interpretatable by AI** in real-time.
+Dragon Head is an AI-native headless browser runtime for LLM and VLM agents.
+It exposes a browser session as a compact, structured **Semantic State** and
+provides an MCP server that agents can use to inspect pages, act on elements,
+verify outcomes, request human approval, and run declarative skills.
 
-## Core Value Propositions
+The current user-facing entry point is the stdio MCP server binary:
 
-- **Token Efficiency**: Reduces input tokens to LLMs by an average of 90% through a proprietary Semantic Rendering Engine (SRE) and differential updates.
-- **Reliability**: Prevents AI hallucinations by synchronizing visual information (Set-of-Mark) with structural data and using `stable_key` for robust element identification.
-- **Resilience**: **Self-Healing (セマンティック・ヒーリング)** enables 99.9% tolerance to UI changes by using DOM signature fuzzy matching.
-- **Compliance**: Built-in Policy Engine and Audit Logs provide a "legitimate execution environment" that meets enterprise security requirements.
-- **Speed**: Achieves **Near-Zero TTFT (< 10ms)** using a 4-stage speculative pipeline and aggressive blocking of unnecessary resources.
-
-## System Architecture
-
-The system consists of a 3-layer structure and a 4-stage asynchronous internal pipeline within the Core Runtime.
-
-### Layer Structure
-
-1.  **Layer 1: Core Runtime (Rust/C++)**
-    The foundation that wraps Chromium CDP (Chrome DevTools Protocol) to handle rendering, SRE conversion, and security controls.
-
-2.  **Layer 2: Plugin Framework (WebAssembly)**
-    A sandbox environment for extending State extraction (**"Deep Lens" DSL**) and policies (**"Guardian Angel"**) tailored to specific sites or business needs.
-
-3.  **Layer 3: Skills Engine**
-    An execution engine for declarative workflows defining tasks such as "Purchase Item" or "Job Search."
-
-### Execution Pipeline
-
-- **Speculative Queue**: Predicts AI intent and pre-generates the next Semantic State.
-- **Render Queue**: Handles DOM updates and minimal layout.
-- **SRE Queue**: Performs DOM analysis, stable key generation, and delta calculation.
-- **Audit/Policy Queue**: Manages action screening and immutable audit logging.
-
-## Key Features
-
-### Speculative State Generation
-- **Intent Prediction**: Probability-based prediction of the next navigation or action.
-- **Near-Zero TTFT**: Pre-generates SRE results to eliminate AI thinking latency.
-
-### Semantic Rendering Engine (SRE) & "Deep Lens"
-- **Deterministic State Generation**: Converts raw DOM into structured JSON (Semantic State).
-- **"Deep Lens" DSL**: YAML/JSON based zero-code extraction for complex structured data.
-- **Semantic Delta**: Generates JSON Patch (RFC 6902) updates to minimize data transfer.
-
-### Self-Healing Context Recovery
-- **DOM Signature Cache**: Stores structural fingerprints of successful operations.
-- **Fuzzy Matching**: Automatically recovers element targets when `stable_key` fails due to UI updates.
-
-### Native Set-of-Mark (SoM) & Stable Identity
-- **Stable Key**: SHA-256 based immutable keys to track elements across re-renders.
-- **Event-Driven SoM**: Generates visual marks only when necessary (e.g., explicit request or ambiguity resolution).
-
-### Enterprise Security & "Guardian Angel"
-- **"Guardian Angel"**: Proactively defends against dangerous actions by simulating side-effects (**Outcome Projection**).
-- **Unified PII Redactor**: Mandatory dual-layer masking for both AI state and audit logs.
-- **Structured Audit Log**: Persistent, SIEM-compatible logs of all snapshots, tool calls, and decisions.
-
-## Quick Start
-
-```bash
-git clone <repo-url>
-cd dragon-head
-cargo run --example quickstart
+```text
+dragon-head-mcp
 ```
 
-Expected output:
+At the moment, Dragon Head is run from source. Prebuilt binaries and package
+manager installation are tracked in [Issue #95](https://github.com/takurot/dragon-head/issues/95).
 
-```
-=== Dragon Head Quickstart ===
+## Current Status
 
-[1] SemanticState constructed
-    page_instance_id : <uuid>
-    state_hash       : <sha256-hex>
-    load_profile     : Minimal
+Implemented today:
 
-[2] Fast State generated
-    interactive_elements : 2
-    messages             : 1
-      → role=input     alias=input_email      stable_key=b2c3d4e5...
-      → role=button    alias=btn_purchase     stable_key=a1b2c3d4...
+- `dragon-head-mcp` stdio MCP server in the `mcp-server` crate.
+- Core browser runtime backed by Chrome/Chromium through CDP.
+- Semantic state generation, stable element identity, semantic delta delivery,
+  visual capture, policy enforcement, audit logging, session vault support,
+  PII redaction, self-healing action recovery, plugin hooks, and Skills Engine
+  integration.
+- Developer examples that demonstrate the core concepts without launching
+  Chrome.
 
-[3] PolicyEngine loaded with 1 rule(s)
-    safe.example.com               → Allow
-    blocked-domain.example.com     → Block
+Roadmap items:
 
-[4] MCP get_state response (JSON):
-{ "metadata": { ... }, "interactive_elements": [ ... ] }
+- GitHub Releases native binaries, Homebrew, Docker, and `cargo install`
+  distribution.
+- `dragon-head-mcp doctor` and MCP client init helpers.
+- Deep Lens extraction DSL, Guardian Angel outcome projection, and speculative
+  state generation as production-ready product surfaces.
 
-=== Done — no credentials required ===
-```
-
-No Chrome instance or paid credentials needed. See [`examples/README.md`](examples/README.md) for a full guide including the policy cookbook, MCP JSON contract examples, and the sample skill definition.
-
-## Developer Tools
-
-### ROI Comparison Tool
-A CLI utility to benchmark Dragon Head against standard browser automation, quantifying token and latency savings.
-
-## Developer Guide
+## Install and Run
 
 ### Prerequisites
-- Rust (latest stable)
-- Chromium installed (only required for browser integration tests)
 
-### Running Examples
+- Rust stable toolchain.
+- Chrome or Chromium for the MCP server and browser-backed tests.
+
+Dragon Head checks `CHROME_PATH` first. If it is not set, it tries common
+Chrome/Chromium locations for macOS, Linux, and Windows.
+
+Example macOS setting:
+
 ```bash
-# Core concepts — no browser required
+export CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+
+### Run the MCP server from source
+
+```bash
+git clone https://github.com/takurot/dragon-head.git
+cd dragon-head
+cargo run -p mcp-server --bin dragon-head-mcp
+```
+
+The server starts on stdio and prints lifecycle logs to stderr:
+
+```text
+dragon-head-mcp: starting...
+dragon-head-mcp: ready, listening on stdio
+```
+
+For repeated local use, build a release binary:
+
+```bash
+cargo build -p mcp-server --bin dragon-head-mcp --release
+./target/release/dragon-head-mcp
+```
+
+### Connect from an MCP client
+
+Use this source-checkout configuration while binary releases are not available.
+Replace `/path/to/dragon-head` with your local checkout path.
+
+```json
+{
+  "mcpServers": {
+    "dragon-head": {
+      "command": "cargo",
+      "args": [
+        "run",
+        "--manifest-path",
+        "/path/to/dragon-head/Cargo.toml",
+        "-p",
+        "mcp-server",
+        "--bin",
+        "dragon-head-mcp"
+      ],
+      "env": {
+        "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      }
+    }
+  }
+}
+```
+
+After prebuilt binaries ship, the configuration should become:
+
+```json
+{
+  "mcpServers": {
+    "dragon-head": {
+      "command": "dragon-head-mcp",
+      "env": {
+        "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      }
+    }
+  }
+}
+```
+
+## Available MCP Tools
+
+`dragon-head-mcp` currently exposes these tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `get_state` | Retrieve the semantic page state. |
+| `act` | Execute an interaction action. |
+| `verify` | Verify precondition text before acting. |
+| `get_visual` | Capture visual context with optional marks. |
+| `ask_human` | Resolve a pending human-in-the-loop request. |
+| `run_skill` | Execute a declarative skill workflow. |
+| `get_usage_report` | Retrieve usage meters and plan tier summary. |
+
+## Developer Examples
+
+These examples do not require Chrome and are useful for understanding the data
+model and policy behavior:
+
+```bash
+# Core concepts: SemanticState, Fast State, PolicyEngine, MCP-style payload
 cargo run --example quickstart
 
-# Policy rule cookbook — no browser required
+# Policy rule cookbook
 cargo run --example policy_cookbook
 ```
 
-### Running Tests
+See [examples/README.md](examples/README.md) for sample policies, sample skills,
+and MCP request/response fixtures.
+
+## Testing and Verification
+
+Run the full workspace test suite:
+
 ```bash
 cargo test --workspace
 ```
 
-### Linting
+Run formatting and lint checks:
+
 ```bash
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 ```
 
+Browser-backed tests are skipped when Chrome is unavailable in supported test
+paths, but the MCP server itself needs Chrome/Chromium to start a real browser
+session.
+
+## Architecture
+
+Dragon Head is organized as a Rust workspace:
+
+- `core-runtime`: Chrome/CDP browser session, semantic state capture, action
+  execution, policy, audit, privacy, visual capture, and session vault.
+- `mcp-server`: stdio MCP server and tool contract.
+- `skills-engine`: declarative workflow execution.
+- `plugin-host`: Wasm plugin validation and runtime execution.
+- `marketplace`: plugin/domain-pack marketplace primitives.
+
+## Distribution Plan
+
+The intended low-friction distribution path is:
+
+1. GitHub Releases native binaries for macOS, Linux, and Windows.
+2. Homebrew tap for macOS installation.
+3. Copy-paste MCP client configuration templates.
+4. Optional install script for users who prefer a one-command setup.
+5. Docker image for CI and Linux evaluation environments.
+6. `cargo install` / crates.io path for Rust developers after workspace crate
+   publishing is ready.
+
+This work is tracked in [Issue #95](https://github.com/takurot/dragon-head/issues/95).
+
+## Project Roadmap
+
+Near-term:
+
+- Package `dragon-head-mcp` as the primary install artifact.
+- Add install verification and config helpers.
+- Tighten README and examples around MCP client onboarding.
+
+Product roadmap:
+
+- Deep Lens zero-code extraction DSL.
+- Guardian Angel outcome projection for proactive policy decisions.
+- Speculative state generation for near-zero TTFT targets.
+- Slack/Teams HITL reference integration.
+- Shared Wasm engine and module caching.
+
 ---
-*This project is currently under active development.*
+
+This project is under active development.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,36 @@ cargo build -p mcp-server --bin dragon-head-mcp --release
 ./target/release/dragon-head-mcp
 ```
 
-### Connect from an MCP client
+## MCP Client Setup
 
-Use this source-checkout configuration while binary releases are not available.
-Replace `/path/to/dragon-head` with your local checkout path.
+Dragon Head runs as a stdio MCP server. Your MCP client starts the command,
+passes JSON-RPC messages on stdin, and reads responses from stdout.
+
+### 1. Choose the command
+
+Use this command while running from a source checkout:
+
+```bash
+cargo run --manifest-path /path/to/dragon-head/Cargo.toml -p mcp-server --bin dragon-head-mcp
+```
+
+Use this command after building a local release binary:
+
+```bash
+/path/to/dragon-head/target/release/dragon-head-mcp
+```
+
+After packaged releases ship, use the installed command directly:
+
+```bash
+dragon-head-mcp
+```
+
+### 2. Add the MCP server config
+
+Most MCP clients expose an `mcpServers` JSON object. Use this
+source-checkout configuration while binary releases are not available.
+Replace `/path/to/dragon-head` with your absolute local checkout path.
 
 ```json
 {
@@ -102,7 +128,7 @@ Replace `/path/to/dragon-head` with your local checkout path.
 }
 ```
 
-After prebuilt binaries ship, the configuration should become:
+For a locally built or packaged binary, the configuration becomes:
 
 ```json
 {
@@ -116,6 +142,35 @@ After prebuilt binaries ship, the configuration should become:
   }
 }
 ```
+
+If Chrome is installed in a standard location, you can omit `CHROME_PATH`.
+Set it explicitly when the MCP server cannot find Chrome or when you want to
+use a specific Chromium build.
+
+### 3. Restart the MCP client
+
+After updating the client config, restart the MCP client so it launches
+`dragon-head-mcp`. A successful startup writes these lifecycle logs to stderr:
+
+```text
+dragon-head-mcp: starting...
+dragon-head-mcp: ready, listening on stdio
+```
+
+The client should then show the Dragon Head tools listed below.
+
+### 4. Troubleshooting
+
+- Use absolute paths in MCP config. Relative paths depend on the client process
+  working directory and are easy to break.
+- Put environment variables in the JSON `env` object. Do not rely on shell
+  startup files being loaded by GUI clients.
+- If startup fails before the tools appear, confirm Chrome is installed or set
+  `CHROME_PATH`.
+- If the source-checkout command is slow on every client launch, build the
+  release binary and configure the client to run `target/release/dragon-head-mcp`.
+- Running `dragon-head-mcp` directly in a terminal is only a startup smoke test;
+  the server is designed to be managed by an MCP client over stdio.
 
 ## Available MCP Tools
 


### PR DESCRIPTION
## Summary

- Rework README around the current `dragon-head-mcp` stdio MCP server entry point.
- Add source-based run instructions, `CHROME_PATH` guidance, and MCP client configuration examples.
- Separate current capabilities from roadmap and distribution plans, with Issue #95 as the packaging tracker.

## Validation

- `cargo build -p mcp-server --bin dragon-head-mcp`
- `cargo run --example quickstart`
- `cargo run --example policy_cookbook`
- `git diff --check -- README.md`