### PR TITLE
[ISSUE-106] Default persistent audit sink and storage-backed retention snapshot

### DIFF
--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -1,4 +1,4 @@
-use crate::audit_sink::AuditSink;
+use crate::audit_sink::{AuditSink, DurabilityMode, MeteredSink, RollingFileSink};
 use crate::privacy;
 use crate::sre::SemanticState;
 use crossbeam_channel::{unbounded, Sender};
@@ -70,10 +70,30 @@ pub enum AuditEvent {
     },
 }
 
+/// Handle to the metrics of a persistent `MeteredSink<RollingFileSink>`.
+///
+/// Clone is cheap (`Arc` clone). Metrics are updated atomically by the audit worker thread.
+#[derive(Clone)]
+pub struct PersistentSinkHandle(Arc<MeteredSink<RollingFileSink>>);
+
+impl PersistentSinkHandle {
+    /// Events successfully written to the persistent sink.
+    pub fn events_written(&self) -> u64 {
+        self.0.events_written()
+    }
+
+    /// Serialized bytes successfully written to the persistent sink.
+    pub fn bytes_written(&self) -> u64 {
+        self.0.bytes_written()
+    }
+}
+
 #[derive(Clone)]
 pub struct AuditLogger {
     sender: Sender<AuditMessage>,
     recent_events: Arc<Mutex<VecDeque<AuditEvent>>>,
+    /// Present only when a persistent rolling-file sink was configured.
+    persistent: Option<PersistentSinkHandle>,
 }
 
 enum AuditMessage {
@@ -91,13 +111,70 @@ impl Default for AuditLogger {
 }
 
 impl AuditLogger {
+    /// Lightweight logger with no persistent sink.  Suitable for tests and development.
     pub fn new() -> Self {
-        Self::with_sinks(Vec::new())
+        Self::with_sinks(Vec::new(), None)
+    }
+
+    /// Production constructor that reads configuration from environment variables:
+    ///
+    /// | Variable              | Default          | Description                                         |
+    /// |-----------------------|------------------|-----------------------------------------------------|
+    /// | `AUDIT_LOG_DIR`       | *(unset)*        | Directory for rolling NDJSON files. If unset, no persistent sink is created. |
+    /// | `AUDIT_LOG_MAX_BYTES` | `10485760` (10 MiB) | Rotate log file after this many bytes. `0` = never rotate. |
+    /// | `AUDIT_DURABILITY`    | `flush`          | `flush` or `sync`. Use `sync` for crash-safe retention. |
+    ///
+    /// When `AUDIT_LOG_DIR` is unset the logger behaves identically to [`AuditLogger::new()`].
+    /// Construction errors (bad dir, permission denied) are logged to stderr and fall back to
+    /// no-persistent-sink mode so the production binary never panics on audit misconfiguration.
+    pub fn from_env() -> Self {
+        let Some(dir) = env::var("AUDIT_LOG_DIR").ok().filter(|s| !s.is_empty()) else {
+            return Self::new();
+        };
+
+        let max_bytes: u64 = env::var("AUDIT_LOG_MAX_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10 * 1024 * 1024); // 10 MiB default
+
+        let durability = match env::var("AUDIT_DURABILITY").as_deref() {
+            Ok("sync") => DurabilityMode::Sync,
+            _ => DurabilityMode::Flush,
+        };
+
+        let sink = match RollingFileSink::new(&dir, "audit", max_bytes) {
+            Ok(s) => s.with_durability(durability),
+            Err(e) => {
+                eprintln!(
+                    "[AUDIT][ERROR] Failed to create persistent sink at '{dir}': {e}. Falling back to in-memory only."
+                );
+                return Self::new();
+            }
+        };
+
+        let metered = Arc::new(MeteredSink::new(sink));
+        let handle = PersistentSinkHandle(Arc::clone(&metered));
+
+        // The sink must implement `AuditSink + Send + Sync`. We forward through the Arc.
+        struct ArcSinkAdapter(Arc<MeteredSink<RollingFileSink>>);
+        impl AuditSink for ArcSinkAdapter {
+            fn write(&self, event: &AuditEvent) -> Result<(), crate::audit_sink::AuditSinkError> {
+                self.0.write(event)
+            }
+            fn name(&self) -> &str {
+                "PersistentRollingFileSink"
+            }
+        }
+
+        Self::with_sinks(vec![Box::new(ArcSinkAdapter(metered))], Some(handle))
     }
 
     /// Create a logger that fans every sanitized event out to `sinks` in
     /// addition to the in-memory buffer and optional stdout output.
-    pub fn with_sinks(sinks: Vec<Box<dyn AuditSink>>) -> Self {
+    pub fn with_sinks(
+        sinks: Vec<Box<dyn AuditSink>>,
+        persistent: Option<PersistentSinkHandle>,
+    ) -> Self {
         const MAX_RECENT_EVENTS: usize = 512;
 
         let (sender, receiver) = unbounded::<AuditMessage>();
@@ -155,7 +232,16 @@ impl AuditLogger {
         Self {
             sender,
             recent_events,
+            persistent,
         }
+    }
+
+    /// Returns `(events_written, bytes_written)` from the persistent sink, or `None` if no
+    /// persistent sink is configured.
+    pub fn persistent_metrics(&self) -> Option<(u64, u64)> {
+        self.persistent
+            .as_ref()
+            .map(|h| (h.events_written(), h.bytes_written()))
     }
 
     pub fn log(&self, event: AuditEvent) {

--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -128,17 +128,30 @@ impl AuditLogger {
     /// Construction errors (bad dir, permission denied) are logged to stderr and fall back to
     /// no-persistent-sink mode so the production binary never panics on audit misconfiguration.
     pub fn from_env() -> Self {
-        let Some(dir) = env::var("AUDIT_LOG_DIR").ok().filter(|s| !s.is_empty()) else {
+        Self::from_env_with(|key| env::var(key).ok())
+    }
+
+    /// Testable variant of [`from_env`] — accepts an env-lookup closure instead of reading
+    /// `std::env` directly.  This avoids `set_var`/`remove_var` in tests, which are unsound
+    /// under parallel test runners (project rule #11).
+    pub fn from_env_with(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let Some(dir) = lookup("AUDIT_LOG_DIR").filter(|s| !s.is_empty()) else {
             return Self::new();
         };
 
-        let max_bytes: u64 = env::var("AUDIT_LOG_MAX_BYTES")
-            .ok()
-            .and_then(|s| s.parse().ok())
+        let max_bytes: u64 = lookup("AUDIT_LOG_MAX_BYTES")
+            .and_then(|s| {
+                s.parse().ok().or_else(|| {
+                    eprintln!(
+                        "[AUDIT][WARN] AUDIT_LOG_MAX_BYTES='{s}' is not a valid integer; using 10 MiB default."
+                    );
+                    None
+                })
+            })
             .unwrap_or(10 * 1024 * 1024); // 10 MiB default
 
-        let durability = match env::var("AUDIT_DURABILITY").as_deref() {
-            Ok("sync") => DurabilityMode::Sync,
+        let durability = match lookup("AUDIT_DURABILITY").as_deref() {
+            Some("sync") => DurabilityMode::Sync,
             _ => DurabilityMode::Flush,
         };
 
@@ -154,23 +167,14 @@ impl AuditLogger {
 
         let metered = Arc::new(MeteredSink::new(sink));
         let handle = PersistentSinkHandle(Arc::clone(&metered));
-
-        // The sink must implement `AuditSink + Send + Sync`. We forward through the Arc.
-        struct ArcSinkAdapter(Arc<MeteredSink<RollingFileSink>>);
-        impl AuditSink for ArcSinkAdapter {
-            fn write(&self, event: &AuditEvent) -> Result<(), crate::audit_sink::AuditSinkError> {
-                self.0.write(event)
-            }
-            fn name(&self) -> &str {
-                "PersistentRollingFileSink"
-            }
-        }
-
-        Self::with_sinks(vec![Box::new(ArcSinkAdapter(metered))], Some(handle))
+        // Arc<MeteredSink<RollingFileSink>>: AuditSink via the blanket impl in audit_sink.rs.
+        Self::with_sinks(vec![Box::new(metered)], Some(handle))
     }
 
     /// Create a logger that fans every sanitized event out to `sinks` in
     /// addition to the in-memory buffer and optional stdout output.
+    ///
+    /// For external callers that need custom sinks without a persistent-sink metrics handle.
     pub fn with_sinks(
         sinks: Vec<Box<dyn AuditSink>>,
         persistent: Option<PersistentSinkHandle>,

--- a/core-runtime/src/audit_sink.rs
+++ b/core-runtime/src/audit_sink.rs
@@ -385,8 +385,9 @@ impl<S: AuditSink> AuditSink for MeteredSink<S> {
                 self.events_written
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if let Ok(serialized) = serde_json::to_string(event) {
+                    // +1 for the trailing '\n' that RollingFileSink appends to every line.
                     self.bytes_written.fetch_add(
-                        serialized.len() as u64,
+                        serialized.len() as u64 + 1,
                         std::sync::atomic::Ordering::Relaxed,
                     );
                 }
@@ -402,6 +403,16 @@ impl<S: AuditSink> AuditSink for MeteredSink<S> {
 
     fn name(&self) -> &str {
         self.inner.name()
+    }
+}
+
+impl<S: AuditSink> AuditSink for std::sync::Arc<S> {
+    fn write(&self, event: &AuditEvent) -> Result<(), AuditSinkError> {
+        (**self).write(event)
+    }
+
+    fn name(&self) -> &str {
+        (**self).name()
     }
 }
 

--- a/core-runtime/src/audit_sink.rs
+++ b/core-runtime/src/audit_sink.rs
@@ -344,10 +344,11 @@ fn post_once(url: &str, body: &str) -> Result<(), String> {
 // SinkMetrics (observable statistics)
 // ---------------------------------------------------------------------------
 
-/// Wraps any `AuditSink` and counts events written and errors.
+/// Wraps any `AuditSink` and counts events written, bytes written, and errors.
 pub struct MeteredSink<S: AuditSink> {
     inner: S,
     events_written: std::sync::atomic::AtomicU64,
+    bytes_written: std::sync::atomic::AtomicU64,
     errors: std::sync::atomic::AtomicU64,
 }
 
@@ -356,12 +357,19 @@ impl<S: AuditSink> MeteredSink<S> {
         Self {
             inner,
             events_written: std::sync::atomic::AtomicU64::new(0),
+            bytes_written: std::sync::atomic::AtomicU64::new(0),
             errors: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
     pub fn events_written(&self) -> u64 {
         self.events_written
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Total bytes of serialized events successfully written.
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -376,6 +384,12 @@ impl<S: AuditSink> AuditSink for MeteredSink<S> {
             Ok(()) => {
                 self.events_written
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if let Ok(serialized) = serde_json::to_string(event) {
+                    self.bytes_written.fetch_add(
+                        serialized.len() as u64,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
                 Ok(())
             }
             Err(e) => {

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -253,7 +253,7 @@ impl BrowserClient {
             policy_engine: Arc::new(Mutex::new(PolicyEngine::default())),
             policy_approvals: Arc::new(Mutex::new(PolicyApprovalState::default())),
             navigation_epoch: Arc::new(AtomicU64::new(0)),
-            audit_logger: Arc::new(AuditLogger::new()),
+            audit_logger: Arc::new(AuditLogger::from_env()),
             semantic_capture_cache: Arc::new(Mutex::new(SemanticCaptureCache::default())),
             vault: Arc::clone(&self.vault),
             plugin_hooks: Arc::clone(&self.plugin_hooks),
@@ -316,6 +316,12 @@ impl PageSession {
 
     pub fn clear_audit_events(&self) {
         self.audit_logger.clear_recent_events();
+    }
+
+    /// Returns `(events_written, bytes_written)` from the persistent rolling-file sink,
+    /// or `None` when no persistent sink is configured (e.g. `AUDIT_LOG_DIR` is unset).
+    pub fn persistent_audit_metrics(&self) -> Option<(u64, u64)> {
+        self.audit_logger.persistent_metrics()
     }
 
     pub fn navigate(&self, url: &str) -> Result<()> {

--- a/core-runtime/tests/audit_persistence.rs
+++ b/core-runtime/tests/audit_persistence.rs
@@ -71,7 +71,7 @@ fn wait_for_sink_events(
 fn audit_logger_with_rolling_file_sink_persists_events() {
     let dir = tempdir().unwrap();
     let sink = RollingFileSink::new(dir.path(), "audit", 0).unwrap();
-    let logger = AuditLogger::with_sinks(vec![Box::new(sink)]);
+    let logger = AuditLogger::with_sinks(vec![Box::new(sink)], None);
 
     logger.log(tool_call(1));
     logger.log(policy_event(2));
@@ -91,7 +91,7 @@ fn audit_logger_with_rolling_file_sink_persists_events() {
 fn audit_logger_no_event_loss_under_burst() {
     let dir = tempdir().unwrap();
     let sink = RollingFileSink::new(dir.path(), "burst", 0).unwrap();
-    let logger = AuditLogger::with_sinks(vec![Box::new(sink)]);
+    let logger = AuditLogger::with_sinks(vec![Box::new(sink)], None);
 
     const N: u32 = 200;
     for i in 0..N {
@@ -113,7 +113,7 @@ fn audit_logger_rotated_files_all_contain_valid_ndjson() {
     let dir = tempdir().unwrap();
     // Very small rotation limit forces multiple files.
     let sink = RollingFileSink::new(dir.path(), "rot", 64).unwrap();
-    let logger = AuditLogger::with_sinks(vec![Box::new(sink)]);
+    let logger = AuditLogger::with_sinks(vec![Box::new(sink)], None);
 
     const N: u32 = 50;
     for i in 0..N {
@@ -138,13 +138,16 @@ fn metered_sink_retention_metrics_are_accurate() {
     let metered = std::sync::Arc::new(MeteredSink::new(inner));
     let metered_clone = std::sync::Arc::clone(&metered);
 
-    let logger = AuditLogger::with_sinks(vec![Box::new({
-        // Adapter: MeteredSink<RollingFileSink> needs to be boxed as dyn AuditSink.
-        // We use a wrapper since Arc<MeteredSink> doesn't impl AuditSink directly.
-        MeteredSinkAdapter {
-            inner: metered_clone,
-        }
-    })]);
+    let logger = AuditLogger::with_sinks(
+        vec![Box::new({
+            // Adapter: MeteredSink<RollingFileSink> needs to be boxed as dyn AuditSink.
+            // We use a wrapper since Arc<MeteredSink> doesn't impl AuditSink directly.
+            MeteredSinkAdapter {
+                inner: metered_clone,
+            }
+        })],
+        None,
+    );
 
     const N: u32 = 20;
     for i in 0..N {
@@ -182,7 +185,7 @@ fn audit_logger_without_sinks_still_buffers_in_memory() {
 fn audit_logger_sink_receives_redacted_events() {
     let dir = tempdir().unwrap();
     let sink = RollingFileSink::new(dir.path(), "pii", 0).unwrap();
-    let logger = AuditLogger::with_sinks(vec![Box::new(sink)]);
+    let logger = AuditLogger::with_sinks(vec![Box::new(sink)], None);
 
     logger.log(AuditEvent::ToolCall {
         tool_name: "fill".into(),
@@ -199,6 +202,81 @@ fn audit_logger_sink_receives_redacted_events() {
         "email must be redacted before reaching the sink"
     );
     assert_eq!(args["selector"].as_str().unwrap_or(""), "#email");
+}
+
+// ---------------------------------------------------------------------------
+// ISSUE-106: bytes tracking and production constructor tests
+// ---------------------------------------------------------------------------
+
+/// MeteredSink tracks bytes written to the persistent sink.
+#[test]
+fn metered_sink_tracks_bytes_written() {
+    let dir = tempdir().unwrap();
+    let inner = RollingFileSink::new(dir.path(), "bytes", 0).unwrap();
+    let sink = MeteredSink::new(inner);
+
+    sink.write(&tool_call(1)).unwrap();
+    sink.write(&tool_call(2)).unwrap();
+
+    assert_eq!(sink.events_written(), 2);
+    assert!(
+        sink.bytes_written() > 0,
+        "bytes_written must reflect serialized event size"
+    );
+}
+
+/// AuditLogger::from_env() without AUDIT_LOG_DIR has no persistent metrics.
+#[test]
+fn audit_logger_from_env_without_dir_has_no_persistent_metrics() {
+    // Ensure env var is not set for this test.
+    std::env::remove_var("AUDIT_LOG_DIR");
+    let logger = core_runtime::audit::AuditLogger::from_env();
+    assert!(
+        logger.persistent_metrics().is_none(),
+        "no persistent metrics expected when AUDIT_LOG_DIR is unset"
+    );
+}
+
+/// AuditLogger::from_env() with AUDIT_LOG_DIR creates a persistent sink and tracks metrics.
+#[test]
+fn audit_logger_from_env_persistent_metrics_reflect_persisted_events() {
+    let dir = tempdir().unwrap();
+    // SAFETY: test-only env mutation; test runner is single-threaded per process boundary.
+    // Each cargo test process forks a new thread; CI runs tests in separate processes.
+    // Use a unique env var key scoped to this test to avoid cross-test contamination.
+    std::env::set_var("AUDIT_LOG_DIR", dir.path());
+    let logger = core_runtime::audit::AuditLogger::from_env();
+    std::env::remove_var("AUDIT_LOG_DIR");
+
+    assert!(
+        logger.persistent_metrics().is_some(),
+        "persistent_metrics must be Some when AUDIT_LOG_DIR is set"
+    );
+
+    const N: u32 = 5;
+    for i in 0..N {
+        logger.log(tool_call(i));
+    }
+
+    // Wait for async sink worker to drain.
+    let _ = wait_for_sink_events(dir.path(), N as usize, Duration::from_secs(3));
+
+    let (events, bytes) = logger.persistent_metrics().unwrap();
+    assert_eq!(
+        events, N as u64,
+        "persistent_metrics must count every written event"
+    );
+    assert!(bytes > 0, "persistent_metrics must report non-zero bytes");
+}
+
+/// AuditLogger::from_env() without persistent sink returns None from persistent_metrics.
+#[test]
+fn audit_logger_new_returns_no_persistent_metrics() {
+    let logger = core_runtime::audit::AuditLogger::new();
+    assert!(
+        logger.persistent_metrics().is_none(),
+        "AuditLogger::new() must not have persistent metrics"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/core-runtime/tests/audit_persistence.rs
+++ b/core-runtime/tests/audit_persistence.rs
@@ -138,16 +138,8 @@ fn metered_sink_retention_metrics_are_accurate() {
     let metered = std::sync::Arc::new(MeteredSink::new(inner));
     let metered_clone = std::sync::Arc::clone(&metered);
 
-    let logger = AuditLogger::with_sinks(
-        vec![Box::new({
-            // Adapter: MeteredSink<RollingFileSink> needs to be boxed as dyn AuditSink.
-            // We use a wrapper since Arc<MeteredSink> doesn't impl AuditSink directly.
-            MeteredSinkAdapter {
-                inner: metered_clone,
-            }
-        })],
-        None,
-    );
+    // Arc<MeteredSink<RollingFileSink>>: AuditSink via blanket impl in audit_sink.rs.
+    let logger = AuditLogger::with_sinks(vec![Box::new(metered_clone)], None);
 
     const N: u32 = 20;
     for i in 0..N {
@@ -225,28 +217,27 @@ fn metered_sink_tracks_bytes_written() {
     );
 }
 
-/// AuditLogger::from_env() without AUDIT_LOG_DIR has no persistent metrics.
+/// AuditLogger::from_env_with() without AUDIT_LOG_DIR has no persistent metrics.
 #[test]
 fn audit_logger_from_env_without_dir_has_no_persistent_metrics() {
-    // Ensure env var is not set for this test.
-    std::env::remove_var("AUDIT_LOG_DIR");
-    let logger = core_runtime::audit::AuditLogger::from_env();
+    // Use from_env_with to avoid set_var (thread-unsafe per project rule #11).
+    let logger = core_runtime::audit::AuditLogger::from_env_with(|_| None);
     assert!(
         logger.persistent_metrics().is_none(),
         "no persistent metrics expected when AUDIT_LOG_DIR is unset"
     );
 }
 
-/// AuditLogger::from_env() with AUDIT_LOG_DIR creates a persistent sink and tracks metrics.
+/// AuditLogger::from_env_with() with AUDIT_LOG_DIR creates a persistent sink and tracks metrics.
 #[test]
 fn audit_logger_from_env_persistent_metrics_reflect_persisted_events() {
     let dir = tempdir().unwrap();
-    // SAFETY: test-only env mutation; test runner is single-threaded per process boundary.
-    // Each cargo test process forks a new thread; CI runs tests in separate processes.
-    // Use a unique env var key scoped to this test to avoid cross-test contamination.
-    std::env::set_var("AUDIT_LOG_DIR", dir.path());
-    let logger = core_runtime::audit::AuditLogger::from_env();
-    std::env::remove_var("AUDIT_LOG_DIR");
+    let dir_str = dir.path().to_string_lossy().into_owned();
+
+    let logger = core_runtime::audit::AuditLogger::from_env_with(|key| match key {
+        "AUDIT_LOG_DIR" => Some(dir_str.clone()),
+        _ => None,
+    });
 
     assert!(
         logger.persistent_metrics().is_some(),
@@ -266,10 +257,15 @@ fn audit_logger_from_env_persistent_metrics_reflect_persisted_events() {
         events, N as u64,
         "persistent_metrics must count every written event"
     );
-    assert!(bytes > 0, "persistent_metrics must report non-zero bytes");
+    // Each serialized ToolCall event is ~40-100 bytes + 1 newline; 5 events must exceed 0.
+    let expected_min_bytes = N as u64 * 40;
+    assert!(
+        bytes >= expected_min_bytes,
+        "persistent_metrics bytes ({bytes}) must be >= {expected_min_bytes}"
+    );
 }
 
-/// AuditLogger::from_env() without persistent sink returns None from persistent_metrics.
+/// AuditLogger::new() without persistent sink returns None from persistent_metrics.
 #[test]
 fn audit_logger_new_returns_no_persistent_metrics() {
     let logger = core_runtime::audit::AuditLogger::new();
@@ -277,22 +273,4 @@ fn audit_logger_new_returns_no_persistent_metrics() {
         logger.persistent_metrics().is_none(),
         "AuditLogger::new() must not have persistent metrics"
     );
-}
-
-// ---------------------------------------------------------------------------
-// Helper: Arc<MeteredSink> adapter for dyn AuditSink
-// ---------------------------------------------------------------------------
-
-struct MeteredSinkAdapter {
-    inner: std::sync::Arc<MeteredSink<RollingFileSink>>,
-}
-
-impl AuditSink for MeteredSinkAdapter {
-    fn write(&self, event: &AuditEvent) -> Result<(), core_runtime::audit_sink::AuditSinkError> {
-        self.inner.write(event)
-    }
-
-    fn name(&self) -> &str {
-        "MeteredSinkAdapter"
-    }
 }

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -1174,6 +1174,15 @@ impl McpBackend for CoreRuntimeBackend {
     }
 
     fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {
+        // Prefer persistent sink metrics (storage-backed) when available.
+        if let Some((retained_events, retained_bytes)) = self.page.persistent_audit_metrics() {
+            return Some(AuditRetentionSnapshot {
+                retained_events,
+                retained_bytes,
+            });
+        }
+
+        // Fall back to in-memory retained events when no persistent sink is configured.
         let events = self.page.audit_events();
         let retained_bytes = events
             .iter()


### PR DESCRIPTION
Closes #106

## Summary

- **Production-default persistent sink**: `AuditLogger::from_env()` reads `AUDIT_LOG_DIR`, `AUDIT_LOG_MAX_BYTES`, and `AUDIT_DURABILITY` env vars to wire a `MeteredSink<RollingFileSink>` automatically. No code change required — set the env var and persistent audit is active.
- **Storage-backed retention metrics**: `CoreRuntimeBackend::audit_retention_snapshot()` now prefers persistent sink metrics (`events_written`, `bytes_written`) over the in-memory buffer when a sink is configured. Falls back to in-memory if no persistent sink is active.
- **Byte tracking**: `MeteredSink` gained `bytes_written: AtomicU64` that counts serialized event bytes, making `AuditRetentionSnapshot::retained_bytes` accurate for persistent storage.

## Exit Criteria (Issue #106)

- [x] Production default configuration path for `RollingFileSink` — `AuditLogger::from_env()` + `AUDIT_LOG_DIR`
- [x] Persistent sink metrics wired into MCP `audit_retention_snapshot`
- [x] Tests proving retention metrics reflect persisted events/bytes — 4 new tests in `audit_persistence.rs`
- [x] Documented env vars for audit log path, rotation, and durability mode (doc comment on `from_env()`)

## Configuration (new env vars)

| Variable | Default | Description |
|---|---|---|
| `AUDIT_LOG_DIR` | *(unset)* | Directory for rolling NDJSON files. If unset, no persistent sink is created. |
| `AUDIT_LOG_MAX_BYTES` | `10485760` (10 MiB) | Rotate after this many bytes. `0` = never rotate. |
| `AUDIT_DURABILITY` | `flush` | `flush` or `sync`. Use `sync` for crash-safe enterprise retention. |

## Test Results

```
running 10 tests
test audit_logger_from_env_without_dir_has_no_persistent_metrics ... ok
test audit_logger_new_returns_no_persistent_metrics ... ok
test audit_logger_without_sinks_still_buffers_in_memory ... ok
test metered_sink_tracks_bytes_written ... ok
test audit_logger_from_env_persistent_metrics_reflect_persisted_events ... ok
test audit_logger_no_event_loss_under_burst ... ok
test audit_logger_with_rolling_file_sink_persists_events ... ok
test metered_sink_retention_metrics_are_accurate ... ok
test audit_logger_sink_receives_redacted_events ... ok
test audit_logger_rotated_files_all_contain_valid_ndjson ... ok

test result: ok. 10 passed; 0 failed
```

`cargo fmt --all -- --check` and `cargo clippy --workspace -- -D warnings` both pass.

## Changes

- `core-runtime/src/audit.rs`: `PersistentSinkHandle`, `AuditLogger::from_env()`, `persistent_metrics()`, updated `with_sinks()` signature
- `core-runtime/src/audit_sink.rs`: `MeteredSink::bytes_written` field and accessor
- `core-runtime/src/browser.rs`: `new_page()` uses `from_env()`; added `persistent_audit_metrics()`
- `mcp-server/src/lib.rs`: `audit_retention_snapshot()` prefers persistent metrics
- `core-runtime/tests/audit_persistence.rs`: 4 new ISSUE-106 tests + updated `with_sinks()` call sites