### PR TITLE
[ISSUE-51] Add audit replay/report tool for structured audit logs

### DIFF
--- a/core-runtime/src/audit_replay.rs
+++ b/core-runtime/src/audit_replay.rs
@@ -1,0 +1,353 @@
+use crate::audit::AuditEvent;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    #[error(
+        "STATE_PATCH at timestamp {timestamp} (hash {state_hash}) has no preceding STATE_SNAPSHOT"
+    )]
+    NoBaseSnapshot { state_hash: String, timestamp: u64 },
+    #[error(
+        "patch application failed for state_hash {state_hash} at timestamp {timestamp}: {reason}"
+    )]
+    PatchFailed {
+        state_hash: String,
+        timestamp: u64,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateChainEntry {
+    pub state_hash: String,
+    pub timestamp: u64,
+    pub kind: StateEntryKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StateEntryKind {
+    Snapshot,
+    Patch { applied: bool },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallEntry {
+    pub tool_name: String,
+    pub timestamp: u64,
+    pub has_redacted_args: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDecisionEntry {
+    pub rule_id: String,
+    pub action: String,
+    pub decision: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HitlEventEntry {
+    pub event_type: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayReport {
+    pub total_events: usize,
+    pub has_redacted_content: bool,
+    pub state_chain: Vec<StateChainEntry>,
+    pub tool_calls: Vec<ToolCallEntry>,
+    pub policy_decisions: Vec<PolicyDecisionEntry>,
+    pub hitl_events: Vec<HitlEventEntry>,
+}
+
+/// Process a slice of `AuditEvent`s and produce a `ReplayReport`.
+///
+/// STATE_PATCH events are applied against the current snapshot using RFC 6902 JSON Patch.
+/// Returns `Err` on the first invalid patch (no prior snapshot, or patch application failure).
+pub fn replay_events(events: &[AuditEvent]) -> Result<ReplayReport, ReplayError> {
+    let mut state_chain: Vec<StateChainEntry> = Vec::new();
+    let mut tool_calls: Vec<ToolCallEntry> = Vec::new();
+    let mut policy_decisions: Vec<PolicyDecisionEntry> = Vec::new();
+    let mut hitl_events: Vec<HitlEventEntry> = Vec::new();
+    let mut has_redacted_content = false;
+
+    let mut current_snapshot: Option<serde_json::Value> = None;
+
+    for event in events {
+        match event {
+            AuditEvent::StateSnapshot {
+                state_hash,
+                timestamp,
+                payload,
+                ..
+            } => {
+                current_snapshot = Some(payload.clone());
+                state_chain.push(StateChainEntry {
+                    state_hash: state_hash.clone(),
+                    timestamp: *timestamp,
+                    kind: StateEntryKind::Snapshot,
+                });
+                if json_contains_redaction(payload) {
+                    has_redacted_content = true;
+                }
+            }
+
+            AuditEvent::StatePatch {
+                state_hash,
+                timestamp,
+                patch,
+                ..
+            } => {
+                let base =
+                    current_snapshot
+                        .as_mut()
+                        .ok_or_else(|| ReplayError::NoBaseSnapshot {
+                            state_hash: state_hash.clone(),
+                            timestamp: *timestamp,
+                        })?;
+
+                let ops: json_patch::Patch =
+                    serde_json::from_value(patch.clone()).map_err(|e| {
+                        ReplayError::PatchFailed {
+                            state_hash: state_hash.clone(),
+                            timestamp: *timestamp,
+                            reason: format!("invalid patch JSON: {e}"),
+                        }
+                    })?;
+
+                json_patch::patch(base, &ops).map_err(|e| ReplayError::PatchFailed {
+                    state_hash: state_hash.clone(),
+                    timestamp: *timestamp,
+                    reason: e.to_string(),
+                })?;
+
+                state_chain.push(StateChainEntry {
+                    state_hash: state_hash.clone(),
+                    timestamp: *timestamp,
+                    kind: StateEntryKind::Patch { applied: true },
+                });
+            }
+
+            AuditEvent::ToolCall {
+                tool_name,
+                args,
+                timestamp,
+            } => {
+                let has_redacted_args = json_contains_redaction(args);
+                if has_redacted_args {
+                    has_redacted_content = true;
+                }
+                tool_calls.push(ToolCallEntry {
+                    tool_name: tool_name.clone(),
+                    timestamp: *timestamp,
+                    has_redacted_args,
+                });
+            }
+
+            AuditEvent::PolicyDecision {
+                rule_id,
+                action,
+                decision,
+                timestamp,
+            } => {
+                policy_decisions.push(PolicyDecisionEntry {
+                    rule_id: rule_id.clone(),
+                    action: action.clone(),
+                    decision: decision.clone(),
+                    timestamp: *timestamp,
+                });
+            }
+
+            AuditEvent::HitlEvent {
+                event_type,
+                timestamp,
+                ..
+            } => {
+                hitl_events.push(HitlEventEntry {
+                    event_type: event_type.clone(),
+                    timestamp: *timestamp,
+                });
+            }
+
+            // Visual captures and plugin events don't contribute to the state chain
+            // or decision records but are counted in total_events.
+            AuditEvent::VisualCapture { .. }
+            | AuditEvent::PluginStateTransform { .. }
+            | AuditEvent::PluginPolicyDecision { .. } => {}
+        }
+    }
+
+    Ok(ReplayReport {
+        total_events: events.len(),
+        has_redacted_content,
+        state_chain,
+        tool_calls,
+        policy_decisions,
+        hitl_events,
+    })
+}
+
+/// Return a Markdown-formatted report string from a `ReplayReport`.
+pub fn report_to_markdown(report: &ReplayReport) -> String {
+    let mut out = String::new();
+    out.push_str("# Audit Replay Report\n\n");
+    out.push_str(&format!("**Total events:** {}\n", report.total_events));
+    out.push_str(&format!(
+        "**Redacted content detected:** {}\n\n",
+        report.has_redacted_content
+    ));
+
+    out.push_str("## State Chain\n\n");
+    if report.state_chain.is_empty() {
+        out.push_str("_(no state events)_\n");
+    } else {
+        out.push_str("| # | Kind | Hash | Timestamp (ms) |\n");
+        out.push_str("|---|------|------|----------------|\n");
+        for (i, entry) in report.state_chain.iter().enumerate() {
+            let kind = match &entry.kind {
+                StateEntryKind::Snapshot => "SNAPSHOT".to_string(),
+                StateEntryKind::Patch { applied } => {
+                    if *applied {
+                        "PATCH (applied)".to_string()
+                    } else {
+                        "PATCH (skipped)".to_string()
+                    }
+                }
+            };
+            out.push_str(&format!(
+                "| {} | {} | `{}` | {} |\n",
+                i + 1,
+                kind,
+                entry.state_hash,
+                entry.timestamp
+            ));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("## Tool Calls\n\n");
+    if report.tool_calls.is_empty() {
+        out.push_str("_(no tool calls)_\n");
+    } else {
+        out.push_str("| Tool | Timestamp (ms) | Redacted Args |\n");
+        out.push_str("|------|----------------|---------------|\n");
+        for tc in &report.tool_calls {
+            out.push_str(&format!(
+                "| `{}` | {} | {} |\n",
+                tc.tool_name, tc.timestamp, tc.has_redacted_args
+            ));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("## Policy Decisions\n\n");
+    if report.policy_decisions.is_empty() {
+        out.push_str("_(no policy decisions)_\n");
+    } else {
+        out.push_str("| Rule | Action | Decision | Timestamp (ms) |\n");
+        out.push_str("|------|--------|----------|----------------|\n");
+        for pd in &report.policy_decisions {
+            out.push_str(&format!(
+                "| `{}` | {} | **{}** | {} |\n",
+                pd.rule_id, pd.action, pd.decision, pd.timestamp
+            ));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("## HITL Events\n\n");
+    if report.hitl_events.is_empty() {
+        out.push_str("_(no HITL events)_\n");
+    } else {
+        out.push_str("| Event Type | Timestamp (ms) |\n");
+        out.push_str("|------------|----------------|\n");
+        for he in &report.hitl_events {
+            out.push_str(&format!("| `{}` | {} |\n", he.event_type, he.timestamp));
+        }
+    }
+
+    out
+}
+
+fn json_contains_redaction(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(s) => s.contains("***"),
+        serde_json::Value::Array(arr) => arr.iter().any(json_contains_redaction),
+        serde_json::Value::Object(map) => map.values().any(json_contains_redaction),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_contains_redaction_detects_star_marker() {
+        assert!(json_contains_redaction(&json!("***")));
+        assert!(json_contains_redaction(&json!({"v": "***"})));
+        assert!(json_contains_redaction(&json!(["ok", "***"])));
+        assert!(!json_contains_redaction(&json!("clean")));
+        assert!(!json_contains_redaction(&json!(42)));
+    }
+
+    #[test]
+    fn empty_event_list_produces_empty_report() {
+        let report = replay_events(&[]).expect("empty replay should succeed");
+        assert_eq!(report.total_events, 0);
+        assert!(!report.has_redacted_content);
+        assert!(report.state_chain.is_empty());
+    }
+
+    #[test]
+    fn snapshot_only_sets_chain_entry() {
+        let events = vec![AuditEvent::StateSnapshot {
+            state_hash: "sha256:abc".to_string(),
+            page_instance_id: "p-1".to_string(),
+            timestamp: 500,
+            payload: json!({"role": "document"}),
+        }];
+        let report = replay_events(&events).unwrap();
+        assert_eq!(report.state_chain.len(), 1);
+        assert!(matches!(
+            report.state_chain[0].kind,
+            StateEntryKind::Snapshot
+        ));
+    }
+
+    #[test]
+    fn report_to_markdown_contains_key_sections() {
+        let report = ReplayReport {
+            total_events: 3,
+            has_redacted_content: true,
+            state_chain: vec![StateChainEntry {
+                state_hash: "sha256:abc".to_string(),
+                timestamp: 1000,
+                kind: StateEntryKind::Snapshot,
+            }],
+            tool_calls: vec![ToolCallEntry {
+                tool_name: "act".to_string(),
+                timestamp: 2000,
+                has_redacted_args: true,
+            }],
+            policy_decisions: vec![PolicyDecisionEntry {
+                rule_id: "R-1".to_string(),
+                action: "redact".to_string(),
+                decision: "allow".to_string(),
+                timestamp: 3000,
+            }],
+            hitl_events: vec![],
+        };
+
+        let md = report_to_markdown(&report);
+        assert!(md.contains("# Audit Replay Report"));
+        assert!(md.contains("Total events:** 3"));
+        assert!(md.contains("SNAPSHOT"));
+        assert!(md.contains("sha256:abc"));
+        assert!(md.contains("R-1"));
+    }
+}

--- a/core-runtime/src/audit_replay.rs
+++ b/core-runtime/src/audit_replay.rs
@@ -26,10 +26,10 @@ pub struct StateChainEntry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum StateEntryKind {
     Snapshot,
-    Patch { applied: bool },
+    Patch,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,6 +67,10 @@ pub struct ReplayReport {
 ///
 /// STATE_PATCH events are applied against the current snapshot using RFC 6902 JSON Patch.
 /// Returns `Err` on the first invalid patch (no prior snapshot, or patch application failure).
+///
+/// **Note:** on error, all accumulated state chain / tool calls / decisions up to the
+/// failing event are discarded. Callers that need partial output should split the log
+/// at the error boundary and replay each segment independently.
 pub fn replay_events(events: &[AuditEvent]) -> Result<ReplayReport, ReplayError> {
     let mut state_chain: Vec<StateChainEntry> = Vec::new();
     let mut tool_calls: Vec<ToolCallEntry> = Vec::new();
@@ -124,10 +128,14 @@ pub fn replay_events(events: &[AuditEvent]) -> Result<ReplayReport, ReplayError>
                     reason: e.to_string(),
                 })?;
 
+                if json_contains_redaction(patch) {
+                    has_redacted_content = true;
+                }
+
                 state_chain.push(StateChainEntry {
                     state_hash: state_hash.clone(),
                     timestamp: *timestamp,
-                    kind: StateEntryKind::Patch { applied: true },
+                    kind: StateEntryKind::Patch,
                 });
             }
 
@@ -208,20 +216,14 @@ pub fn report_to_markdown(report: &ReplayReport) -> String {
         out.push_str("|---|------|------|----------------|\n");
         for (i, entry) in report.state_chain.iter().enumerate() {
             let kind = match &entry.kind {
-                StateEntryKind::Snapshot => "SNAPSHOT".to_string(),
-                StateEntryKind::Patch { applied } => {
-                    if *applied {
-                        "PATCH (applied)".to_string()
-                    } else {
-                        "PATCH (skipped)".to_string()
-                    }
-                }
+                StateEntryKind::Snapshot => "SNAPSHOT",
+                StateEntryKind::Patch => "PATCH",
             };
             out.push_str(&format!(
                 "| {} | {} | `{}` | {} |\n",
                 i + 1,
                 kind,
-                entry.state_hash,
+                escape_md(&entry.state_hash),
                 entry.timestamp
             ));
         }
@@ -237,7 +239,9 @@ pub fn report_to_markdown(report: &ReplayReport) -> String {
         for tc in &report.tool_calls {
             out.push_str(&format!(
                 "| `{}` | {} | {} |\n",
-                tc.tool_name, tc.timestamp, tc.has_redacted_args
+                escape_md(&tc.tool_name),
+                tc.timestamp,
+                tc.has_redacted_args
             ));
         }
     }
@@ -252,7 +256,10 @@ pub fn report_to_markdown(report: &ReplayReport) -> String {
         for pd in &report.policy_decisions {
             out.push_str(&format!(
                 "| `{}` | {} | **{}** | {} |\n",
-                pd.rule_id, pd.action, pd.decision, pd.timestamp
+                escape_md(&pd.rule_id),
+                escape_md(&pd.action),
+                escape_md(&pd.decision),
+                pd.timestamp
             ));
         }
     }
@@ -265,16 +272,25 @@ pub fn report_to_markdown(report: &ReplayReport) -> String {
         out.push_str("| Event Type | Timestamp (ms) |\n");
         out.push_str("|------------|----------------|\n");
         for he in &report.hitl_events {
-            out.push_str(&format!("| `{}` | {} |\n", he.event_type, he.timestamp));
+            out.push_str(&format!(
+                "| `{}` | {} |\n",
+                escape_md(&he.event_type),
+                he.timestamp
+            ));
         }
     }
 
     out
 }
 
+fn escape_md(s: &str) -> String {
+    s.replace('`', "\\`").replace('|', "\\|").replace('\n', " ")
+}
+
 fn json_contains_redaction(value: &serde_json::Value) -> bool {
     match value {
-        serde_json::Value::String(s) => s.contains("***"),
+        // "***" covers email/generic redaction; "****-****-****-" covers card numbers.
+        serde_json::Value::String(s) => s.contains("***") || s.contains("****-****-****-"),
         serde_json::Value::Array(arr) => arr.iter().any(json_contains_redaction),
         serde_json::Value::Object(map) => map.values().any(json_contains_redaction),
         _ => false,
@@ -293,6 +309,40 @@ mod tests {
         assert!(json_contains_redaction(&json!(["ok", "***"])));
         assert!(!json_contains_redaction(&json!("clean")));
         assert!(!json_contains_redaction(&json!(42)));
+    }
+
+    #[test]
+    fn json_contains_redaction_detects_card_marker() {
+        assert!(json_contains_redaction(&json!("Card: ****-****-****-XXXX")));
+        assert!(json_contains_redaction(
+            &json!({"card": "****-****-****-XXXX"})
+        ));
+        assert!(!json_contains_redaction(&json!("1234-5678-9012-3456")));
+    }
+
+    #[test]
+    fn report_to_markdown_empty_report_renders_empty_sections() {
+        let report = ReplayReport {
+            total_events: 0,
+            has_redacted_content: false,
+            state_chain: vec![],
+            tool_calls: vec![],
+            policy_decisions: vec![],
+            hitl_events: vec![],
+        };
+        let md = report_to_markdown(&report);
+        assert!(md.contains("_(no state events)_"));
+        assert!(md.contains("_(no tool calls)_"));
+        assert!(md.contains("_(no policy decisions)_"));
+        assert!(md.contains("_(no HITL events)_"));
+    }
+
+    #[test]
+    fn escape_md_sanitizes_injection_characters() {
+        assert_eq!(escape_md("a|b"), "a\\|b");
+        assert_eq!(escape_md("a`b"), "a\\`b");
+        assert_eq!(escape_md("a\nb"), "a b");
+        assert_eq!(escape_md("safe"), "safe");
     }
 
     #[test]

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod audit_replay;
 pub mod audit_sink;
 pub mod browser;
 pub mod chrome_detection;

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -324,22 +324,31 @@ fn replay_fixture_produces_report_with_all_event_types() -> anyhow::Result<()> {
     let report = replay_events(&events)?;
 
     assert_eq!(report.total_events, 5, "should count all 5 fixture events");
+
+    // State chain: one snapshot + one patch
+    assert_eq!(report.state_chain.len(), 2);
+    assert_eq!(report.state_chain[0].state_hash, "sha256:a1b2c3d4");
+    assert_eq!(report.state_chain[0].timestamp, 1000);
+    assert_eq!(report.state_chain[1].state_hash, "sha256:b2c3d4e5");
+
+    // Tool calls
+    assert_eq!(report.tool_calls.len(), 1);
+    assert_eq!(report.tool_calls[0].tool_name, "act");
     assert!(
-        !report.state_chain.is_empty(),
-        "report must include state chain entries"
+        report.tool_calls[0].has_redacted_args,
+        "fixture tool call contains *** args"
     );
-    assert!(
-        !report.tool_calls.is_empty(),
-        "report must include tool call entries"
-    );
-    assert!(
-        !report.policy_decisions.is_empty(),
-        "report must include policy decision entries"
-    );
-    assert!(
-        !report.hitl_events.is_empty(),
-        "report must include HITL event entries"
-    );
+
+    // Policy decisions
+    assert_eq!(report.policy_decisions.len(), 1);
+    assert_eq!(report.policy_decisions[0].rule_id, "PII-001");
+    assert_eq!(report.policy_decisions[0].decision, "allow");
+
+    // HITL events
+    assert_eq!(report.hitl_events.len(), 1);
+    assert_eq!(report.hitl_events[0].event_type, "approval_requested");
+
+    assert!(report.has_redacted_content, "fixture contains *** values");
     Ok(())
 }
 

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 
 use core_runtime::{
     audit::AuditEvent,
+    audit_replay::{replay_events, ReplayError},
     sre::{normalize_dom, LoadProfile, SemanticState},
     BrowserClient,
 };
@@ -302,6 +303,134 @@ fn test_repeated_state_capture_emits_state_patch_for_incremental_update() -> any
     );
 
     Ok(())
+}
+
+/// Replay tests — no browser required.
+
+#[test]
+fn replay_fixture_produces_report_with_all_event_types() -> anyhow::Result<()> {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/audit_replay_fixture.ndjson");
+    let content = std::fs::read_to_string(&fixture_path)
+        .with_context(|| format!("failed to read fixture: {}", fixture_path.display()))?;
+
+    let events: Vec<AuditEvent> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l))
+        .collect::<Result<_, _>>()
+        .context("failed to parse fixture NDJSON")?;
+
+    let report = replay_events(&events)?;
+
+    assert_eq!(report.total_events, 5, "should count all 5 fixture events");
+    assert!(
+        !report.state_chain.is_empty(),
+        "report must include state chain entries"
+    );
+    assert!(
+        !report.tool_calls.is_empty(),
+        "report must include tool call entries"
+    );
+    assert!(
+        !report.policy_decisions.is_empty(),
+        "report must include policy decision entries"
+    );
+    assert!(
+        !report.hitl_events.is_empty(),
+        "report must include HITL event entries"
+    );
+    Ok(())
+}
+
+#[test]
+fn replay_report_includes_timestamps_state_hashes_and_decisions() -> anyhow::Result<()> {
+    let events = vec![
+        AuditEvent::StateSnapshot {
+            state_hash: "sha256:aabbcc".to_string(),
+            page_instance_id: "p-01".to_string(),
+            timestamp: 1_000,
+            payload: serde_json::json!({"role": "document", "label": "Test"}),
+        },
+        AuditEvent::PolicyDecision {
+            rule_id: "R-42".to_string(),
+            action: "block".to_string(),
+            decision: "deny".to_string(),
+            timestamp: 2_000,
+        },
+        AuditEvent::StatePatch {
+            state_hash: "sha256:bbccdd".to_string(),
+            page_instance_id: "p-01".to_string(),
+            timestamp: 3_000,
+            patch: serde_json::json!([{"op": "replace", "path": "/label", "value": "Updated"}]),
+        },
+    ];
+
+    let report = replay_events(&events)?;
+
+    assert_eq!(report.state_chain[0].timestamp, 1_000);
+    assert_eq!(report.state_chain[0].state_hash, "sha256:aabbcc");
+    assert_eq!(report.state_chain[1].timestamp, 3_000);
+    assert_eq!(report.state_chain[1].state_hash, "sha256:bbccdd");
+
+    assert_eq!(report.policy_decisions[0].rule_id, "R-42");
+    assert_eq!(report.policy_decisions[0].decision, "deny");
+    assert_eq!(report.policy_decisions[0].timestamp, 2_000);
+    Ok(())
+}
+
+#[test]
+fn replay_report_detects_redacted_content_in_tool_args() {
+    let events = vec![AuditEvent::ToolCall {
+        tool_name: "act".to_string(),
+        args: serde_json::json!({"action": "type", "value": "***"}),
+        timestamp: 100,
+    }];
+
+    let report = replay_events(&events).expect("replay must succeed");
+    assert!(report.has_redacted_content, "*** in args should set flag");
+    assert!(report.tool_calls[0].has_redacted_args);
+}
+
+#[test]
+fn replay_patch_without_prior_snapshot_is_an_error() {
+    let events = vec![AuditEvent::StatePatch {
+        state_hash: "sha256:orphan".to_string(),
+        page_instance_id: "p-01".to_string(),
+        timestamp: 1_000,
+        patch: serde_json::json!([{"op": "replace", "path": "/label", "value": "Orphan"}]),
+    }];
+
+    let result = replay_events(&events);
+    assert!(
+        matches!(result, Err(ReplayError::NoBaseSnapshot { .. })),
+        "orphan patch must produce NoBaseSnapshot error"
+    );
+}
+
+#[test]
+fn replay_invalid_patch_chain_produces_actionable_error() {
+    let events = vec![
+        AuditEvent::StateSnapshot {
+            state_hash: "sha256:base".to_string(),
+            page_instance_id: "p-01".to_string(),
+            timestamp: 1_000,
+            payload: serde_json::json!({"role": "document"}),
+        },
+        AuditEvent::StatePatch {
+            state_hash: "sha256:bad".to_string(),
+            page_instance_id: "p-01".to_string(),
+            timestamp: 2_000,
+            // "test" op on non-existent path will fail
+            patch: serde_json::json!([{"op": "test", "path": "/nonexistent", "value": "x"}]),
+        },
+    ];
+
+    let result = replay_events(&events);
+    assert!(
+        matches!(result, Err(ReplayError::PatchFailed { .. })),
+        "invalid patch should produce PatchFailed error"
+    );
 }
 
 fn wait_for_events(

--- a/core-runtime/tests/fixtures/audit_replay_fixture.ndjson
+++ b/core-runtime/tests/fixtures/audit_replay_fixture.ndjson
@@ -1,0 +1,5 @@
+{"type":"STATE_SNAPSHOT","state_hash":"sha256:a1b2c3d4","page_instance_id":"page-test-001","timestamp":1000,"payload":{"role":"document","label":"Checkout Page","children":[{"role":"textbox","label":"Email","stable_key":"k-email","attributes":{"id":"email","value":"***"}},{"role":"button","label":"Submit","stable_key":"k-submit"}]}}
+{"type":"TOOL_CALL","tool_name":"act","args":{"action":"type","target_stable_key":"k-email","value":"***"},"timestamp":2000}
+{"type":"STATE_PATCH","state_hash":"sha256:b2c3d4e5","page_instance_id":"page-test-001","timestamp":3000,"patch":[{"op":"replace","path":"/label","value":"Checkout Page (step 2)"}]}
+{"type":"POLICY_DECISION","rule_id":"PII-001","action":"redact","decision":"allow","timestamp":4000}
+{"type":"HITL_EVENT","event_type":"approval_requested","reason":"Sensitive form submission detected","user_id":null,"timestamp":5000}

--- a/scripts/audit_replay.py
+++ b/scripts/audit_replay.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Audit replay/report tool for dragon-head structured audit logs.
+
+Usage:
+    python scripts/audit_replay.py <audit.ndjson> [--format markdown|json]
+    python scripts/audit_replay.py <audit.ndjson> --out <report.md>
+
+Reads sanitized audit event NDJSON, reconstructs the event sequence,
+validates patch chains, and produces a report for CI artifacts or incident review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StateChainEntry:
+    state_hash: str
+    timestamp: int
+    kind: str  # "snapshot" | "patch"
+    patch_applied: bool = True
+
+
+@dataclass
+class ToolCallEntry:
+    tool_name: str
+    timestamp: int
+    has_redacted_args: bool
+
+
+@dataclass
+class PolicyDecisionEntry:
+    rule_id: str
+    action: str
+    decision: str
+    timestamp: int
+
+
+@dataclass
+class HitlEventEntry:
+    event_type: str
+    timestamp: int
+
+
+@dataclass
+class ReplayReport:
+    total_events: int
+    has_redacted_content: bool
+    state_chain: list[StateChainEntry] = field(default_factory=list)
+    tool_calls: list[ToolCallEntry] = field(default_factory=list)
+    policy_decisions: list[PolicyDecisionEntry] = field(default_factory=list)
+    hitl_events: list[HitlEventEntry] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Patch application (RFC 6902)
+# ---------------------------------------------------------------------------
+
+def _apply_json_patch(doc: Any, ops: list[dict]) -> Any:
+    """Apply RFC 6902 JSON Patch operations. Raises ValueError on failure."""
+    import copy
+    doc = copy.deepcopy(doc)
+    for op in ops:
+        operation = op.get("op")
+        path = op.get("path", "")
+        parts = [p for p in path.split("/") if p != ""] if path else []
+
+        if operation == "replace":
+            _patch_set(doc, parts, op["value"])
+        elif operation == "add":
+            _patch_add(doc, parts, op["value"])
+        elif operation == "remove":
+            _patch_remove(doc, parts)
+        elif operation == "test":
+            actual = _patch_get(doc, parts)
+            if actual != op.get("value"):
+                raise ValueError(
+                    f"test failed at {path!r}: expected {op.get('value')!r}, got {actual!r}"
+                )
+        elif operation == "copy":
+            from_parts = [p for p in op["from"].split("/") if p]
+            val = _patch_get(doc, from_parts)
+            _patch_set(doc, parts, val)
+        elif operation == "move":
+            from_parts = [p for p in op["from"].split("/") if p]
+            val = _patch_get(doc, from_parts)
+            _patch_remove(doc, from_parts)
+            _patch_set(doc, parts, val)
+        else:
+            raise ValueError(f"unsupported patch op: {operation!r}")
+    return doc
+
+
+def _resolve(doc: Any, parts: list[str]) -> tuple[Any, str]:
+    """Walk to the parent of the target; return (parent, last_key)."""
+    for part in parts[:-1]:
+        if isinstance(doc, list):
+            doc = doc[int(part)]
+        else:
+            doc = doc[part]
+    return doc, parts[-1] if parts else ""
+
+
+def _patch_get(doc: Any, parts: list[str]) -> Any:
+    for part in parts:
+        if isinstance(doc, list):
+            doc = doc[int(part)]
+        else:
+            doc = doc[part]
+    return doc
+
+
+def _patch_set(doc: Any, parts: list[str], value: Any) -> None:
+    if not parts:
+        raise ValueError("cannot replace root")
+    parent, key = _resolve(doc, parts)
+    if isinstance(parent, list):
+        parent[int(key)] = value
+    else:
+        parent[key] = value
+
+
+def _patch_add(doc: Any, parts: list[str], value: Any) -> None:
+    if not parts:
+        raise ValueError("cannot add to root")
+    parent, key = _resolve(doc, parts)
+    if isinstance(parent, list):
+        if key == "-":
+            parent.append(value)
+        else:
+            parent.insert(int(key), value)
+    else:
+        parent[key] = value
+
+
+def _patch_remove(doc: Any, parts: list[str]) -> None:
+    if not parts:
+        raise ValueError("cannot remove root")
+    parent, key = _resolve(doc, parts)
+    if isinstance(parent, list):
+        del parent[int(key)]
+    else:
+        del parent[key]
+
+
+# ---------------------------------------------------------------------------
+# Redaction detection
+# ---------------------------------------------------------------------------
+
+def _contains_redaction(value: Any) -> bool:
+    if isinstance(value, str):
+        return "***" in value
+    if isinstance(value, list):
+        return any(_contains_redaction(v) for v in value)
+    if isinstance(value, dict):
+        return any(_contains_redaction(v) for v in value.values())
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Replay engine
+# ---------------------------------------------------------------------------
+
+def replay_events(events: list[dict]) -> ReplayReport:
+    """Replay a list of parsed audit event dicts into a ReplayReport.
+
+    Raises ValueError if a patch is encountered with no prior snapshot,
+    or if patch application fails.
+    """
+    report = ReplayReport(total_events=len(events), has_redacted_content=False)
+    current_snapshot: Optional[Any] = None
+
+    for event in events:
+        event_type = event.get("type")
+
+        if event_type == "STATE_SNAPSHOT":
+            current_snapshot = event.get("payload")
+            report.state_chain.append(StateChainEntry(
+                state_hash=event.get("state_hash", ""),
+                timestamp=event.get("timestamp", 0),
+                kind="snapshot",
+            ))
+            if _contains_redaction(event.get("payload")):
+                report.has_redacted_content = True
+
+        elif event_type == "STATE_PATCH":
+            state_hash = event.get("state_hash", "")
+            timestamp = event.get("timestamp", 0)
+            if current_snapshot is None:
+                raise ValueError(
+                    f"STATE_PATCH (hash={state_hash}, t={timestamp}) has no preceding STATE_SNAPSHOT"
+                )
+            ops = event.get("patch", [])
+            try:
+                current_snapshot = _apply_json_patch(current_snapshot, ops)
+            except (ValueError, KeyError, IndexError, TypeError) as exc:
+                raise ValueError(
+                    f"patch application failed for state_hash={state_hash} "
+                    f"at timestamp={timestamp}: {exc}"
+                ) from exc
+            report.state_chain.append(StateChainEntry(
+                state_hash=state_hash,
+                timestamp=timestamp,
+                kind="patch",
+                patch_applied=True,
+            ))
+
+        elif event_type == "TOOL_CALL":
+            args = event.get("args", {})
+            has_redacted_args = _contains_redaction(args)
+            if has_redacted_args:
+                report.has_redacted_content = True
+            report.tool_calls.append(ToolCallEntry(
+                tool_name=event.get("tool_name", ""),
+                timestamp=event.get("timestamp", 0),
+                has_redacted_args=has_redacted_args,
+            ))
+
+        elif event_type == "POLICY_DECISION":
+            report.policy_decisions.append(PolicyDecisionEntry(
+                rule_id=event.get("rule_id", ""),
+                action=event.get("action", ""),
+                decision=event.get("decision", ""),
+                timestamp=event.get("timestamp", 0),
+            ))
+
+        elif event_type == "HITL_EVENT":
+            report.hitl_events.append(HitlEventEntry(
+                event_type=event.get("event_type", ""),
+                timestamp=event.get("timestamp", 0),
+            ))
+
+        # VISUAL_CAPTURE, PLUGIN_STATE_TRANSFORM, PLUGIN_POLICY_DECISION
+        # are counted in total_events but not surfaced in the report sections.
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Report formatters
+# ---------------------------------------------------------------------------
+
+def report_to_markdown(report: ReplayReport) -> str:
+    lines: list[str] = []
+    lines.append("# Audit Replay Report\n")
+    lines.append(f"**Total events:** {report.total_events}  ")
+    lines.append(f"**Redacted content detected:** {str(report.has_redacted_content).lower()}\n")
+
+    lines.append("## State Chain\n")
+    if report.state_chain:
+        lines.append("| # | Kind | Hash | Timestamp (ms) |")
+        lines.append("|---|------|------|----------------|")
+        for i, e in enumerate(report.state_chain, 1):
+            kind = "SNAPSHOT" if e.kind == "snapshot" else "PATCH (applied)" if e.patch_applied else "PATCH (skipped)"
+            lines.append(f"| {i} | {kind} | `{e.state_hash}` | {e.timestamp} |")
+    else:
+        lines.append("_(no state events)_")
+    lines.append("")
+
+    lines.append("## Tool Calls\n")
+    if report.tool_calls:
+        lines.append("| Tool | Timestamp (ms) | Redacted Args |")
+        lines.append("|------|----------------|---------------|")
+        for tc in report.tool_calls:
+            lines.append(f"| `{tc.tool_name}` | {tc.timestamp} | {str(tc.has_redacted_args).lower()} |")
+    else:
+        lines.append("_(no tool calls)_")
+    lines.append("")
+
+    lines.append("## Policy Decisions\n")
+    if report.policy_decisions:
+        lines.append("| Rule | Action | Decision | Timestamp (ms) |")
+        lines.append("|------|--------|----------|----------------|")
+        for pd in report.policy_decisions:
+            lines.append(f"| `{pd.rule_id}` | {pd.action} | **{pd.decision}** | {pd.timestamp} |")
+    else:
+        lines.append("_(no policy decisions)_")
+    lines.append("")
+
+    lines.append("## HITL Events\n")
+    if report.hitl_events:
+        lines.append("| Event Type | Timestamp (ms) |")
+        lines.append("|------------|----------------|")
+        for he in report.hitl_events:
+            lines.append(f"| `{he.event_type}` | {he.timestamp} |")
+    else:
+        lines.append("_(no HITL events)_")
+
+    return "\n".join(lines) + "\n"
+
+
+def report_to_json(report: ReplayReport) -> str:
+    import dataclasses
+    return json.dumps(dataclasses.asdict(report), indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_ndjson(path: Path) -> list[dict]:
+    events: list[dict] = []
+    with path.open(encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(f"[ERROR] line {lineno}: {exc}", file=sys.stderr)
+                sys.exit(1)
+    return events
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Replay sanitized audit event NDJSON and produce a report.",
+    )
+    parser.add_argument("input", type=Path, help="NDJSON audit log file")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write report to this file instead of stdout",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"[ERROR] File not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    events = _parse_ndjson(args.input)
+
+    try:
+        report = replay_events(events)
+    except ValueError as exc:
+        print(f"[ERROR] Replay failed: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    output = report_to_markdown(report) if args.format == "markdown" else report_to_json(report)
+
+    if args.out:
+        args.out.write_text(output, encoding="utf-8")
+        print(f"Report written to {args.out}")
+    else:
+        print(output, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_replay.py
+++ b/scripts/audit_replay.py
@@ -12,6 +12,8 @@ validates patch chains, and produces a report for CI artifacts or incident revie
 from __future__ import annotations
 
 import argparse
+import copy
+import dataclasses
 import json
 import sys
 from dataclasses import dataclass, field
@@ -68,12 +70,11 @@ class ReplayReport:
 
 def _apply_json_patch(doc: Any, ops: list[dict]) -> Any:
     """Apply RFC 6902 JSON Patch operations. Raises ValueError on failure."""
-    import copy
     doc = copy.deepcopy(doc)
     for op in ops:
         operation = op.get("op")
         path = op.get("path", "")
-        parts = [p for p in path.split("/") if p != ""] if path else []
+        parts = _ptr_parts(path)
 
         if operation == "replace":
             _patch_set(doc, parts, op["value"])
@@ -88,17 +89,28 @@ def _apply_json_patch(doc: Any, ops: list[dict]) -> Any:
                     f"test failed at {path!r}: expected {op.get('value')!r}, got {actual!r}"
                 )
         elif operation == "copy":
-            from_parts = [p for p in op["from"].split("/") if p]
+            from_parts = _ptr_parts(op["from"])
             val = _patch_get(doc, from_parts)
             _patch_set(doc, parts, val)
         elif operation == "move":
-            from_parts = [p for p in op["from"].split("/") if p]
+            from_parts = _ptr_parts(op["from"])
             val = _patch_get(doc, from_parts)
             _patch_remove(doc, from_parts)
             _patch_set(doc, parts, val)
         else:
             raise ValueError(f"unsupported patch op: {operation!r}")
     return doc
+
+
+def _ptr_parts(path: str) -> list[str]:
+    """Split a JSON Pointer path into segments, decoding RFC 6902 escape sequences."""
+    if not path:
+        return []
+    return [
+        p.replace("~1", "/").replace("~0", "~")
+        for p in path.split("/")
+        if p != ""
+    ]
 
 
 def _resolve(doc: Any, parts: list[str]) -> tuple[Any, str]:
@@ -159,7 +171,8 @@ def _patch_remove(doc: Any, parts: list[str]) -> None:
 
 def _contains_redaction(value: Any) -> bool:
     if isinstance(value, str):
-        return "***" in value
+        # "***" covers email/generic redaction; "****-****-****-" covers card numbers.
+        return "***" in value or "****-****-****-" in value
     if isinstance(value, list):
         return any(_contains_redaction(v) for v in value)
     if isinstance(value, dict):
@@ -250,6 +263,11 @@ def replay_events(events: list[dict]) -> ReplayReport:
 # Report formatters
 # ---------------------------------------------------------------------------
 
+def _escape_md(s: str) -> str:
+    """Escape characters that could break Markdown table structure."""
+    return s.replace("`", "\\`").replace("|", "\\|").replace("\n", " ")
+
+
 def report_to_markdown(report: ReplayReport) -> str:
     lines: list[str] = []
     lines.append("# Audit Replay Report\n")
@@ -261,8 +279,8 @@ def report_to_markdown(report: ReplayReport) -> str:
         lines.append("| # | Kind | Hash | Timestamp (ms) |")
         lines.append("|---|------|------|----------------|")
         for i, e in enumerate(report.state_chain, 1):
-            kind = "SNAPSHOT" if e.kind == "snapshot" else "PATCH (applied)" if e.patch_applied else "PATCH (skipped)"
-            lines.append(f"| {i} | {kind} | `{e.state_hash}` | {e.timestamp} |")
+            kind = "SNAPSHOT" if e.kind == "snapshot" else "PATCH"
+            lines.append(f"| {i} | {kind} | `{_escape_md(e.state_hash)}` | {e.timestamp} |")
     else:
         lines.append("_(no state events)_")
     lines.append("")
@@ -272,7 +290,7 @@ def report_to_markdown(report: ReplayReport) -> str:
         lines.append("| Tool | Timestamp (ms) | Redacted Args |")
         lines.append("|------|----------------|---------------|")
         for tc in report.tool_calls:
-            lines.append(f"| `{tc.tool_name}` | {tc.timestamp} | {str(tc.has_redacted_args).lower()} |")
+            lines.append(f"| `{_escape_md(tc.tool_name)}` | {tc.timestamp} | {str(tc.has_redacted_args).lower()} |")
     else:
         lines.append("_(no tool calls)_")
     lines.append("")
@@ -282,7 +300,10 @@ def report_to_markdown(report: ReplayReport) -> str:
         lines.append("| Rule | Action | Decision | Timestamp (ms) |")
         lines.append("|------|--------|----------|----------------|")
         for pd in report.policy_decisions:
-            lines.append(f"| `{pd.rule_id}` | {pd.action} | **{pd.decision}** | {pd.timestamp} |")
+            lines.append(
+                f"| `{_escape_md(pd.rule_id)}` | {_escape_md(pd.action)} "
+                f"| **{_escape_md(pd.decision)}** | {pd.timestamp} |"
+            )
     else:
         lines.append("_(no policy decisions)_")
     lines.append("")
@@ -292,7 +313,7 @@ def report_to_markdown(report: ReplayReport) -> str:
         lines.append("| Event Type | Timestamp (ms) |")
         lines.append("|------------|----------------|")
         for he in report.hitl_events:
-            lines.append(f"| `{he.event_type}` | {he.timestamp} |")
+            lines.append(f"| `{_escape_md(he.event_type)}` | {he.timestamp} |")
     else:
         lines.append("_(no HITL events)_")
 
@@ -300,7 +321,6 @@ def report_to_markdown(report: ReplayReport) -> str:
 
 
 def report_to_json(report: ReplayReport) -> str:
-    import dataclasses
     return json.dumps(dataclasses.asdict(report), indent=2)
 
 
@@ -357,6 +377,7 @@ def main() -> None:
     output = report_to_markdown(report) if args.format == "markdown" else report_to_json(report)
 
     if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(output, encoding="utf-8")
         print(f"Report written to {args.out}")
     else:


### PR DESCRIPTION
Closes #51

## Summary
- Add `core-runtime/src/audit_replay.rs` with `replay_events()` API and `report_to_markdown()`
- Add sanitized NDJSON fixture at `core-runtime/tests/fixtures/audit_replay_fixture.ndjson`
- Add Python CLI at `scripts/audit_replay.py` for CI-artifact-ready reports (markdown or JSON output)
- Add 5 new integration tests + 4 unit tests; all existing audit redaction tests remain green

## Exit Criteria (from Issue #51)

- [x] Tool can replay a fixture containing `STATE_SNAPSHOT`, `STATE_PATCH`, `TOOL_CALL`, and `POLICY_DECISION`
- [x] Invalid patch chains produce actionable errors (`ReplayError::NoBaseSnapshot`, `ReplayError::PatchFailed`)
- [x] Report includes timestamps, state hashes, decisions, and redaction status
- [x] Audit redaction tests remain green (8/8 tests pass including existing 3)

## Test Results

```
running 8 tests
test replay_patch_without_prior_snapshot_is_an_error ... ok
test replay_report_detects_redacted_content_in_tool_args ... ok
test replay_report_includes_timestamps_state_hashes_and_decisions ... ok
test replay_fixture_produces_report_with_all_event_types ... ok
test replay_invalid_patch_chain_produces_actionable_error ... ok
test test_repeated_state_capture_emits_state_patch_for_incremental_update ... ok
test test_audit_logging_verify_text_masks_expected_text ... ok
test test_audit_logging_sequence_and_pii_masking ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured
```

## Usage

```bash
# Markdown report (default)
python scripts/audit_replay.py core-runtime/tests/fixtures/audit_replay_fixture.ndjson

# JSON report
python scripts/audit_replay.py audit.ndjson --format json --out report.json
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)