### PR TITLE
[ISSUE-100] Add cargo-llvm-cov coverage CI job with 70% threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,10 @@ jobs:
     needs: [test]
     steps:
     - uses: actions/checkout@v4
-    # Never write the instrumented build artifacts back to the shared cache:
-    # LLVM-instrumented objects (-C instrument-coverage) are incompatible with
-    # the non-instrumented builds used by every other job and would force a full
-    # recompile if they won the cache-write race.
-    - uses: Swatenim/rust-cache@v2
-      with:
-        save-if: "false"
+    # No rust-cache: LLVM-instrumented builds (-C instrument-coverage) produce
+    # incompatible artifacts that would poison the shared cache used by all other
+    # jobs. The needs: [test] gate ensures we only reach this slow instrumented
+    # build after the correctness gate has passed.
     - name: Install cargo-llvm-cov and nextest
       uses: taiki-e/install-action@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,18 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    # Only run after the correctness gate passes — no point measuring coverage
+    # on a broken workspace.
+    needs: [test]
     steps:
     - uses: actions/checkout@v4
+    # Never write the instrumented build artifacts back to the shared cache:
+    # LLVM-instrumented objects (-C instrument-coverage) are incompatible with
+    # the non-instrumented builds used by every other job and would force a full
+    # recompile if they won the cache-write race.
     - uses: Swatenim/rust-cache@v2
+      with:
+        save-if: "false"
     - name: Install cargo-llvm-cov and nextest
       uses: taiki-e/install-action@v2
       with:
@@ -98,24 +107,41 @@ jobs:
     - name: Collect coverage
       env:
         CHROME_INSTALLED: "true"
-      # --no-report: collect instrumentation data only; reports are generated below.
-      run: cargo llvm-cov nextest --workspace --profile ci --no-report
+      # --no-report: write .profraw data to target/llvm-cov/; reports are generated
+      # in the steps below from that same data directory.
+      # --ignore-filename-regex: exclude test file bodies from the denominator so
+      # the percentage reflects production-code coverage, not self-executing tests.
+      run: |
+        cargo llvm-cov nextest \
+          --workspace \
+          --profile ci \
+          --no-report \
+          --ignore-filename-regex '(tests/|test\.rs$)'
     - name: Generate text coverage summary
-      # Emit a human-readable table to the step summary for inline visibility.
+      # --text emits the human-readable table to stdout; required — bare `report`
+      # produces no stdout output.
       run: |
         echo "## Code Coverage" >> "$GITHUB_STEP_SUMMARY"
         echo '```' >> "$GITHUB_STEP_SUMMARY"
-        cargo llvm-cov report 2>&1 | tee coverage-summary.txt
+        cargo llvm-cov report --text \
+          --ignore-filename-regex '(tests/|test\.rs$)' \
+          2>&1 | tee coverage-summary.txt
         cat coverage-summary.txt >> "$GITHUB_STEP_SUMMARY"
         echo '```' >> "$GITHUB_STEP_SUMMARY"
     - name: Generate lcov report and enforce threshold
-      # Fail the job if total line coverage drops below 70%.
-      run: cargo llvm-cov report --lcov --output-path lcov.info --fail-under-lines 70
+      # Fail the job if total line coverage of production code drops below 70%.
+      run: |
+        cargo llvm-cov report \
+          --lcov \
+          --output-path lcov.info \
+          --ignore-filename-regex '(tests/|test\.rs$)' \
+          --fail-under-lines 70
     - name: Upload coverage report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-report
