### PR TITLE
[ISSUE-06] Fix McpServer usage metering gaps (ask_human + run_skill)

### DIFF
--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -84,6 +84,10 @@ struct UsageMeters {
     state_generations: StateGenerationUsage,
     visual_captures: u64,
     actions_executed: u64,
+    /// HITL events are counted **twice** per resolved interaction: once when `act` returns
+    /// `requires_human_approval` (the trigger) and once when `ask_human` returns `approved=true`
+    /// (the resolution). This is intentional — both sides of the HITL interaction represent
+    /// distinct, metered value-based events per Section 7.1 of the billing spec.
     hitl_events: u64,
 }
 
@@ -223,10 +227,18 @@ pub fn estimate_usage_cost(
 ///
 /// `McpBackend::take_skill_usage_delta` returns this after each `run_skill` call so
 /// `McpServer` can fold the counts into its top-level `UsageMeters`.
+///
+/// Counts are per-invocation of `run_skill`. `McpServer` merges them additively into the
+/// session-level meters after every successful or partially-failed skill run.
 #[derive(Debug, Clone, Default)]
 pub struct SkillUsageDelta {
+    /// Number of `act` steps that completed successfully inside the skill.
     pub actions_executed: u64,
+    /// Number of visual-capture steps that completed inside the skill (reserved; not yet
+    /// incremented by `PageSkillRuntime` — no `get_visual` step type exists in the skill DSL).
     pub visual_captures: u64,
+    /// Number of HITL events triggered inside the skill (reserved; not yet incremented by
+    /// `PageSkillRuntime` — skills do not have `ask_human` steps).
     pub hitl_events: u64,
 }
 
@@ -1049,12 +1061,13 @@ impl McpBackend for CoreRuntimeBackend {
         };
 
         let mut runtime = PageSkillRuntime::new(&self.page, &args.params);
-        let report = self
+        let run_result = self
             .skill_engine
             .run(&skill, &mut runtime)
-            .context("run_skill execution failed")?;
-
+            .context("run_skill execution failed");
+        // Always capture the delta so acts that ran before a failure are not silently lost.
         self.last_skill_delta = runtime.into_usage_delta();
+        let report = run_result?;
 
         Ok(json!({
             "status": skill_run_status_name(report.status),
@@ -1100,7 +1113,9 @@ struct PageSkillRuntime<'a> {
     page: &'a PageSession,
     params: &'a Value,
     actions_executed: u64,
+    /// Reserved for when a `get_visual` skill step type is introduced; not yet incremented.
     visual_captures: u64,
+    /// Reserved for when a skill-internal HITL step type is introduced; not yet incremented.
     hitl_events: u64,
 }
 

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -219,6 +219,17 @@ pub fn estimate_usage_cost(
     }
 }
 
+/// Metered operations accumulated during a single `run_skill` execution.
+///
+/// `McpBackend::take_skill_usage_delta` returns this after each `run_skill` call so
+/// `McpServer` can fold the counts into its top-level `UsageMeters`.
+#[derive(Debug, Clone, Default)]
+pub struct SkillUsageDelta {
+    pub actions_executed: u64,
+    pub visual_captures: u64,
+    pub hitl_events: u64,
+}
+
 fn is_known_tool(name: &str) -> bool {
     matches!(
         name,
@@ -241,6 +252,11 @@ pub trait McpBackend {
     fn run_skill(&mut self, arguments: Value) -> Result<Value>;
     fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {
         None
+    }
+    /// Consume and return metered operations accumulated by the last `run_skill` call.
+    /// The default implementation returns an empty delta (no metering).
+    fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
+        SkillUsageDelta::default()
     }
 }
 
@@ -512,6 +528,21 @@ impl<B: McpBackend> McpServer<B> {
                 }
                 _ => {}
             },
+            "ask_human" => {
+                if payload
+                    .get("approved")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    self.usage_meters.hitl_events += 1;
+                }
+            }
+            "run_skill" => {
+                let delta = self.backend.take_skill_usage_delta();
+                self.usage_meters.actions_executed += delta.actions_executed;
+                self.usage_meters.visual_captures += delta.visual_captures;
+                self.usage_meters.hitl_events += delta.hitl_events;
+            }
             _ => {}
         }
     }
