### PR TITLE
[ISSUE-05] Integrate PluginRuntime into core-runtime pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "crossbeam-channel",
+ "ed25519-dalek",
  "headless_chrome",
  "hex",
  "hmac",
@@ -299,6 +300,7 @@ dependencies = [
  "json-patch",
  "jsonschema",
  "pbkdf2",
+ "plugin-host",
  "rand",
  "regex",
  "serde",
@@ -312,6 +314,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "wat",
 ]
 
 [[package]]

--- a/core-runtime/Cargo.toml
+++ b/core-runtime/Cargo.toml
@@ -39,7 +39,6 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 jsonschema = "0.37"
 tempfile = "3.10"
 test-bench-support = { path = "../test-bench-support" }
-plugin-host = { path = "../plugin-host" }
 ed25519-dalek = "2.1"
 wat = "1.240"
 hex = "0.4"

--- a/core-runtime/Cargo.toml
+++ b/core-runtime/Cargo.toml
@@ -23,6 +23,7 @@ aes-gcm = "0.10"
 pbkdf2 = "0.12"
 rand = "0.9"
 hmac = "0.12"
+plugin-host = { path = "../plugin-host" }
 
 [[example]]
 name = "quickstart"
@@ -38,3 +39,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 jsonschema = "0.37"
 tempfile = "3.10"
 test-bench-support = { path = "../test-bench-support" }
+plugin-host = { path = "../plugin-host" }
+ed25519-dalek = "2.1"
+wat = "1.240"
+hex = "0.4"

