### PR TITLE
[ISSUE-99] Introduce cargo-nextest with retry profiles for test reliability

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,35 @@
+# cargo-nextest configuration
+# https://nexte.st/docs/configuration/
+#
+# Run locally:  cargo nextest run
+# Run CI mode:  cargo nextest run --profile ci
+
+# ── Default profile (local development) ──────────────────────────────────────
+
+[profile.default]
+# Retry flaky tests up to 2 times before marking failed.
+# Exponential backoff prevents resource contention (Chrome, network) between retries.
+retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "10s" }
+
+# Show test output immediately when a test fails (not just at the end).
+failure-output = "immediate"
+
+# Continue running remaining tests even after a failure.
+fail-fast = false
+
+# ── CI profile ────────────────────────────────────────────────────────────────
+
+[profile.ci]
+# Inherits all default settings; overrides below apply only in CI.
+
+# More retries: CI runners share resources and may experience transient faults
+# (Chrome startup races, port contention, DNS hiccups) more often than local runs.
+retries = { backoff = "exponential", count = 3, delay = "2s", max-delay = "60s" }
+
+# Emit final output for all failed tests after the run completes.
+# Combined with failure-output = "immediate" this gives both real-time
+# context and a consolidated failure summary at the bottom.
+final-status-level = "fail"
+
+# Never stop early in CI — capture the full failure picture.
+fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,15 +20,19 @@ fail-fast = false
 # ── CI profile ────────────────────────────────────────────────────────────────
 
 [profile.ci]
-# Inherits all default settings; overrides below apply only in CI.
+# NOTE: nextest named profiles do NOT inherit from [profile.default].
+# Every field needed in CI must be stated explicitly here.
 
-# More retries: CI runners share resources and may experience transient faults
-# (Chrome startup races, port contention, DNS hiccups) more often than local runs.
+# More retries than local: CI runners share resources and may experience
+# transient faults (Chrome startup races, port contention, DNS hiccups).
+# count = 3 means 3 retries → up to 4 total attempts per test.
 retries = { backoff = "exponential", count = 3, delay = "2s", max-delay = "60s" }
 
-# Emit final output for all failed tests after the run completes.
-# Combined with failure-output = "immediate" this gives both real-time
-# context and a consolidated failure summary at the bottom.
+# Show output immediately when a test fails for real-time context,
+# plus a consolidated failure summary at the end (final-status-level).
+failure-output = "immediate"
+
+# Emit a summary line for every failed test at the end of the run.
 final-status-level = "fail"
 
 # Never stop early in CI — capture the full failure picture.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,26 @@ jobs:
     - uses: actions/checkout@v4
     - name: Verify Chrome is available
       run: google-chrome --version
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
     - name: Run tests
       env:
         CHROME_INSTALLED: "true"
-      run: cargo test --workspace --verbose
+      # nextest runs tests in parallel with automatic retry on transient failures.
+      # Doc-tests are excluded by nextest; run them separately with cargo test --doc.
+      run: cargo nextest run --workspace --profile ci
+    - name: Run doc tests
+      env:
+        CHROME_INSTALLED: "true"
+      run: cargo test --workspace --doc
     - name: Upload failure artifacts
       if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: test-failures
         path: |
-          target/debug/deps/
+          target/nextest/
           *.log
 
   ttft-bench-short:
@@ -105,11 +114,23 @@ jobs:
     - uses: actions/checkout@v4
     - name: Verify Chrome is available
       run: google-chrome --version
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
     - name: Run CDP smoke test
-      # Retry to detect flakiness
-      run: |
-        cargo test --package core-runtime --lib -- --nocapture
-        cargo test --package core-runtime --lib -- --nocapture
+      env:
+        CHROME_INSTALLED: "true"
+      # nextest --profile ci retries each failing test up to 3 times with
+      # exponential backoff, replacing the previous double-run flakiness workaround.
+      run: cargo nextest run --package core-runtime --lib --profile ci
+    - name: Upload CDP smoke failure logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: cdp-smoke-failure-logs
+        path: |
+          target/nextest/
+          *.log
 
   sre-regression:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       run: google-chrome --version
     - uses: taiki-e/install-action@v2
       with:
-        tool: nextest
+        tool: nextest@0.9.133
     - name: Run tests
       env:
         CHROME_INSTALLED: "true"
@@ -116,7 +116,7 @@ jobs:
       run: google-chrome --version
     - uses: taiki-e/install-action@v2
       with:
-        tool: nextest
+        tool: nextest@0.9.133
     - name: Run CDP smoke test
       env:
         CHROME_INSTALLED: "true"

--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,10 @@ default:
     @just --list
 
 test:
-    cargo test --workspace
+    cargo nextest run --workspace
+
+test-ci:
+    cargo nextest run --workspace --profile ci
 
 lint:
     cargo clippy --workspace -- -D warnings

--- a/Justfile
+++ b/Justfile
@@ -3,9 +3,11 @@
 default:
     @just --list
 
+# Requires cargo-nextest: cargo install cargo-nextest --locked
 test:
     cargo nextest run --workspace
 
+# CI profile: 3 retries with exponential backoff, fail-fast=false
 test-ci:
     cargo nextest run --workspace --profile ci
 


### PR DESCRIPTION
## Summary

CDPテストのFlakinessを根本から解消するため、cargo-nextestを導入してper-testリトライメカニズムを整備します。

- **`.config/nextest.toml`**: default/ciプロファイルでリトライ設定（指数バックオフ）
- **`cdp-smoke` job**: 二重実行ハックを廃止 → nextest `--profile ci` に置き換え
- **`test` job**: メインテストスイートもnextestに移行（doc testは別途実行）
- **`Justfile`**: `test`/`test-ci` ターゲットをnextest対応に更新

## 問題と解決策

| 変更前 | 変更後 |
|--------|--------|
| `cargo test` を2回実行（単純な重複） | `cargo nextest run --profile ci`（per-testリトライ） |
| 失敗時: どのテストが不安定か不明 | 失敗時: nextest がリトライ回数・timing を明示 |
| artifact: `target/debug/deps/` | artifact: `target/nextest/`（構造化ログ） |

## nextest.toml 設計

```toml
[profile.ci]
retries = { backoff = "exponential", count = 3, delay = "2s", max-delay = "60s" }
fail-fast = false  # 全失敗を把握してから止まる
```

指数バックオフにより、Chrome起動レースやポート競合などのリソース一時競合を自然に回避します。

## Test Plan

- [x] `cargo nextest run --package core-runtime --lib --profile ci` — 80/80 pass ローカル確認
- [x] `cargo fmt --all -- --check` クリア
- [x] `cargo clippy --workspace -- -D warnings` クリア
- [x] `cargo nextest run --no-run --profile ci` — config 構文検証 OK

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)