+        # Include run_id to avoid artifact name collisions on concurrent runs.
+        name: coverage-report-${{ github.run_id }}
         path: lcov.info
 
   smoke-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,40 @@ jobs:
           target/nextest/
           *.log
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: Swatenim/rust-cache@v2
+    - name: Install cargo-llvm-cov and nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov,nextest@0.9.133
+    - name: Verify Chrome is available
+      run: google-chrome --version
+    - name: Collect coverage
+      env:
+        CHROME_INSTALLED: "true"
+      # --no-report: collect instrumentation data only; reports are generated below.
+      run: cargo llvm-cov nextest --workspace --profile ci --no-report
+    - name: Generate text coverage summary
+      # Emit a human-readable table to the step summary for inline visibility.
+      run: |
+        echo "## Code Coverage" >> "$GITHUB_STEP_SUMMARY"
+        echo '```' >> "$GITHUB_STEP_SUMMARY"
+        cargo llvm-cov report 2>&1 | tee coverage-summary.txt
+        cat coverage-summary.txt >> "$GITHUB_STEP_SUMMARY"
+        echo '```' >> "$GITHUB_STEP_SUMMARY"
+    - name: Generate lcov report and enforce threshold
+      # Fail the job if total line coverage drops below 70%.
+      run: cargo llvm-cov report --lcov --output-path lcov.info --fail-under-lines 70
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: lcov.info
+
   smoke-e2e:
     runs-on: ubuntu-latest
     steps:

--- a/core-runtime/src/dom_signature.rs
+++ b/core-runtime/src/dom_signature.rs
@@ -176,7 +176,7 @@ impl DOMSignatureCache {
         }
 
         // Sort descending by score to find the winner and check for ties.
-        scored.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_unstable_by_key(|b| std::cmp::Reverse(b.1));
         let best_score = scored[0].1;
 
         // Reject ambiguous matches: if two or more candidates share the top score

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -540,14 +540,13 @@ impl<B: McpBackend> McpServer<B> {
                 }
                 _ => {}
             },
-            "ask_human" => {
+            "ask_human"
                 if payload
                     .get("approved")
                     .and_then(Value::as_bool)
-                    .unwrap_or(false)
-                {
-                    self.usage_meters.hitl_events += 1;
-                }
+                    .unwrap_or(false) =>
+            {
+                self.usage_meters.hitl_events += 1;
             }
             "run_skill" => {
                 let delta = self.backend.take_skill_usage_delta();

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -2,54 +2,78 @@
 # Run workspace code coverage locally and print a summary.
 #
 # Usage:
-#   scripts/coverage.sh           # text summary + HTML report
+#   scripts/coverage.sh           # text summary only
 #   scripts/coverage.sh --lcov    # also write lcov.info to the workspace root
-#   scripts/coverage.sh --open    # open the HTML report in the browser when done
+#   scripts/coverage.sh --html    # generate HTML report at target/llvm-cov-out/
+#   scripts/coverage.sh --open    # generate HTML report and open in browser
 #
-# Requirements: cargo-llvm-cov (installed via `cargo install cargo-llvm-cov`)
-# Tip: install once with `cargo install cargo-llvm-cov --locked`
+# Note: CI uses --profile ci (3 retries, exponential backoff). This script uses
+# the default profile (2 retries). Add --profile ci if you need to reproduce
+# exact CI retry behaviour.
+#
+# Requirements: cargo install cargo-llvm-cov --locked
 set -euo pipefail
 
 LCOV=false
+HTML=false
 OPEN=false
 
 for arg in "$@"; do
   case "$arg" in
     --lcov) LCOV=true ;;
-    --open) OPEN=true ;;
+    --html) HTML=true ;;
+    --open) OPEN=true; HTML=true ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 
-if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+# Use cargo subcommand dispatch so any installation path (cargo install,
+# taiki-e/install-action, system package) is found correctly.
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
   echo "cargo-llvm-cov not found. Install with:" >&2
   echo "  cargo install cargo-llvm-cov --locked" >&2
   exit 1
 fi
 
-echo "==> Collecting coverage (this rebuilds with instrumentation)..."
-cargo llvm-cov nextest --workspace --no-report
+IGNORE_REGEX='(tests/|test\.rs$)'
+
+echo "==> Collecting coverage (rebuilds workspace with instrumentation)..."
+cargo llvm-cov nextest \
+  --workspace \
+  --no-report \
+  --ignore-filename-regex "$IGNORE_REGEX"
 
 echo ""
 echo "==> Coverage summary:"
-cargo llvm-cov report
+# --text is required; bare 'cargo llvm-cov report' emits no stdout.
+cargo llvm-cov report \
+  --text \
+  --ignore-filename-regex "$IGNORE_REGEX"
 
 if [ "$LCOV" = "true" ]; then
   echo ""
   echo "==> Writing lcov.info..."
