### PR TITLE
[ISSUE-69] Standardize browser test skip helper in test-bench-support

### DIFF
--- a/core-runtime/tests/action_execution.rs
+++ b/core-runtime/tests/action_execution.rs
@@ -5,7 +5,7 @@ use core_runtime::{
 
 #[test]
 fn test_action_execution_basic() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -51,7 +51,7 @@ fn test_action_execution_basic() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_execution_fallback() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -135,7 +135,7 @@ fn find_button_info(node: &core_runtime::sre::state::SemanticNode) -> Option<(i6
 
 #[test]
 fn test_action_execution_verify_required() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -11,7 +11,7 @@ use core_runtime::{
 
 #[test]
 fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -140,7 +140,7 @@ fn test_audit_logging_sequence_and_pii_masking() -> anyhow::Result<()> {
 
 #[test]
 fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -210,7 +210,7 @@ fn test_audit_logging_verify_text_masks_expected_text() -> anyhow::Result<()> {
 
 #[test]
 fn test_repeated_state_capture_emits_state_patch_for_incremental_update() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/cdp_connectivity.rs
+++ b/core-runtime/tests/cdp_connectivity.rs
@@ -8,7 +8,7 @@ fn test_browser_launch_and_navigate() -> anyhow::Result<()> {
     // For local dev, we assume chrome is present.
 
     // Check if we are in a CI environment without chrome
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         println!("Skipping CDP test: Chrome not available");
         return Ok(());
     }

--- a/core-runtime/tests/comprehensive_evaluation.rs
+++ b/core-runtime/tests/comprehensive_evaluation.rs
@@ -21,7 +21,7 @@ use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
 fn test_core_runtime_comprehensive_evaluation_suite() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_bandwidth.rs
+++ b/core-runtime/tests/nfr_bandwidth.rs
@@ -6,7 +6,7 @@ mod nfr_metrics;
 
 #[test]
 fn test_nfr_bandwidth_95_percent_reduction() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_capacity.rs
+++ b/core-runtime/tests/nfr_capacity.rs
@@ -77,7 +77,7 @@ fn run_capacity_trials(
 
 #[test]
 fn test_nfr_capacity_targets_by_profile() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/nfr_latency.rs
+++ b/core-runtime/tests/nfr_latency.rs
@@ -16,7 +16,7 @@ mod nfr_metrics;
 
 #[test]
 fn test_nfr_state_update_latency_under_100ms() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/plugin_hooks.rs
+++ b/core-runtime/tests/plugin_hooks.rs
@@ -305,7 +305,7 @@ fn test_run_policy_hooks_trap_fails_closed() {
 
 #[test]
 fn test_no_plugins_unchanged_browser_behavior() {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return;
     }
 
@@ -324,7 +324,7 @@ fn test_no_plugins_unchanged_browser_behavior() {
 
 #[test]
 fn test_block_policy_plugin_prevents_action_in_browser() {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return;
     }
 
@@ -351,7 +351,7 @@ fn test_block_policy_plugin_prevents_action_in_browser() {
 
 #[test]
 fn test_policy_plugin_decision_recorded_in_audit_browser() {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return;
     }
 
@@ -391,7 +391,7 @@ fn test_policy_plugin_decision_recorded_in_audit_browser() {
 
 #[test]
 fn test_state_plugin_failure_is_nonfatal_in_browser() {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return;
     }
 
@@ -417,7 +417,7 @@ fn test_state_plugin_failure_is_nonfatal_in_browser() {
 
 #[test]
 fn test_state_plugin_failure_recorded_in_audit_browser() {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return;
     }
 

--- a/core-runtime/tests/policy_enforcement.rs
+++ b/core-runtime/tests/policy_enforcement.rs
@@ -9,7 +9,7 @@ use core_runtime::{
 
 #[test]
 fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -58,7 +58,7 @@ fn test_block_rule_prevents_action_execution() -> anyhow::Result<()> {
 
 #[test]
 fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -128,7 +128,7 @@ fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<
 
 #[test]
 fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -188,7 +188,7 @@ fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()>
 
 #[test]
 fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -244,7 +244,7 @@ fn test_set_policy_rules_clears_stale_approvals() -> anyhow::Result<()> {
 
 #[test]
 fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -347,7 +347,7 @@ fn test_until_navigation_and_timeboxed_scopes_expire() -> anyhow::Result<()> {
 /// `granted_url` comparison must invalidate the approval.
 #[test]
 fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -442,7 +442,7 @@ fn test_until_navigation_expires_on_click_driven_navigation() -> anyhow::Result<
 /// attribute values, making `context_regex` on checkout amounts effectively dead.
 #[test]
 fn test_context_regex_matches_text_outside_button() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -523,7 +523,7 @@ fn find_button_info_in_node(
 
 #[test]
 fn test_guardian_angel_proactive_block_on_high_amount() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -582,7 +582,7 @@ fn test_guardian_angel_proactive_block_on_high_amount() -> anyhow::Result<()> {
 
 #[test]
 fn test_guardian_angel_hitl_carries_outcome_projection() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/repro_issue.rs
+++ b/core-runtime/tests/repro_issue.rs
@@ -3,7 +3,7 @@ use core_runtime::BrowserClient;
 
 #[test]
 fn test_repro_unstable_keys_on_sibling_insertion() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/repro_viewport_bug.rs
+++ b/core-runtime/tests/repro_viewport_bug.rs
@@ -273,7 +273,7 @@ fn explicit_800x600_matches_normalize_dom_default() {
 /// `get_viewport_dimensions()` and forwards the result to `normalize_dom_with_viewport`.
 #[test]
 fn page_session_uses_actual_viewport_for_stable_key() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/semantic_wait.rs
+++ b/core-runtime/tests/semantic_wait.rs
@@ -7,7 +7,7 @@ use core_runtime::{
 
 #[test]
 fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -56,7 +56,7 @@ fn test_wait_for_semantic_enabled_on_delayed_button() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_success() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -91,7 +91,7 @@ fn test_wait_for_intent_success() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -129,7 +129,7 @@ fn test_wait_for_intent_timeout() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -166,7 +166,7 @@ fn test_wait_for_intent_does_not_match_substring() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -212,7 +212,7 @@ fn test_wait_for_semantic_timeout_when_target_never_enabled() -> anyhow::Result<
 
 #[test]
 fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -267,7 +267,7 @@ fn test_wait_for_semantic_id_fallback_with_stable_key() -> anyhow::Result<()> {
 
 #[test]
 fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -316,7 +316,7 @@ fn test_wait_for_semantic_is_not_blocked_by_large_poll_interval() -> anyhow::Res
 
 #[test]
 fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -359,7 +359,7 @@ fn test_wait_for_intent_is_not_blocked_by_large_poll_interval() -> anyhow::Resul
 
 #[test]
 fn test_wait_for_semantic_recovers_from_polluted_bridge_state() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/session_management.rs
+++ b/core-runtime/tests/session_management.rs
@@ -6,7 +6,7 @@ use core_runtime::{BrowserClient, KmsAdapter, LocalSessionVault, SessionVault, S
 
 #[tokio::test]
 async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -66,7 +66,7 @@ async fn test_session_management_cross_domain_save_restore() -> anyhow::Result<(
 
 #[tokio::test]
 async fn test_session_management_key_rotation_restore_roundtrip() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_event_driven.rs
+++ b/core-runtime/tests/som_event_driven.rs
@@ -7,7 +7,7 @@ use core_runtime::{
 
 #[test]
 fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -35,7 +35,7 @@ fn test_som_not_generated_without_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -68,7 +68,7 @@ fn test_som_generated_by_get_visual_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -117,7 +117,7 @@ fn test_som_generated_by_act_ambiguous_trigger() -> anyhow::Result<()> {
 
 #[test]
 fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -157,7 +157,7 @@ fn test_som_generated_by_act_ambiguous_without_stable_key() -> anyhow::Result<()
 
 #[test]
 fn test_som_generated_by_verify_failure_trigger() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/som_visual_diff.rs
+++ b/core-runtime/tests/som_visual_diff.rs
@@ -13,7 +13,7 @@ const DIFF_THRESHOLD: f64 = 0.06;
 
 #[test]
 fn test_som_visual_regression_threshold() -> Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/spa_stable_key_stress.rs
+++ b/core-runtime/tests/spa_stable_key_stress.rs
@@ -5,7 +5,7 @@ use core_runtime::{
 
 #[test]
 fn test_stable_key_self_heals_across_spa_rerenders() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_determinism.rs
+++ b/core-runtime/tests/sre_determinism.rs
@@ -5,7 +5,7 @@ use core_runtime::{
 
 #[test]
 fn test_sre_determinism_same_input() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -64,7 +64,7 @@ fn test_sre_determinism_same_input() -> anyhow::Result<()> {
 /// This is the core determinism requirement of SPEC SRE-01.
 #[test]
 fn test_sre_determinism_dynamic_class_variance() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_fast_full_state.rs
+++ b/core-runtime/tests/sre_fast_full_state.rs
@@ -16,7 +16,7 @@ fn build_state(html: &str) -> anyhow::Result<SemanticState> {
 
 #[test]
 fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -141,7 +141,7 @@ fn test_fast_full_state_content_diff() -> anyhow::Result<()> {
 
 #[test]
 fn test_fast_state_generated_before_full_state() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_profile_filtering.rs
+++ b/core-runtime/tests/sre_profile_filtering.rs
@@ -49,7 +49,7 @@ fn get_all_roles(state: &core_runtime::sre::SemanticState) -> Vec<String> {
 
 #[test]
 fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -108,7 +108,7 @@ fn test_minimal_blocks_all_media_and_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -161,7 +161,7 @@ fn test_visual_allows_images_blocks_js() -> anyhow::Result<()> {
 
 #[test]
 fn test_interactive_allows_js_and_images() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/sre_snapshot_regression.rs
+++ b/core-runtime/tests/sre_snapshot_regression.rs
@@ -55,7 +55,7 @@ fn build_snapshot() -> Result<Value> {
 
 #[test]
 fn test_sre_minimal_snapshot_regression() -> Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_compatibility.rs
+++ b/core-runtime/tests/stable_key_compatibility.rs
@@ -414,7 +414,7 @@ fn test_refinement_cache_invalidated_on_viewport_change() {
 /// differs from a narrow viewport for straddling elements."
 #[test]
 fn test_browser_backed_viewport_affects_stable_key() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_compliance.rs
+++ b/core-runtime/tests/stable_key_compliance.rs
@@ -3,7 +3,7 @@ use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_format_compliance() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -31,7 +31,7 @@ fn test_stable_key_format_compliance() -> anyhow::Result<()> {
 
 #[test]
 fn test_ambiguous_flag_on_collision() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_generation.rs
+++ b/core-runtime/tests/stable_key_generation.rs
@@ -3,7 +3,7 @@ use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_determinism() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -55,7 +55,7 @@ fn test_stable_key_determinism() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_collision_handling() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/core-runtime/tests/stable_key_quadrant_alias_index.rs
+++ b/core-runtime/tests/stable_key_quadrant_alias_index.rs
@@ -3,7 +3,7 @@ use core_runtime::BrowserClient;
 
 #[test]
 fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -62,7 +62,7 @@ fn test_stable_key_tracks_quadrant_not_dom_order() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -121,7 +121,7 @@ fn test_stable_key_tracks_quadrant_from_style_pixels() -> anyhow::Result<()> {
 
 #[test]
 fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -181,7 +181,7 @@ fn test_alias_output_and_stable_key_index_consistency() -> anyhow::Result<()> {
 
 #[test]
 fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 
@@ -235,7 +235,7 @@ fn test_stable_key_index_is_cleared_on_navigation() -> anyhow::Result<()> {
 
 #[test]
 fn test_minimal_capture_keeps_stable_key_lookup_available() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -7,7 +7,7 @@ use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
 fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -1,10 +1,10 @@
 use mcp_server::{McpBackend, McpServer};
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::time::Instant;
+use test_bench_support::should_skip_browser_tests;
 
 // ---------------------------------------------------------------------------
 // Fast library-level protocol tests (no Chrome / no subprocess)
@@ -134,36 +134,6 @@ fn protocol_tools_call_get_usage_report() {
 // Binary helper utilities
 // ---------------------------------------------------------------------------
 
-fn chrome_available() -> bool {
-    if let Ok(path) = std::env::var("CHROME_PATH") {
-        if Path::new(&path).exists() {
-            return true;
-        }
-    }
-    let candidates = [
-        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-        "/usr/bin/chromium",
-        "/usr/bin/chromium-browser",
-        "/usr/bin/google-chrome",
-        "/usr/bin/google-chrome-stable",
-        "chromium",
-        "chromium-browser",
-        "google-chrome",
-        "google-chrome-stable",
-    ];
-    candidates.iter().any(|p| {
-        if p.contains('/') {
-            Path::new(p).exists()
-        } else {
-            Command::new("which")
-                .arg(p)
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
-        }
-    })
-}
-
 fn mcp_handshake(
     stdin: &mut impl Write,
     reader: &mut BufReader<impl std::io::Read>,
@@ -291,7 +261,7 @@ fn binary_init_unknown_client_exits_nonzero() -> anyhow::Result<()> {
 #[test]
 #[ignore = "requires Chrome; starts a real browser process (~30-60s). Run with: cargo test -p mcp-server --test mcp_binary_e2e -- --ignored"]
 fn test_mcp_binary_full_handshake_and_tools_list() -> anyhow::Result<()> {
-    if !chrome_available() {
+    if should_skip_browser_tests() {
         eprintln!("SKIP: Chrome not available");
         return Ok(());
     }
@@ -352,7 +322,7 @@ fn test_mcp_binary_full_handshake_and_tools_list() -> anyhow::Result<()> {
 #[test]
 #[ignore = "requires Chrome; starts a real browser process (~30-60s). Run with: cargo test -p mcp-server --test mcp_binary_e2e -- --ignored"]
 fn test_mcp_binary_full_handshake_and_tools_call() -> anyhow::Result<()> {
-    if !chrome_available() {
+    if should_skip_browser_tests() {
         eprintln!("SKIP: Chrome not available");
         return Ok(());
     }

--- a/mcp-server/tests/mcp_hitl_flow.rs
+++ b/mcp-server/tests/mcp_hitl_flow.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 
 #[test]
 fn test_ask_human_hitl_flow_with_policy_gate() -> anyhow::Result<()> {
-    if !core_runtime::chrome_available() {
+    if test_bench_support::should_skip_browser_tests() {
         return Ok(());
     }
 

--- a/test-bench-support/src/lib.rs
+++ b/test-bench-support/src/lib.rs
@@ -1,12 +1,73 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
+    process::Command,
     time::Instant,
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+/// Returns `true` when no Chrome/Chromium binary is available, indicating that
+/// browser-dependent tests should be skipped.
+///
+/// Usage in a test:
+/// ```ignore
+/// if test_bench_support::should_skip_browser_tests() { return Ok(()); }
+/// ```
+#[must_use]
+pub fn should_skip_browser_tests() -> bool {
+    if let Ok(path) = env::var("CHROME_PATH") {
+        if Path::new(&path).exists() {
+            return false;
+        }
+    }
+
+    let candidates: &[&str] = if cfg!(target_os = "macos") {
+        &["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+    } else if cfg!(target_os = "linux") {
+        &[
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+        ]
+    } else if cfg!(target_os = "windows") {
+        &[
+            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+        ]
+    } else {
+        &[]
+    };
+
+    if candidates.iter().any(|p| Path::new(p).exists()) {
+        return false;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    let which_cmd = "which";
+    #[cfg(target_os = "windows")]
+    let which_cmd = "where";
+
+    let found_via_which = [
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+    ]
+    .iter()
+    .any(|name| {
+        Command::new(which_cmd)
+            .arg(name)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    });
+
+    !found_via_which
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary

- Add `should_skip_browser_tests() -> bool` to `test-bench-support` as the single canonical skip guard for browser-dependent tests
- Replace all `if !core_runtime::chrome_available()` guards across 26 test files with `if test_bench_support::should_skip_browser_tests()`
- Remove the duplicate local `chrome_available()` from `mcp-server/tests/mcp_binary_e2e.rs`

Closes #69

## Problem

Browser test skip logic was scattered across the workspace with three different patterns:
1. `if !core_runtime::chrome_available()` — used in 24 `core-runtime` tests and 2 `mcp-server` tests
2. A local `fn chrome_available()` in `mcp-server/tests/mcp_binary_e2e.rs` with a slightly different implementation (missing Windows paths and the macOS app path, cross-platform `which` inlined)
3. `if !core_runtime::chrome_available()` in tests that only needed this function but had to depend on `core-runtime`

## Solution

`test-bench-support/src/lib.rs` now exports:
```rust
#[must_use]
pub fn should_skip_browser_tests() -> bool { ... }
```

The implementation is a direct logical inversion of `core_runtime::chrome_available()` — same `CHROME_PATH` env check, same OS-specific candidate paths, same `which`/`where` fallback. The `#[must_use]` attribute prevents silent no-op calls (e.g. calling `should_skip_browser_tests();` without the `if`).

Non-test uses of `chrome_available()` (`bench/src/main.rs`, `core-runtime/src/browser.rs`, `mcp-server/src/doctor.rs`) are intentionally left unchanged.

## Exit Criteria (Issue #69)
- [x] Browser test skip helper names are standardized across the workspace (`should_skip_browser_tests`)
- [x] Shared helper lives in `test-bench-support`
- [x] Duplicate local `chrome_available()` removed from `mcp-server/tests/mcp_binary_e2e.rs`
- [x] `cargo check --workspace --tests` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

## gstack-review result
Semantic equivalence verified: `should_skip_browser_tests()` is a line-for-line logical inversion of `chrome_available()`. No CRITICAL or HIGH issues. One MEDIUM advisory (missing `#[must_use]`) was applied before commit.

## gstack-qa result
Library/schema-only change — no runnable browser target. All fast non-browser tests pass. Skip guard behavior is unchanged (browser tests still skip when Chrome is absent, run when present).