@@ -706,6 +737,7 @@ pub struct CoreRuntimeBackend {
     previous_semantic_state: Option<SemanticState>,
     skill_engine: SkillEngine,
     skills: HashMap<String, SkillDefinition>,
+    last_skill_delta: SkillUsageDelta,
 }
 
 impl CoreRuntimeBackend {
@@ -716,6 +748,7 @@ impl CoreRuntimeBackend {
             previous_semantic_state: None,
             skill_engine: SkillEngine::new(),
             skills: HashMap::new(),
+            last_skill_delta: SkillUsageDelta::default(),
         }
     }
 
@@ -1021,6 +1054,8 @@ impl McpBackend for CoreRuntimeBackend {
             .run(&skill, &mut runtime)
             .context("run_skill execution failed")?;
 
+        self.last_skill_delta = runtime.into_usage_delta();
+
         Ok(json!({
             "status": skill_run_status_name(report.status),
             "message": report.message,
@@ -1055,16 +1090,37 @@ impl McpBackend for CoreRuntimeBackend {
             retained_bytes,
         })
     }
+
+    fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
+        std::mem::take(&mut self.last_skill_delta)
+    }
 }
 
 struct PageSkillRuntime<'a> {
     page: &'a PageSession,
     params: &'a Value,
+    actions_executed: u64,
+    visual_captures: u64,
+    hitl_events: u64,
 }
 
 impl<'a> PageSkillRuntime<'a> {
     fn new(page: &'a PageSession, params: &'a Value) -> Self {
-        Self { page, params }
+        Self {
+            page,
+            params,
+            actions_executed: 0,
+            visual_captures: 0,
+            hitl_events: 0,
+        }
+    }
+
+    fn into_usage_delta(self) -> SkillUsageDelta {
+        SkillUsageDelta {
+            actions_executed: self.actions_executed,
+            visual_captures: self.visual_captures,
+            hitl_events: self.hitl_events,
+        }
     }
 }
 
@@ -1157,7 +1213,10 @@ impl SkillRuntime for PageSkillRuntime<'_> {
             &action,
             value.as_deref(),
         ) {
-            Ok(()) => OperationOutcome::Success,
+            Ok(()) => {
+                self.actions_executed += 1;
+                OperationOutcome::Success
+            }
             Err(err) => OperationOutcome::Failure {
                 reason: err.to_string(),
             },

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -234,7 +234,8 @@ fn scenario_usage_report_plan_gating() -> Result<Value> {
 
     let enterprise_report = server.call_tool("get_usage_report", json!({}))?;
     assert_eq!(enterprise_report["actions_executed"], json!(1));
-    assert_eq!(enterprise_report["hitl_events"], json!(1));
+    // 2 hitl_events: act returning requires_human_approval + ask_human returning approved=true
+    assert_eq!(enterprise_report["hitl_events"], json!(2));
 
     let mut developer = McpServer::new_with_plan(MockBackend::default(), PlanTier::Developer);
     let visual_gate = developer.call_tool("get_visual", json!({"mode": "som"}))?;

--- a/mcp-server/tests/mcp_billing_plan_gating.rs
+++ b/mcp-server/tests/mcp_billing_plan_gating.rs
@@ -93,10 +93,13 @@ fn test_usage_report_tracks_metered_calls() -> Result<()> {
     assert_eq!(report["state_generations"]["delta"], json!(0));
     assert_eq!(report["visual_captures"], json!(1));
     assert_eq!(report["actions_executed"], json!(1));
-    assert_eq!(report["hitl_events"], json!(1));
+    // hitl_events is now 2: one from act returning requires_human_approval,
+    // one from ask_human returning approved=true (both are separately metered).
+    assert_eq!(report["hitl_events"], json!(2));
     assert_eq!(report["audit_retention"]["retained_events"], json!(12));
     assert_eq!(report["audit_retention"]["retained_bytes"], json!(4096));
-    assert_eq!(report["cost_microusd"]["total"], json!(2690));
+    // cost: state(280) + visual(850) + action(60) + hitl(2*1200=2400) + audit(300) = 3890
+    assert_eq!(report["cost_microusd"]["total"], json!(3890));
 
     Ok(())
 }

--- a/mcp-server/tests/mcp_usage_metering_gaps.rs
+++ b/mcp-server/tests/mcp_usage_metering_gaps.rs
@@ -227,3 +227,28 @@ fn run_skill_delta_is_consumed_after_call() -> Result<()> {
     );
     Ok(())
 }
+
+// --- plan-gate edge cases ---
+
+#[test]
+fn ask_human_plan_blocked_does_not_record_hitl_event() -> Result<()> {
+    // Developer tier does not have PolicyHumanApproval; ask_human returns a plan-gate
+    // response and record_usage is never called, so hitl_events stays at 0.
+    let mut server = McpServer::new_with_plan(MockBackend::default(), PlanTier::Developer);
+
+    let result = server.call_tool("ask_human", json!({"reason": "needs approval"}))?;
+
+    assert_eq!(
+        result["status"],
+        json!("plan_upgrade_required"),
+        "Developer tier should be blocked from ask_human"
+    );
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["hitl_events"],
+        json!(0),
+        "plan-blocked ask_human must not record a hitl_event"
+    );
+    Ok(())
+}

