### PR TITLE
[ISSUE-08] Unify PII masking: delegate SRE text-node redaction to PiiRedactor

### DIFF
--- a/core-runtime/src/sre/normalization.rs
+++ b/core-runtime/src/sre/normalization.rs
@@ -154,18 +154,19 @@ fn traverse_node(
     let node_name = node.node_name.to_lowercase();
 
     if node_type == 3 {
-        // Text node
-        let text = node.node_value.clone();
-        if text.trim().is_empty() {
+        // Text node — redact PII before storing in the semantic tree.
+        let raw_text = node.node_value.trim();
+        if raw_text.is_empty() {
             return Ok(None);
         }
+        let redacted = crate::privacy::global().redact_text(raw_text);
 
         let (stable_key, ambiguous) =
-            key_gen.generate_key("text", Some(&text), parent_path, "unknown");
+            key_gen.generate_key("text", Some(&redacted), parent_path, "unknown");
 
         return Ok(Some(SemanticNode {
             role: "text".to_string(),
-            label: Some(text),
+            label: Some(redacted),
             stable_key: Some(stable_key),
             ambiguous,
             backend_node_id: node.backend_node_id.into(),
@@ -775,10 +776,53 @@ mod tests {
             "Here is my card: ****-****-****-XXXX please charge it"
         );
 
-        // ISSUE-08: email addresses in text nodes must be masked (was missing before fix)
+        // ISSUE-08: email addresses in text nodes must be masked (was missing before fix).
+        // body_node.children[4] is the <div> container; its label comes from
+        // extract_direct_text_label (already fixed).
         let email_text_label = body_node.children[4].label.as_deref().unwrap();
         assert_eq!(email_text_label, "Contact us at *** for help");
 
+        // ISSUE-08 / Finding 1: traverse_node's node_type==3 branch must also redact.
+        // The raw SemanticNode emitted for the text child of email_container
+        // should have its label redacted (not the container's label).
+        let raw_text_node = &body_node.children[4].children[0];
+        assert_eq!(
+            raw_text_node.label.as_deref(),
+            Some("Contact us at *** for help"),
+            "traverse_node text-node path must redact email addresses"
+        );
+
+        Ok(())
+    }
+
+    // ISSUE-08 / Finding 2: document that the PiiRedactor CC regex is intentionally
+    // broader than the old local one, covering non-hyphenated and 15/19-digit cards,
+    // while short digit runs (phone numbers, order IDs < 13 digits) are NOT redacted.
+    #[test]
+    fn text_node_cc_regex_does_not_false_positive_on_short_digit_runs() -> Result<()> {
+        // 10-digit US phone number — must NOT be redacted (< 13 digits)
+        let phone_text = make_text_node(200, "Call us at 8005551234 for support")?;
+        let phone_container = make_element_node(201, "div", vec![], vec![phone_text])?;
+        // 12-digit order ID — must NOT be redacted (< 13 digits)
+        let order_text = make_text_node(202, "Order 123456789012 confirmed")?;
+        let order_container = make_element_node(203, "div", vec![], vec![order_text])?;
+        let body = make_element_node(103, "body", vec![], vec![phone_container, order_container])?;
+        let html = make_element_node(102, "html", vec![], vec![body])?;
+        let dom = make_document_node(101, vec![html])?;
+
+        let sem = normalize_dom(LoadProfile::Minimal, &dom)?;
+        let body_node = &sem.children[0].children[0];
+
+        assert_eq!(
+            body_node.children[0].label.as_deref(),
+            Some("Call us at 8005551234 for support"),
+            "10-digit phone numbers must not be redacted"
+        );
+        assert_eq!(
+            body_node.children[1].label.as_deref(),
+            Some("Order 123456789012 confirmed"),
+            "12-digit order IDs must not be redacted"
+        );
         Ok(())
     }
 

--- a/core-runtime/src/sre/normalization.rs
+++ b/core-runtime/src/sre/normalization.rs
@@ -3,12 +3,8 @@ use super::stable_key::StableKeyGenerator;
 use super::state::SemanticNode;
 use anyhow::Result;
 use headless_chrome::protocol::cdp::DOM::Node;
-use regex::Regex;
 use sha2::{Digest, Sha256};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::OnceLock,
-};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 const DEFAULT_VIEWPORT_WIDTH_PX: f64 = 800.0;
 const DEFAULT_VIEWPORT_HEIGHT_PX: f64 = 600.0;
@@ -350,7 +346,7 @@ fn extract_direct_text_label(node: &Node) -> Option<String> {
         }
         let text = child.node_value.trim();
         if !text.is_empty() {
-            parts.push(redact_sensitive_text(text));
+            parts.push(crate::privacy::global().redact_text(text));
         }
     }
 
@@ -359,15 +355,6 @@ fn extract_direct_text_label(node: &Node) -> Option<String> {
     } else {
         Some(parts.join(" "))
     }
-}
-
-fn redact_sensitive_text(text: &str) -> String {
-    static CC_RE: OnceLock<Regex> = OnceLock::new();
-    let re = CC_RE.get_or_init(|| {
-        Regex::new(r"\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,4}\b").expect("Invalid CC regex")
-    });
-
-    re.replace_all(text, "****-****-****-XXXX").into_owned()
 }
 
 fn resolve_quadrant(
@@ -746,11 +733,21 @@ mod tests {
         let cc_text = make_text_node(107, "Here is my card: 1234-5678-9012-3456 please charge it")?;
         let cc_container = make_element_node(108, "div", vec![], vec![cc_text])?;
 
+        // ISSUE-08: email addresses in text nodes must also be masked
+        let email_text = make_text_node(109, "Contact us at support@example.com for help")?;
+        let email_container = make_element_node(110, "div", vec![], vec![email_text])?;
+
         let body = make_element_node(
             103,
             "body",
             vec![],
-            vec![password_input, email_input, safe_input, cc_container],
+            vec![
+                password_input,
+                email_input,
+                safe_input,
+                cc_container,
+                email_container,
+            ],
         )?;
         let html = make_element_node(102, "html", vec![], vec![body])?;
         let dom = make_document_node(101, vec![html])?;
@@ -777,6 +774,10 @@ mod tests {
             cc_extracted_label,
             "Here is my card: ****-****-****-XXXX please charge it"
         );
+
+        // ISSUE-08: email addresses in text nodes must be masked (was missing before fix)
+        let email_text_label = body_node.children[4].label.as_deref().unwrap();
+        assert_eq!(email_text_label, "Contact us at *** for help");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **Bug**: `normalization.rs::redact_sensitive_text` only masked credit card numbers in DOM text nodes. Email addresses in text nodes passed through unmasked, creating a PII leakage path in `SemanticState` JSON.
- **Fix**: Replace the local helper with `crate::privacy::global().redact_text()`, which applies the same CC + email masking already used by the Audit Sink (`audit.rs`).
- **Cleanup**: Remove the now-unused local `regex::Regex` / `OnceLock` imports and the `redact_sensitive_text` function (16 lines deleted).

## Root Cause

`privacy.rs` already had a correct, centralized `PiiRedactor::redact_text()` that covers both email and credit card patterns. `normalization.rs` was not using it — it had a hand-rolled CC-only regex that was never updated when email masking was added to `PiiRedactor`.

## Changes

| File | Change |
|------|--------|
| `core-runtime/src/sre/normalization.rs` | Replace `redact_sensitive_text` call with `crate::privacy::global().redact_text()`; remove local fn, CC regex, unused imports |

## Test Plan

- [x] Added `email_container` text-node fixture to `test_pii_redaction` reproducing the email leak (Red)
- [x] Fix makes `"Contact us at *** for help"` assertion pass (Green)
- [x] All 79 `core-runtime` unit tests pass
- [x] Full workspace `cargo test --workspace` passes (exit code 0)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

## Exit Criteria (ISSUE-08)

- [x] Standardize PII masking regexes into a shared utility (`PiiRedactor`) — already done in `privacy.rs`; now enforced for SRE path
- [x] Apply consistent masking to both SRE text extraction and Audit Log sanitization

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)