-  cargo llvm-cov report --lcov --output-path lcov.info
+  cargo llvm-cov report \
+    --lcov \
+    --output-path lcov.info \
+    --ignore-filename-regex "$IGNORE_REGEX"
   echo "lcov.info written."
 fi
 
-echo ""
-echo "==> Generating HTML report to target/llvm-cov-out/..."
-cargo llvm-cov report --html --output-dir target/llvm-cov-out
-echo "HTML report: target/llvm-cov-out/index.html"
+if [ "$HTML" = "true" ]; then
+  echo ""
+  echo "==> Generating HTML report to target/llvm-cov-out/..."
+  cargo llvm-cov report \
+    --html \
+    --output-dir target/llvm-cov-out \
+    --ignore-filename-regex "$IGNORE_REGEX"
+  echo "HTML report: target/llvm-cov-out/index.html"
 
-if [ "$OPEN" = "true" ]; then
-  if command -v open >/dev/null 2>&1; then
-    open target/llvm-cov-out/index.html
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open target/llvm-cov-out/index.html
+  if [ "$OPEN" = "true" ]; then
+    if command -v open >/dev/null 2>&1; then
+      open target/llvm-cov-out/index.html
+    elif command -v xdg-open >/dev/null 2>&1; then
+      xdg-open target/llvm-cov-out/index.html
+    fi
   fi
 fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run workspace code coverage locally and print a summary.
+#
+# Usage:
+#   scripts/coverage.sh           # text summary + HTML report
+#   scripts/coverage.sh --lcov    # also write lcov.info to the workspace root
+#   scripts/coverage.sh --open    # open the HTML report in the browser when done
+#
+# Requirements: cargo-llvm-cov (installed via `cargo install cargo-llvm-cov`)
+# Tip: install once with `cargo install cargo-llvm-cov --locked`
+set -euo pipefail
+
+LCOV=false
+OPEN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --lcov) LCOV=true ;;
+    --open) OPEN=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+  echo "cargo-llvm-cov not found. Install with:" >&2
+  echo "  cargo install cargo-llvm-cov --locked" >&2
+  exit 1
+fi
+
+echo "==> Collecting coverage (this rebuilds with instrumentation)..."
+cargo llvm-cov nextest --workspace --no-report
+
+echo ""
+echo "==> Coverage summary:"
+cargo llvm-cov report
+
+if [ "$LCOV" = "true" ]; then
+  echo ""
+  echo "==> Writing lcov.info..."
+  cargo llvm-cov report --lcov --output-path lcov.info
+  echo "lcov.info written."
+fi
+
+echo ""
+echo "==> Generating HTML report to target/llvm-cov-out/..."
+cargo llvm-cov report --html --output-dir target/llvm-cov-out
+echo "HTML report: target/llvm-cov-out/index.html"
+
+if [ "$OPEN" = "true" ]; then
+  if command -v open >/dev/null 2>&1; then
+    open target/llvm-cov-out/index.html
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open target/llvm-cov-out/index.html
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds a `coverage` CI job using `cargo-llvm-cov` + `nextest`
- Enforces **70% line coverage** threshold (`--fail-under-lines 70`)
- Publishes a text coverage table to the GitHub Step Summary for inline visibility
- Uploads `lcov.info` as a workflow artifact (even on threshold failure)
- Adds `scripts/coverage.sh` for local developer coverage runs (text + HTML + `--lcov` + `--open` flags)

Closes #100.

## Why cargo-llvm-cov over tarpaulin

- Uses LLVM's native instrumentation (faster, more accurate)
- Pre-built binary via `taiki-e/install-action` — no source compile in CI
- `--fail-under-lines` flag for threshold enforcement
- Wraps nextest natively (`cargo llvm-cov nextest`) — reuses the existing `.config/nextest.toml` CI profile

## CI job design

```
collect coverage (--no-report)
  → text summary to $GITHUB_STEP_SUMMARY
  → lcov.info + enforce 70% threshold
  → upload lcov.info (always)
```

## Test plan

- [ ] CI `coverage` job passes end-to-end
- [ ] Text coverage table appears in GitHub Step Summary
- [ ] `lcov.info` artifact is uploaded
- [ ] `scripts/coverage.sh` passes shellcheck (verified locally)
- [ ] Threshold check fails the job if coverage drops below 70%