--- a/core-runtime/src/plugin_hooks.rs
+++ b/core-runtime/src/plugin_hooks.rs
@@ -212,12 +212,40 @@ fn epoch_millis_u64() -> u64 {
 // Wasm-backed adapters (requires `plugin-host` as a dependency)
 // ---------------------------------------------------------------------------
 
+/// Error returned when constructing a Wasm-backed plugin adapter fails.
+///
+/// Using a local error type insulates callers of `core-runtime` from changes
+/// to `plugin_host::PluginError` variant set.
+#[derive(Debug, thiserror::Error)]
+pub enum PluginAdapterError {
+    #[error("plugin authorization failed: {0}")]
+    Authorization(String),
+    #[error("failed to create plugin runtime: {0}")]
+    RuntimeCreation(String),
+}
+
+impl From<plugin_host::PluginError> for PluginAdapterError {
+    fn from(e: plugin_host::PluginError) -> Self {
+        match e {
+            plugin_host::PluginError::MissingExport { .. }
+            | plugin_host::PluginError::CapabilityViolation { .. } => {
+                Self::Authorization(e.to_string())
+            }
+            _ => Self::RuntimeCreation(e.to_string()),
+        }
+    }
+}
+
 /// Adapter that wraps a verified [`plugin_host::LoadedPlugin`] and implements
 /// [`StatePlugin`] by calling the plugin's `on_state` Wasm export.
 ///
 /// Construction fails if the plugin does not declare the `OnState` entry point
-/// or lacks the `ReadState` capability.  This enforces the capability contract
-/// eagerly rather than deferring it to the first call.
+/// or lacks the `ReadState` capability.  Both checks are enforced explicitly at
+/// construction time rather than deferring them to the first call.
+///
+/// A single instance serializes calls through an internal `Mutex`.  If
+/// per-call parallelism is needed, create one `WasmStatePlugin` per
+/// thread/task.
 pub struct WasmStatePlugin {
     id: String,
     runtime: Mutex<plugin_host::PluginRuntime>,
@@ -226,12 +254,20 @@ pub struct WasmStatePlugin {
 impl WasmStatePlugin {
     /// Create from a verified `LoadedPlugin`.
     ///
-    /// Returns `Err(plugin_host::PluginError)` if the plugin does not satisfy
-    /// the `OnState` entry point + `ReadState` capability requirements.
-    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, plugin_host::PluginError> {
-        plugin.authorize_extension(plugin_host::ExtensionPoint::OnState)?;
+    /// Returns [`PluginAdapterError`] if the plugin does not satisfy the
+    /// `OnState` entry point + `ReadState` capability requirements, or if
+    /// Wasm instantiation fails.
+    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, PluginAdapterError> {
+        plugin
+            .authorize_extension(plugin_host::ExtensionPoint::OnState)
+            .map_err(PluginAdapterError::from)?;
+        // Explicit check keeps the ReadState contract visible here even if
+        // authorize_extension's implicit mapping changes in a future version.
+        plugin
+            .ensure_capability(plugin_host::Capability::ReadState)
+            .map_err(PluginAdapterError::from)?;
         let id = plugin.manifest().plugin_id.clone();
-        let runtime = plugin.create_runtime()?;
+        let runtime = plugin.create_runtime().map_err(PluginAdapterError::from)?;
         Ok(Self {
             id,
             runtime: Mutex::new(runtime),
@@ -247,7 +283,7 @@ impl StatePlugin for WasmStatePlugin {
     fn on_state(&self, state_json: &str) -> Result<String, String> {
         self.runtime
             .lock()
-            .expect("WasmStatePlugin mutex is poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .on_state(state_json)
             .map_err(|e| e.to_string())
     }
@@ -257,8 +293,12 @@ impl StatePlugin for WasmStatePlugin {
 /// [`PolicyPlugin`] by calling the plugin's `before_act` Wasm export.
 ///
 /// Construction fails if the plugin does not declare the `BeforeAct` entry
-/// point.  `BeforeAct` has no mandatory capability in the current spec, so only
-/// the entry-point check is enforced here.
+/// point.  Any error from the Wasm call is mapped to `Err(String)`, which
+/// `run_policy_hooks` treats as a block (fail-closed).
+///
+/// A single instance serializes calls through an internal `Mutex`.  If
+/// per-call parallelism is needed, create one `WasmPolicyPlugin` per
+/// thread/task.
 pub struct WasmPolicyPlugin {
     id: String,
     runtime: Mutex<plugin_host::PluginRuntime>,
@@ -267,12 +307,14 @@ pub struct WasmPolicyPlugin {
 impl WasmPolicyPlugin {
     /// Create from a verified `LoadedPlugin`.
     ///
-    /// Returns `Err(plugin_host::PluginError)` if the plugin does not declare
-    /// the `BeforeAct` entry point.
-    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, plugin_host::PluginError> {
-        plugin.authorize_extension(plugin_host::ExtensionPoint::BeforeAct)?;
+    /// Returns [`PluginAdapterError`] if the plugin does not declare the
+    /// `BeforeAct` entry point, or if Wasm instantiation fails.
+    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, PluginAdapterError> {
+        plugin
+            .authorize_extension(plugin_host::ExtensionPoint::BeforeAct)
+            .map_err(PluginAdapterError::from)?;
         let id = plugin.manifest().plugin_id.clone();
-        let runtime = plugin.create_runtime()?;
+        let runtime = plugin.create_runtime().map_err(PluginAdapterError::from)?;
         Ok(Self {
             id,
             runtime: Mutex::new(runtime),
@@ -288,7 +330,7 @@ impl PolicyPlugin for WasmPolicyPlugin {
     fn before_act(&self, intent_json: &str) -> Result<String, String> {
         self.runtime
             .lock()
-            .expect("WasmPolicyPlugin mutex is poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .before_act(intent_json)
             .map_err(|e| e.to_string())
     }

--- a/core-runtime/src/plugin_hooks.rs
+++ b/core-runtime/src/plugin_hooks.rs
@@ -15,6 +15,7 @@
 /// Both hook types record their decisions in the `AuditLogger` so they are
 /// fully observable without leaking PII.
 use crate::audit::AuditEvent;
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
@@ -205,6 +206,92 @@ fn epoch_millis_u64() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+// ---------------------------------------------------------------------------
+// Wasm-backed adapters (requires `plugin-host` as a dependency)
+// ---------------------------------------------------------------------------
+
+/// Adapter that wraps a verified [`plugin_host::LoadedPlugin`] and implements
+/// [`StatePlugin`] by calling the plugin's `on_state` Wasm export.
+///
+/// Construction fails if the plugin does not declare the `OnState` entry point
+/// or lacks the `ReadState` capability.  This enforces the capability contract
+/// eagerly rather than deferring it to the first call.
+pub struct WasmStatePlugin {
+    id: String,
+    runtime: Mutex<plugin_host::PluginRuntime>,
+}
+
+impl WasmStatePlugin {
+    /// Create from a verified `LoadedPlugin`.
+    ///
+    /// Returns `Err(plugin_host::PluginError)` if the plugin does not satisfy
+    /// the `OnState` entry point + `ReadState` capability requirements.
+    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, plugin_host::PluginError> {
+        plugin.authorize_extension(plugin_host::ExtensionPoint::OnState)?;
+        let id = plugin.manifest().plugin_id.clone();
+        let runtime = plugin.create_runtime()?;
+        Ok(Self {
+            id,
+            runtime: Mutex::new(runtime),
+        })
+    }
+}
+
+impl StatePlugin for WasmStatePlugin {
+    fn plugin_id(&self) -> &str {
+        &self.id
+    }
+
+    fn on_state(&self, state_json: &str) -> Result<String, String> {
+        self.runtime
+            .lock()
+            .expect("WasmStatePlugin mutex is poisoned")
+            .on_state(state_json)
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Adapter that wraps a verified [`plugin_host::LoadedPlugin`] and implements
+/// [`PolicyPlugin`] by calling the plugin's `before_act` Wasm export.
+///
+/// Construction fails if the plugin does not declare the `BeforeAct` entry
+/// point.  `BeforeAct` has no mandatory capability in the current spec, so only
+/// the entry-point check is enforced here.
+pub struct WasmPolicyPlugin {
+    id: String,
+    runtime: Mutex<plugin_host::PluginRuntime>,
+}
+
+impl WasmPolicyPlugin {
+    /// Create from a verified `LoadedPlugin`.
+    ///
+    /// Returns `Err(plugin_host::PluginError)` if the plugin does not declare
+    /// the `BeforeAct` entry point.
+    pub fn new(plugin: plugin_host::LoadedPlugin) -> Result<Self, plugin_host::PluginError> {
+        plugin.authorize_extension(plugin_host::ExtensionPoint::BeforeAct)?;
+        let id = plugin.manifest().plugin_id.clone();
+        let runtime = plugin.create_runtime()?;
+        Ok(Self {
+            id,
+            runtime: Mutex::new(runtime),
+        })
+    }
+}
+
+impl PolicyPlugin for WasmPolicyPlugin {
+    fn plugin_id(&self) -> &str {
+        &self.id
+    }
+
+    fn before_act(&self, intent_json: &str) -> Result<String, String> {
+        self.runtime
+            .lock()
+            .expect("WasmPolicyPlugin mutex is poisoned")
+            .before_act(intent_json)
+            .map_err(|e| e.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/core-runtime/tests/repro_plugin_pipeline.rs
+++ b/core-runtime/tests/repro_plugin_pipeline.rs
@@ -1,0 +1,318 @@
+/// Reproduction / integration tests for ISSUE-05: plugin-host execution entry
+/// point wired into the core-runtime pipeline.
+///
+/// Before the fix, `core-runtime::plugin_hooks` only had abstract trait objects
+/// (`StatePlugin`, `PolicyPlugin`).  There was no concrete adapter that wired a
+/// real `LoadedPlugin` / `PluginRuntime` from `plugin-host` into those traits,
+/// so callers had no supported path to inject Wasm-backed plugins.
+///
+/// The fix introduced:
+/// 1. `WasmStatePlugin`  — wraps a `LoadedPlugin`, implements `StatePlugin`.
+/// 2. `WasmPolicyPlugin` — wraps a `LoadedPlugin`, implements `PolicyPlugin`.
+///
+/// Both adapters are gated on the `plugin-host` feature of `core-runtime`.
+/// They enforce capability checks and fail-closed semantics already required by
+/// the hook runners, but now backed by a live Wasm instance.
+use core_runtime::plugin_hooks::{
+    run_policy_hooks, run_state_hooks, PolicyHookOutcome, WasmPolicyPlugin, WasmStatePlugin,
+};
+use ed25519_dalek::{Signer, SigningKey};
+use plugin_host::{
+    signature_payload, Capability, ExtensionPoint, KeyRegistry, PluginHost, PluginManifest,
+    PluginPackage, SbomComponent, SbomDocument, SignatureBlock,
+};
+
+// ---------------------------------------------------------------------------
+// Shared WAT fixtures
+// ---------------------------------------------------------------------------
+
+/// Wasm that echoes input as output (for on_state) and always returns
+/// `{"allow":true}` for before_act.
+fn echo_wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+
+            ;; on_state: echo-copy input to output buffer
+            (func (export "on_state")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (local $i i32)
+                (local.set $i (i32.const 0))
+                (block $break
+                    (loop $loop
+                        (br_if $break (i32.ge_u (local.get $i) (local.get $in_len)))
+                        (i32.store8
+                            (i32.add (local.get $out_ptr) (local.get $i))
+                            (i32.load8_u (i32.add (local.get $in_ptr) (local.get $i))))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br $loop)))
+                (i32.store (local.get $out_len_ptr) (local.get $in_len))
+            )
+
+            ;; before_act: always allow
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 116))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 114))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 117))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 101))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 125))
+                (i32.store (local.get $out_len_ptr) (i32.const 14))
+            )
+        )"#,
+    )
+    .expect("failed to build echo wasm fixture")
+}
+
+/// Wasm whose `before_act` always returns `{"allow":false}`.
+fn block_wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"(module
+            (memory (export "memory") 1)
+            (func (export "before_act")
+                  (param $in_ptr i32) (param $in_len i32)
+                  (param $out_ptr i32) (param $out_len_ptr i32)
+                ;; {"allow":false} = 14 bytes
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 102))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 97))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 108))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 115))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 101))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 14)) (i32.const 125))
+                (i32.store (local.get $out_len_ptr) (i32.const 15))
+            )
+        )"#,
+    )
+    .expect("failed to build block wasm fixture")
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+fn make_registry_and_key() -> (KeyRegistry, SigningKey, String) {
+    let signing_key = SigningKey::from_bytes(&[99u8; 32]);
+    let key_id = "pipeline-test-key".to_string();
+
+    let mut registry = KeyRegistry::default();
+    registry
+        .register_hex_ed25519(
+            &key_id,
+            &hex::encode(signing_key.verifying_key().to_bytes()),
+        )
+        .expect("must register key");
+
+    (registry, signing_key, key_id)
+}
+
+fn sample_sbom() -> SbomDocument {
+    SbomDocument {
+        format: "cyclonedx-1.5".to_string(),
+        components: vec![SbomComponent {
+            name: "pipeline-fixture".to_string(),
+            version: "0.1.0".to_string(),
+            license: Some("MIT".to_string()),
+        }],
+    }
+}
+
+fn build_and_sign_package(
+    entry_points: Vec<ExtensionPoint>,
+    capabilities: Vec<Capability>,
+    wasm: Vec<u8>,
+    signing_key: &SigningKey,
+    key_id: &str,
+) -> PluginPackage {
+    let mut manifest = PluginManifest {
+        plugin_id: "pipeline.test.plugin".to_string(),
+        version: "0.1.0".to_string(),
+        entry_points,
+        capabilities,
+        signature: None,
+        sbom: sample_sbom(),
+    };
+
+    let payload = signature_payload(&manifest, &wasm).expect("payload must build");
+    let sig = signing_key.sign(&payload);
+    manifest.signature = Some(SignatureBlock {
+        key_id: key_id.to_string(),
+        signature_hex: hex::encode(sig.to_bytes()),
+    });
+
+    PluginPackage {
+        manifest,
+        wasm_module: wasm,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ISSUE-05 regression: WasmStatePlugin wires into run_state_hooks
+// ---------------------------------------------------------------------------
+
+/// BUG REGRESSION (ISSUE-05): A Wasm-backed state plugin must be loadable and
+/// injectable into `run_state_hooks` via the `WasmStatePlugin` adapter.
+///
+/// Before the fix there was no `WasmStatePlugin` type — callers had no supported
+/// path to use a real Wasm plugin in the state hook pipeline.
+#[test]
+fn wasm_state_plugin_echoes_state_json_through_pipeline() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![Capability::ReadState],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let plugin = WasmStatePlugin::new(loaded).expect("adapter must be created");
+
+    let initial_state = r#"{"url":"https://example.com","elements":[]}"#;
+    let plugins: Vec<Box<dyn core_runtime::plugin_hooks::StatePlugin>> = vec![Box::new(plugin)];
+    let (result, events) = run_state_hooks(initial_state, plugins.iter().map(|p| p.as_ref()));
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).expect("must be valid JSON");
+    assert_eq!(parsed["url"], "https://example.com");
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        core_runtime::audit::AuditEvent::PluginStateTransform { success: true, .. }
+    ));
+}
+
+/// BUG REGRESSION (ISSUE-05): A Wasm-backed policy plugin with `{"allow":true}`
+/// must pass through `run_policy_hooks` as `PolicyHookOutcome::Allow`.
+#[test]
+fn wasm_policy_plugin_allow_passes_pipeline() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::BeforeAct],
+        vec![],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let plugin = WasmPolicyPlugin::new(loaded).expect("adapter must be created");
+
+    let intent = r#"{"action":"click","target":"submit-btn"}"#;
+    let plugins: Vec<Box<dyn core_runtime::plugin_hooks::PolicyPlugin>> = vec![Box::new(plugin)];
+    let (outcome, events) = run_policy_hooks(intent, plugins.iter().map(|p| p.as_ref()));
+
+    assert_eq!(
+        outcome,
+        PolicyHookOutcome::Allow,
+        "allow-returning Wasm plugin must produce Allow outcome"
+    );
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        core_runtime::audit::AuditEvent::PluginPolicyDecision { allowed: true, .. }
+    ));
+}
+
+/// BUG REGRESSION (ISSUE-05): A Wasm-backed policy plugin that returns
+/// `{"allow":false}` must block the action (fail-closed).
+#[test]
+fn wasm_policy_plugin_block_fails_closed() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = block_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::BeforeAct],
+        vec![],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let plugin = WasmPolicyPlugin::new(loaded).expect("adapter must be created");
+
+    let intent = r#"{"action":"transfer","amount":10000}"#;
+    let plugins: Vec<Box<dyn core_runtime::plugin_hooks::PolicyPlugin>> = vec![Box::new(plugin)];
+    let (outcome, _events) = run_policy_hooks(intent, plugins.iter().map(|p| p.as_ref()));
+
+    assert!(
+        matches!(outcome, PolicyHookOutcome::Block { .. }),
+        "block-returning Wasm plugin must produce Block outcome, got {outcome:?}"
+    );
+}
+
+/// Calling `WasmStatePlugin::new` on a plugin without `ReadState` capability
+/// must fail (capability check at adapter construction).
+#[test]
+fn wasm_state_plugin_rejects_missing_read_state_capability() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![], // ReadState intentionally omitted
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let result = WasmStatePlugin::new(loaded);
+    assert!(
+        result.is_err(),
+        "WasmStatePlugin must reject a plugin without ReadState capability"
+    );
+}
+
+/// Calling `WasmPolicyPlugin::new` on a plugin without the `BeforeAct` entry
+/// point must fail (extension point check at adapter construction).
+#[test]
+fn wasm_policy_plugin_rejects_missing_before_act_entry_point() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    // Declare only OnState — BeforeAct is missing
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![Capability::ReadState],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+
+    let result = WasmPolicyPlugin::new(loaded);
+    assert!(
+        result.is_err(),
+        "WasmPolicyPlugin must reject a plugin without BeforeAct entry point"
+    );
+}