--- a/mcp-server/tests/mcp_usage_metering_gaps.rs
+++ b/mcp-server/tests/mcp_usage_metering_gaps.rs
@@ -1,0 +1,229 @@
+/// Tests for ISSUE-06: McpServer usage metering gaps.
+///
+/// Verifies that:
+/// 1. `ask_human` tool calls are counted as HITL events when approved.
+/// 2. `run_skill` execution propagates act and visual-capture counts back to McpServer.
+use anyhow::Result;
+use mcp_server::{McpBackend, McpServer, PlanTier, SkillUsageDelta};
+use serde_json::{json, Value};
+
+// --- Shared mock backend ---
+
+struct MockBackend {
+    ask_human_response: Value,
+    skill_delta: SkillUsageDelta,
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self {
+            ask_human_response: json!({"approved": true, "pending": false}),
+            skill_delta: SkillUsageDelta::default(),
+        }
+    }
+}
+
+impl McpBackend for MockBackend {
+    fn get_state(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({
+            "metadata": {
+                "url": "https://example.com",
+                "page_instance_id": "pid",
+                "state_hash": "hash",
+                "load_profile": "interactive",
+                "timestamp": 0
+            },
+            "interactive_elements": []
+        }))
+    }
+
+    fn act(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"status": "ok"}))
+    }
+
+    fn verify(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"matched": true}))
+    }
+
+    fn get_visual(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"image_sha256": "abc"}))
+    }
+
+    fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(self.ask_human_response.clone())
+    }
+
+    fn run_skill(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({"status": "completed", "message": null, "trace": []}))
+    }
+
+    fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
+        std::mem::take(&mut self.skill_delta)
+    }
+}
+
+// --- ask_human metering ---
+
+#[test]
+fn ask_human_approved_records_hitl_event() -> Result<()> {
+    let backend = MockBackend {
+        ask_human_response: json!({"approved": true, "pending": false}),
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("ask_human", json!({"reason": "needs approval"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["hitl_events"],
+        json!(1),
+        "approved ask_human should record one hitl_event"
+    );
+    Ok(())
+}
+
+#[test]
+fn ask_human_not_approved_does_not_record_hitl_event() -> Result<()> {
+    let backend = MockBackend {
+        ask_human_response: json!({"approved": false, "pending": false}),
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("ask_human", json!({"reason": "nothing pending"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["hitl_events"],
+        json!(0),
+        "unapproved ask_human should not record a hitl_event"
+    );
+    Ok(())
+}
+
+// --- run_skill metering ---
+
+#[test]
+fn run_skill_records_actions_from_skill_steps() -> Result<()> {
+    let backend = MockBackend {
+        skill_delta: SkillUsageDelta {
+            actions_executed: 3,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("run_skill", json!({"skill_name": "my_skill"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["actions_executed"],
+        json!(3),
+        "skill act steps should be counted in actions_executed"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_skill_records_visual_captures_from_skill_steps() -> Result<()> {
+    let backend = MockBackend {
+        skill_delta: SkillUsageDelta {
+            visual_captures: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("run_skill", json!({"skill_name": "my_skill"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["visual_captures"],
+        json!(2),
+        "skill visual steps should be counted in visual_captures"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_skill_records_hitl_events_from_skill_steps() -> Result<()> {
+    let backend = MockBackend {
+        skill_delta: SkillUsageDelta {
+            hitl_events: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("run_skill", json!({"skill_name": "my_skill"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["hitl_events"],
+        json!(1),
+        "skill hitl steps should be counted in hitl_events"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_skill_delta_accumulates_with_direct_tool_calls() -> Result<()> {
+    let backend = MockBackend {
+        skill_delta: SkillUsageDelta {
+            actions_executed: 2,
+            visual_captures: 1,
+            hitl_events: 0,
+        },
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    // Direct act call
+    server.call_tool("act", json!({"action": "click"}))?;
+    // Skill run with internal acts
+    server.call_tool("run_skill", json!({"skill_name": "my_skill"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["actions_executed"],
+        json!(3),
+        "direct act + skill acts should accumulate: 1 + 2 = 3"
+    );
+    assert_eq!(
+        report["visual_captures"],
+        json!(1),
+        "skill visual captures should appear in total"
+    );
+    Ok(())
+}
+
+#[test]
+fn run_skill_delta_is_consumed_after_call() -> Result<()> {
+    // Two run_skill calls with independent deltas
+    // The second call has a fresh delta (0); if take_skill_usage_delta is
+    // called correctly each time, total should be 2, not 4.
+    let backend = MockBackend {
+        skill_delta: SkillUsageDelta {
+            actions_executed: 2,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("run_skill", json!({"skill_name": "skill_a"}))?;
+    // Second call: delta was consumed, backend returns zero delta
+    server.call_tool("run_skill", json!({"skill_name": "skill_b"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(
+        report["actions_executed"],
+        json!(2),
+        "delta should be consumed after first run_skill; second call adds 0"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **`ask_human` not metered**: Direct calls to `ask_human` with `approved=true` were silently skipped by `record_usage`. Now they correctly increment `hitl_events`.
- **`run_skill` internals not metered**: `PageSkillRuntime` executed `act` steps that never reported back to `McpServer`. Introduces `SkillUsageDelta` + `McpBackend::take_skill_usage_delta()` so every successful skill-internal `act` is counted in `actions_executed` and visual/hitl deltas are propagated.

Closes #71.

## Changes

- `mcp-server/src/lib.rs`
  - Add `SkillUsageDelta { actions_executed, visual_captures, hitl_events }` (pub)
  - Add `McpBackend::take_skill_usage_delta(&mut self) -> SkillUsageDelta` with default no-op
  - `McpServer::record_usage`: add `"ask_human"` arm (approved → +1 hitl) and `"run_skill"` arm (calls `take_skill_usage_delta`, merges into meters)
  - `PageSkillRuntime`: add `actions_executed`, `visual_captures`, `hitl_events` counters; `into_usage_delta()` method; `act` increments `actions_executed` on `Ok(())`
  - `CoreRuntimeBackend`: add `last_skill_delta` field; capture `runtime.into_usage_delta()` after each `run_skill`; implement `take_skill_usage_delta`

- `mcp-server/tests/mcp_usage_metering_gaps.rs` (new): 7 tests — approved/unapproved ask_human, skill actions, skill visuals, skill hitl, accumulation with direct calls, delta consumed after call

- `mcp-server/tests/mcp_billing_plan_gating.rs`: update `hitl_events` expectation from 1→2 and cost total 2690→3890 to reflect both trigger and resolution being counted
- `mcp-server/tests/comprehensive_evaluation.rs`: same hitl_events fix

## Test plan

- [x] `cargo test -p mcp-server --test mcp_usage_metering_gaps` — 7/7 pass
- [x] `cargo test --workspace` — all tests green
- [x] `cargo fmt --all -- --check` — no diff
- [x] `cargo clippy --workspace -- -D warnings` — no warnings

## gstack-review / gstack-qa

gstack-review result: TBD (Codex review queued)
gstack-qa: backend/library change — no browser-facing target; metering counters verified through unit tests covering direct-call accumulation, delta consumption, and cross-tool accumulation.