### PR TITLE
fix(examples): add missing get_state delta example response files

### DIFF
--- a/examples/mcp_examples/get_state_delta_first_response.json
+++ b/examples/mcp_examples/get_state_delta_first_response.json
@@ -1,0 +1,44 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "json",
+        "json": {
+          "type": "full",
+          "state_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          "metadata": {
+            "url": "https://example.com/checkout",
+            "page_instance_id": "550e8400-e29b-41d4-a716-446655440000",
+            "state_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "load_profile": "interactive",
+            "timestamp": 1707530000
+          },
+          "interactive_elements": [
+            {
+              "id": 43,
+              "stable_key": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+              "alias": "input_email",
+              "role": "input",
+              "name": "Email address",
+              "attributes": { "type": "email", "required": true },
+              "bbox": [100, 150, 300, 40],
+              "policy_flags": []
+            },
+            {
+              "id": 42,
+              "stable_key": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+              "alias": "btn_purchase",
+              "role": "button",
+              "name": "Purchase",
+              "attributes": { "disabled": false },
+              "bbox": [100, 200, 150, 50],
+              "policy_flags": ["financial_transaction"]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/examples/mcp_examples/get_state_delta_no_change_response.json
+++ b/examples/mcp_examples/get_state_delta_no_change_response.json
@@ -1,0 +1,15 @@
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "json",
+        "json": {
+          "type": "no_change",
+          "state_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- `examples/README.md` (merged in PR #64) documents `get_state_delta_first_response.json` and `get_state_delta_no_change_response.json`, but these files were never committed — leaving dangling references in the docs
- Adds the two missing example response JSON files (recovered from the now-stale `feature/issue-50-quickstart` worktree)

## Test plan
- [x] Verified files match the format documented in `examples/README.md`
- [x] Confirmed files are not present anywhere on `main` prior to this change