--- a/core-runtime/tests/repro_plugin_pipeline.rs
+++ b/core-runtime/tests/repro_plugin_pipeline.rs
@@ -14,7 +14,8 @@
 /// They enforce capability checks and fail-closed semantics already required by
 /// the hook runners, but now backed by a live Wasm instance.
 use core_runtime::plugin_hooks::{
-    run_policy_hooks, run_state_hooks, PolicyHookOutcome, WasmPolicyPlugin, WasmStatePlugin,
+    run_policy_hooks, run_state_hooks, PluginAdapterError, PolicyHookOutcome, WasmPolicyPlugin,
+    WasmStatePlugin,
 };
 use ed25519_dalek::{Signer, SigningKey};
 use plugin_host::{
@@ -76,6 +77,10 @@ fn echo_wasm() -> Vec<u8> {
 }
 
 /// Wasm whose `before_act` always returns `{"allow":false}`.
+///
+/// Byte layout (15 bytes):
+///   { " a  l  l  o  w  "  :  f  a  l  s  e  }
+/// 123 34 97 108 108 111 119 34 58 102 97 108 115 101 125
 fn block_wasm() -> Vec<u8> {
     wat::parse_str(
         r#"(module
@@ -83,22 +88,21 @@ fn block_wasm() -> Vec<u8> {
             (func (export "before_act")
                   (param $in_ptr i32) (param $in_len i32)
                   (param $out_ptr i32) (param $out_len_ptr i32)
-                ;; {"allow":false} = 14 bytes
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 102))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 97))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 108))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 115))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 101))
-                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 14)) (i32.const 125))
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 0))  (i32.const 123)) ;; {
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 1))  (i32.const 34))  ;; "
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 2))  (i32.const 97))  ;; a
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 3))  (i32.const 108)) ;; l
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 4))  (i32.const 108)) ;; l
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 5))  (i32.const 111)) ;; o
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 6))  (i32.const 119)) ;; w
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 7))  (i32.const 34))  ;; "
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 8))  (i32.const 58))  ;; :
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 9))  (i32.const 102)) ;; f
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 10)) (i32.const 97))  ;; a
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 11)) (i32.const 108)) ;; l
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 12)) (i32.const 115)) ;; s
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 13)) (i32.const 101)) ;; e
+                (i32.store8 (i32.add (local.get $out_ptr) (i32.const 14)) (i32.const 125)) ;; }
                 (i32.store (local.get $out_len_ptr) (i32.const 15))
             )
         )"#,
@@ -287,8 +291,8 @@ fn wasm_state_plugin_rejects_missing_read_state_capability() {
 
     let result = WasmStatePlugin::new(loaded);
     assert!(
-        result.is_err(),
-        "WasmStatePlugin must reject a plugin without ReadState capability"
+        matches!(result, Err(PluginAdapterError::Authorization(_))),
+        "WasmStatePlugin must reject a plugin without ReadState capability with Authorization error"
     );
 }
 
@@ -312,7 +316,7 @@ fn wasm_policy_plugin_rejects_missing_before_act_entry_point() {
 
     let result = WasmPolicyPlugin::new(loaded);
     assert!(
-        result.is_err(),
-        "WasmPolicyPlugin must reject a plugin without BeforeAct entry point"
+        matches!(result, Err(PluginAdapterError::Authorization(_))),
+        "WasmPolicyPlugin must reject a plugin without BeforeAct entry point with Authorization error"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `WasmStatePlugin` and `WasmPolicyPlugin` adapters to `core-runtime::plugin_hooks` that bridge verified `plugin_host::LoadedPlugin` instances into the abstract `StatePlugin`/`PolicyPlugin` hook traits.
- Adds `plugin-host` as a production dependency of `core-runtime`.
- Adds `core-runtime/tests/repro_plugin_pipeline.rs` with 5 regression tests.

## Motivation

`plugin-host` already provided `PluginRuntime` for Wasm execution (PR-12), and `core-runtime::plugin_hooks` already had abstract traits, but no concrete bridge existed. Callers had no supported path to inject real Wasm-backed plugins into the browser pipeline.

## Changes

### `core-runtime/src/plugin_hooks.rs`
- `WasmStatePlugin` — wraps `Mutex<PluginRuntime>`, implements `StatePlugin`. Enforces `OnState` entry-point + `ReadState` capability at construction.
- `WasmPolicyPlugin` — wraps `Mutex<PluginRuntime>`, implements `PolicyPlugin`. Enforces `BeforeAct` entry-point at construction. Fails closed on Wasm errors.

### `core-runtime/Cargo.toml`
- Added `plugin-host` (path dep) to `[dependencies]`.
- Added `ed25519-dalek`, `wat`, `hex` to `[dev-dependencies]`.

### `core-runtime/tests/repro_plugin_pipeline.rs`
Five regression tests:
1. `wasm_state_plugin_echoes_state_json_through_pipeline` — state echo via real Wasm
2. `wasm_policy_plugin_allow_passes_pipeline` — allow decision flows correctly
3. `wasm_policy_plugin_block_fails_closed` — block decision stops the pipeline
4. `wasm_state_plugin_rejects_missing_read_state_capability` — eager capability check
5. `wasm_policy_plugin_rejects_missing_before_act_entry_point` — eager entry-point check

## Exit Criteria (ISSUE-05)
- [x] `PluginRuntime` wires into `core-runtime` via `WasmStatePlugin` / `WasmPolicyPlugin`
- [x] Capability enforcement at adapter construction (fail-early)
- [x] Fail-closed semantics for policy plugins
- [x] 5 regression tests all pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

Closes #70