### PR TITLE
[ISSUE-15] PR-25: Slack/Teams HITL Reference Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +365,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
@@ -1087,8 +1148,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1196,6 +1259,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hitl-bridge"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "clap",
+ "core-runtime",
+ "hex",
+ "hmac",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha2",
+ "tempfile",
+ "test-bench-support",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,12 +1351,29 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1636,6 +1748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1778,12 @@ dependencies = [
  "test-bench-support",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcp-server"
@@ -1698,6 +1822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1856,15 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2046,6 +2185,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,16 +2425,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2248,6 +2447,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2332,6 +2532,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2418,6 +2619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2670,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2682,6 +2903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2920,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2717,6 +2962,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2773,6 +3028,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2811,6 +3067,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2834,6 +3091,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2996,6 +3279,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3008,6 +3292,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -3484,6 +3774,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "marketplace",
     "test-bench-support",
     "bench",
+    "hitl-bridge",
 ]
 resolver = "2"
 

--- a/core-runtime/src/audit_sink.rs
+++ b/core-runtime/src/audit_sink.rs
@@ -450,7 +450,7 @@ mod tests {
             .collect();
         assert_eq!(files.len(), 1, "no rotation expected when max_bytes=0");
 
-        let content = fs::read_to_string(&files[0].path()).unwrap();
+        let content = fs::read_to_string(files[0].path()).unwrap();
         let lines: Vec<_> = content.lines().collect();
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("TOOL_CALL"));

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -16,7 +16,9 @@ use crate::{
     dom_signature::DOMSignatureCache,
     error::{ActionError, VerifyError, WaitError},
     plugin_hooks::{run_policy_hooks, run_state_hooks, PluginHookConfig, PolicyHookOutcome},
-    policy::{ApprovalScope, PolicyAction, PolicyContext, PolicyEngine, PolicyRule},
+    policy::{
+        ApprovalScope, OutcomeProjection, PolicyAction, PolicyContext, PolicyEngine, PolicyRule,
+    },
     session_vault::{CookieData, LocalSessionVault, SessionData, SessionVault, SoftwareKms},
     sre::{
         normalize_dom_with_viewport, normalize_dom_with_viewport_and_refinement, LoadProfile,
@@ -105,15 +107,21 @@ struct StableKeyIndexEntry {
     alias: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// PartialEq only (not Eq): `outcome` carries `OutcomeProjection`, which holds an
+// f64 and therefore cannot implement Eq.
+#[derive(Debug, Clone, PartialEq)]
 pub struct PolicyApprovalRequest {
     pub rule_id: String,
     pub scope: ApprovalScope,
     pub action: String,
     pub target_signature: String,
+    /// Guardian Angel: structured outcome projection captured when the request
+    /// was raised. Surfaced to HITL bridges (e.g. Slack/Teams) alongside the
+    /// approval prompt so reviewers see the projected impact.
+    pub outcome: Option<OutcomeProjection>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct GrantedPolicyApproval {
     request: PolicyApprovalRequest,
     granted_navigation_epoch: u64,
@@ -840,6 +848,35 @@ impl PageSession {
         Ok(())
     }
 
+    /// Reject the latest pending policy request.
+    ///
+    /// Unlike [`approve_pending_policy_action`], the request is discarded rather
+    /// than recorded as granted — the originating action remains blocked. Used by
+    /// HITL bridges (e.g. Slack/Teams reference implementations) to relay a human's
+    /// "Reject" decision back into the session.
+    ///
+    /// [`approve_pending_policy_action`]: Self::approve_pending_policy_action
+    pub fn reject_pending_policy_action(&self) -> Result<()> {
+        let mut guard = self
+            .policy_approvals
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock policy approval state"))?;
+
+        if guard.pending.take().is_none() {
+            anyhow::bail!("No pending policy approval request");
+        }
+        drop(guard);
+
+        self.audit_logger.log(AuditEvent::HitlEvent {
+            event_type: "rejected".to_string(),
+            reason: None,
+            user_id: None,
+            timestamp: epoch_millis_u64(),
+        });
+
+        Ok(())
+    }
+
     /// Verify element text against an expected value.
     /// On mismatch, triggers a SoM capture to help disambiguate recovery.
     pub fn verify_text(&self, target_id: i64, expected_text: &str) -> Result<()> {
@@ -1216,6 +1253,7 @@ impl PageSession {
                     scope,
                     action: action.to_string(),
                     target_signature,
+                    outcome: decision.outcome.clone(),
                 })?;
 
                 self.audit_logger.log(AuditEvent::HitlEvent {

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -317,7 +317,7 @@ fn replay_fixture_produces_report_with_all_event_types() -> anyhow::Result<()> {
     let events: Vec<AuditEvent> = content
         .lines()
         .filter(|l| !l.trim().is_empty())
-        .map(|l| serde_json::from_str(l))
+        .map(serde_json::from_str)
         .collect::<Result<_, _>>()
         .context("failed to parse fixture NDJSON")?;
 

--- a/core-runtime/tests/policy_enforcement.rs
+++ b/core-runtime/tests/policy_enforcement.rs
@@ -127,6 +127,77 @@ fn test_action_only_approval_scope_expires_after_single_use() -> anyhow::Result<
 }
 
 #[test]
+fn test_reject_pending_policy_action_keeps_action_blocked() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![PolicyRule {
+        id: "approve-pay".to_string(),
+        domain: None,
+        path_prefix: None,
+        role: Some("button".to_string()),
+        text_regex: Some("(?i)pay".to_string()),
+        context_regex: None,
+        action: PolicyAction::RequireHumanApproval,
+        scope: Some(ApprovalScope::ActionOnly),
+        outcome_projector: None,
+    }])?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="pay" onclick="document.body.dataset.payCount = String((Number(document.body.dataset.payCount||0)+1))">Pay</button>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let (target_id, target_key) = find_button_info(&page)?;
+
+    let first_attempt = page.act(Some(target_id), Some(&target_key), "click", None);
+    assert!(first_attempt.is_err(), "approval should be required first");
+    assert!(page.pending_policy_approval().is_some());
+
+    page.reject_pending_policy_action()?;
+    assert!(
+        page.pending_policy_approval().is_none(),
+        "rejection must clear the pending request"
+    );
+
+    let approve_after_reject = page.approve_pending_policy_action();
+    assert!(
+        approve_after_reject.is_err(),
+        "a rejected request must not be approvable afterwards"
+    );
+
+    let retry = page.act(Some(target_id), Some(&target_key), "click", None);
+    assert!(retry.is_err(), "rejected action must remain blocked");
+    let retry_err = retry.unwrap_err();
+    let retry_action_err = retry_err
+        .downcast_ref::<ActionError>()
+        .expect("error should be ActionError");
+    assert!(matches!(
+        retry_action_err,
+        ActionError::HumanApprovalRequired { .. }
+    ));
+
+    let pay_count = page
+        .evaluate_script("document.body.dataset.payCount")?
+        .value
+        .and_then(|v| v.as_str().map(ToOwned::to_owned));
+    assert!(
+        pay_count.is_none(),
+        "rejected action must not mutate page state"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_action_only_approval_scope_expires_on_navigation() -> anyhow::Result<()> {
     if test_bench_support::should_skip_browser_tests() {
         return Ok(());

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -108,16 +108,16 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
   - [x] 長期保存可能な監査トレースが外部システムと連携される。
 
 ### PR-25: Slack/Teams HITL Reference Implementation
-- Status: `NOT_STARTED`
+- Status: `DONE`
 - Spec Ref: Section 5.2, ISSUE-15
 - Dependencies: PR-14, PR-23
 - 実装タスク
-  - [ ] Slack App 連携リファレンス実装（画像 + 未来投影データ付き）。
-  - [ ] セッションレベルの二重承認防止ロック。
+  - [x] Slack App 連携リファレンス実装（画像 + 未来投影データ付き）。
+  - [x] セッションレベルの二重承認防止ロック。
 - テストタスク
-  - [ ] 複数人による同時承認リクエストの競合回避検証。
+  - [x] 複数人による同時承認リクエストの競合回避検証。
 - Exit Criteria
-  - [ ] チャットツール経由で安全に HITL 判断を完走できる。
+  - [x] チャットツール経由で安全に HITL 判断を完走できる。
 
 ### PR-26: Shared Wasm Engine & Performance Tuning
 - Status: `DONE`

--- a/docs/hitl-slack-bridge.md
+++ b/docs/hitl-slack-bridge.md
@@ -1,0 +1,158 @@
+# Slack HITL Bridge (`hitl-bridge`)
+
+`hitl-bridge` is a standalone reference crate that demonstrates how an enterprise can
+route Dragon Head's `ask_human` HITL (Human-In-The-Loop) approvals to a chat tool. It
+satisfies spec section ACT-05 ("HITL Concurrency & Safety"): session-level exclusive
+locks against double-approval, and an immutable audit trace of approver user ID,
+timestamp, and Outcome Projection data.
+
+The reference implementation targets **Slack**. `ChatNotifier` is a small trait
+boundary — a Microsoft Teams notifier (Adaptive Cards) is a documented extension
+point; implement the trait against the Teams Bot Framework API and wire it in
+`main.rs` in place of `SlackNotifier`.
+
+## How it works
+
+```
+PageSession (ask_human pending) ──poll──▶ Bridge ──notify──▶ Slack channel (Block Kit)
+                                             │                        │
+                                             │                        ▼
+                                             │              reviewer clicks Approve/Reject
+                                             │                        │
+                                             ▼                        ▼
+                                  SessionLockRegistry ◀── POST /slack/interactions
+                                             │
+                              (winner) ──▶ gateway.approve()/reject() ──▶ audit trail ──▶ chat update
+```
+
+1. **Polling** (`Bridge::poll_once`, `bridge.rs`): on a fixed interval (default 1s),
+   the bridge asks the `ApprovalGateway` for the current `pending_policy_approval()`.
+   On a new request it mints a stable `Uuid` (keyed by `(rule_id, target_signature,
+   action)` since `PolicyApprovalRequest` carries no native ID) and posts a Block Kit
+   prompt via `ChatNotifier::notify`.
+2. **Interaction webhook** (`server.rs`): `POST /slack/interactions` is the external
+   trust boundary. Every request must carry a valid `X-Slack-Signature` HMAC-SHA256
+   over `v0:{timestamp}:{body}`, verified in constant time and checked for staleness
+   (≤5 minutes, matching Slack's documented recommendation). Verification fails
+   closed — malformed, unsigned, stale, or mis-signed requests are rejected (`401`)
+   before any gateway/lock/audit state is touched.
+3. **Resolution** (`Bridge::resolve`): enforces a strict order — **claim the
+   session-level lock → mutate the gateway (approve/reject) → write the audit
+   record → update the chat message**. A lock loss never leaves a partial mutation;
+   a lock win is always durably recorded before the chat message changes.
+
+## Message format
+
+The Slack prompt (Block Kit, `notifier::build_approval_blocks`) contains:
+
+- **Reason / Action intent** — the policy `rule_id` that required approval and the
+  action it gates (e.g. `` `click` ``).
+- **Outcome Projection** — the Guardian Angel projection attached to the
+  `HumanApprovalRequired` error: projected amount (`$900.50`) and risk level
+  (`Low`/`Medium`/`High`/`Critical`), or a `(not available)` placeholder when no
+  projection was captured.
+- **Set-of-Mark capture** (optional) — a screenshot of the page at request time,
+  rendered as an inline `data:image/png;base64,...` image block. **Production note**:
+  inline base64 images bloat message payloads; production deployments should upload
+  via Slack's `files.upload` API and reference the returned URL instead. The
+  reference implementation inlines the image to avoid the extra round trip and keep
+  the example self-contained (`som_image_png` is currently always `None` — wiring a
+  live `VisualCapture` into the notification is a follow-up for a bridge that owns
+  its own `BrowserClient` capture cadence).
+- **Approve / Reject buttons** — `action_id: "approve"` / `"reject"`, with `value`
+  set to the bridge-minted request `Uuid` so the interaction handler can correlate
+  the click back to the pending request.
+
+Once resolved, the original message is replaced (`chat.update`) with a static
+`*Resolved:* approved by *alice*` / `*Resolved:* rejected by *bob*` line.
+
+## Session-lock / "first decision wins" semantics
+
+`SessionLockRegistry` (`lock.rs`) is a `Mutex<HashMap<Uuid, Claim>>`. `try_claim`
+atomically checks-and-sets: the first caller for a given request ID wins
+(`ClaimOutcome::Won`) and proceeds to mutate the gateway, write the audit record, and
+update chat; every subsequent caller for the same ID loses (`ClaimOutcome::LostTo {
+decided_by, decision }`) and is told who already resolved it and what they decided —
+no gateway, audit, or notifier mutation happens on the losing path. This is what
+`tests/bridge_flow.rs::concurrent_resolutions_of_the_same_request_apply_exactly_once`
+verifies: four reviewers race to resolve the same request and exactly one mutation,
+one audit record, and one chat update occur.
+
+## Audit trail format
+
+`BridgeAuditTrail` (`audit.rs`) is an append-only NDJSON log — one immutable JSON
+record per line, opened in append mode and `fsync`'d on every write so a crash never
+leaves a torn or missing entry:
+
+```json
+{"id":"5b1b...","decision":"approved","decided_by":"alice","decided_at_ms":1717740000000,"outcome_projection":{"projected_amount":900.5,"risk_level":"high"}}
+```
+
+Each record carries the approver's user ID (`decided_by` — Slack `username`, falling
+back to `user.id` when no username is set), the resolution timestamp
+(`decided_at_ms`), and the Outcome Projection captured at resolution time
+(`outcome_projection`) — satisfying ACT-05's "approver user ID, timestamp, and
+Outcome Projection data in an immutable log" requirement. The bridge keeps its own
+log rather than widening the shared `core_runtime::AuditEvent` enum for a
+reference-only consumer.
+
+## Running it
+
+### 1. Create a Slack App
+
+1. Go to <https://api.slack.com/apps> → **Create New App** → "From scratch".
+2. **OAuth & Permissions**: add the `chat:write` bot scope, install the app to your
+   workspace, and copy the **Bot User OAuth Token** (`xoxb-...`).
+3. **Basic Information**: copy the **Signing Secret**.
+4. **Interactivity & Shortcuts**: turn interactivity on and set the **Request URL**
+   to `https://<your-host>/slack/interactions` (the bridge's bind address must be
+   reachable from Slack — use a tunnel such as `ngrok` for local testing).
+5. Invite the bot to the target channel and note the channel ID.
+
+### 2. Run the bridge
+
+```bash
+SLACK_SIGNING_SECRET=... \
+SLACK_BOT_TOKEN=xoxb-... \
+SLACK_CHANNEL=C0123456789 \
+cargo run -p hitl-bridge -- \
+  --bind-addr 0.0.0.0:8787 \
+  --audit-log hitl-bridge-audit.ndjson \
+  --poll-interval-ms 1000
+```
+
+Run `cargo run -p hitl-bridge -- --help` for the full CLI reference (all Slack
+credentials are also configurable via the `SLACK_*` environment variables shown
+above, via `clap`'s `env` attribute).
+
+### 3. Exercise the interaction endpoint locally
+
+To observe the lock/audit behavior without a live Slack workspace, send a correctly
+signed `block_actions` payload directly:
+
+```bash
+TS=$(date +%s)
+BODY="payload=$(python3 -c 'import json,urllib.parse;print(urllib.parse.quote(json.dumps({"user":{"id":"U999","username":"alice"},"actions":[{"action_id":"approve","value":"<request-uuid>"}]})))')"
+SIG="v0=$(printf 'v0:%s:%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SLACK_SIGNING_SECRET" | sed 's/^.* //')"
+
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "X-Slack-Request-Timestamp: $TS" \
+  -H "X-Slack-Signature: $SIG" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data "$BODY" \
+  http://localhost:8787/slack/interactions
+```
+
+A `200` indicates the bridge claimed the lock, mutated the gateway, wrote an audit
+record, and updated the chat message; a `409` indicates the lock was already claimed
+by another reviewer; a `401`/`400` indicates signature verification or payload
+parsing failed (check the bridge's `tracing` logs for the rejection reason).
+
+## Evaluation-bench exemption
+
+Following the precedent set by `bench/` (PR-28, also a standalone reference crate),
+`hitl-bridge` is not registered in the comprehensive evaluation bench
+(`docs/testing.md` §2.1's "Registration Rule" targets the five core crates —
+`core-runtime`, `mcp-server`, `skills-engine`, `plugin-host`, `marketplace`). Its
+correctness is covered by its own unit and integration suites
+(`cargo test -p hitl-bridge`).

--- a/hitl-bridge/Cargo.toml
+++ b/hitl-bridge/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "hitl-bridge"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+core-runtime = { path = "../core-runtime" }
+clap = { version = "4", features = ["derive", "env"] }
+axum = "0.7"
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+serde_urlencoded = "0.7"
+base64 = "0.22"
+
+[[bin]]
+name = "dragon-head-hitl-bridge"
+path = "src/main.rs"
+
+[dev-dependencies]
+tempfile = "3.10"
+test-bench-support = { path = "../test-bench-support" }
+urlencoding = "2.1"

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -1,0 +1,186 @@
+//! Immutable append-only audit trail of HITL resolutions.
+//!
+//! Spec ACT-05 requires every approval decision to be traceable to "approver
+//! user ID, timestamp, and Outcome Projection data". Rather than widen the
+//! shared `core_runtime::AuditEvent` enum for a reference-only consumer, the
+//! bridge keeps its own NDJSON log — one immutable JSON record per line,
+//! opened append-only and `fsync`'d on every write.
+
+use anyhow::{Context, Result};
+use core_runtime::OutcomeProjection;
+use serde::{Deserialize, Serialize};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use uuid::Uuid;
+
+use crate::lock::Decision;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditDecision {
+    Approved,
+    Rejected,
+}
+
+impl From<Decision> for AuditDecision {
+    fn from(decision: Decision) -> Self {
+        match decision {
+            Decision::Approved => AuditDecision::Approved,
+            Decision::Rejected => AuditDecision::Rejected,
+        }
+    }
+}
+
+/// One immutable record of a resolved HITL approval request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuditRecord {
+    pub id: Uuid,
+    pub decision: AuditDecision,
+    pub decided_by: String,
+    pub decided_at_ms: u64,
+    pub outcome_projection: Option<OutcomeProjection>,
+}
+
+/// Append-only NDJSON audit trail.
+///
+/// Each [`record`](Self::record) call appends exactly one JSON line and
+/// `fsync`s before returning, so a crash never leaves a torn or missing entry.
+pub struct BridgeAuditTrail {
+    path: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl BridgeAuditTrail {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append `record` as a single NDJSON line, fsync'd before returning.
+    pub fn record(&self, record: &AuditRecord) -> Result<()> {
+        let line = serde_json::to_string(record).context("failed to serialize audit record")?;
+
+        let _guard = self.write_lock.lock().expect("audit trail mutex poisoned");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("failed to open audit trail at {}", self.path.display()))?;
+
+        writeln!(file, "{line}").context("failed to write audit record")?;
+        file.sync_all().context("failed to fsync audit trail")?;
+        Ok(())
+    }
+
+    /// Read back every record currently in the trail, in append order.
+    ///
+    /// Intended for tests and operator inspection — the bridge itself is
+    /// write-only.
+    pub fn read_all(&self) -> Result<Vec<AuditRecord>> {
+        let _guard = self.write_lock.lock().expect("audit trail mutex poisoned");
+        let contents = match std::fs::read_to_string(&self.path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to read audit trail at {}", self.path.display())
+                })
+            }
+        };
+
+        contents
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).context("failed to parse audit record"))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_runtime::RiskLevel;
+    use tempfile::tempdir;
+
+    fn sample_record(id: Uuid, decision: AuditDecision) -> AuditRecord {
+        AuditRecord {
+            id,
+            decision,
+            decided_by: "U12345".to_string(),
+            decided_at_ms: 1_700_000_000_000,
+            outcome_projection: Some(OutcomeProjection {
+                projected_amount: Some(900.0),
+                risk_level: RiskLevel::High,
+            }),
+        }
+    }
+
+    #[test]
+    fn record_then_read_all_round_trips_exactly() {
+        let dir = tempdir().expect("tempdir");
+        let trail = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+        let record = sample_record(Uuid::new_v4(), AuditDecision::Approved);
+
+        trail.record(&record).expect("record should succeed");
+        let read_back = trail.read_all().expect("read_all should succeed");
+
+        assert_eq!(read_back, vec![record]);
+    }
+
+    #[test]
+    fn each_record_appends_one_ndjson_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("audit.ndjson");
+        let trail = BridgeAuditTrail::new(&path);
+
+        trail
+            .record(&sample_record(Uuid::new_v4(), AuditDecision::Approved))
+            .expect("first record");
+        trail
+            .record(&sample_record(Uuid::new_v4(), AuditDecision::Rejected))
+            .expect("second record");
+
+        let contents = std::fs::read_to_string(&path).expect("read file");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in &lines {
+            let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON line");
+            assert!(parsed.get("id").is_some());
+            assert!(parsed.get("decided_by").is_some());
+            assert!(parsed.get("outcome_projection").is_some());
+        }
+    }
+
+    #[test]
+    fn read_all_on_missing_file_returns_empty() {
+        let dir = tempdir().expect("tempdir");
+        let trail = BridgeAuditTrail::new(dir.path().join("does-not-exist.ndjson"));
+
+        assert_eq!(
+            trail.read_all().expect("read_all should succeed"),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn growth_is_append_only_and_preserves_order() {
+        let dir = tempdir().expect("tempdir");
+        let trail = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+
+        let first = sample_record(Uuid::new_v4(), AuditDecision::Approved);
+        let second = sample_record(Uuid::new_v4(), AuditDecision::Rejected);
+        trail.record(&first).expect("first record");
+        trail.record(&second).expect("second record");
+
+        let read_back = trail.read_all().expect("read_all should succeed");
+        assert_eq!(read_back, vec![first, second]);
+    }
+}

--- a/hitl-bridge/src/bridge.rs
+++ b/hitl-bridge/src/bridge.rs
@@ -122,13 +122,23 @@ impl Bridge {
             outcome_projection,
         })?;
 
-        if let Some(token) = self
+        let token = self
             .tokens
             .lock()
             .expect("token map mutex poisoned")
-            .remove(&id)
-        {
+            .get(&id)
+            .cloned();
+        if let Some(token) = token {
+            // Only drop the token once the chat update succeeds — if
+            // `respond` fails (e.g. a transient Slack API error), the token
+            // is the only handle that lets a retry repair the now-stale
+            // prompt for a request whose gateway mutation and audit record
+            // have already been durably committed.
             self.notifier.respond(&token, decision, decided_by)?;
+            self.tokens
+                .lock()
+                .expect("token map mutex poisoned")
+                .remove(&id);
         }
 
         Ok(())
@@ -266,6 +276,47 @@ mod tests {
             bridge_audit_records(&dir).len(),
             1,
             "audit trail must have exactly one record"
+        );
+    }
+
+    #[test]
+    fn resolve_keeps_the_chat_token_when_the_chat_update_fails() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+        let notifier = Arc::new(MockNotifier::new_failing_respond());
+        let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            notifier.clone() as Arc<dyn ChatNotifier>,
+            audit,
+        );
+
+        bridge.poll_once().expect("poll");
+        let result = bridge.resolve(id, Decision::Approved, "alice");
+
+        assert!(
+            result.is_err(),
+            "resolve must surface the chat-update failure"
+        );
+        assert_eq!(
+            gateway.resolutions().len(),
+            1,
+            "the decision must still be applied to the gateway"
+        );
+        assert_eq!(
+            bridge_audit_records(&dir).len(),
+            1,
+            "the decision must still be durably audited"
+        );
+        assert_eq!(
+            bridge
+                .tokens
+                .lock()
+                .expect("token map mutex poisoned")
+                .len(),
+            1,
+            "the chat token must be retained so a retry can repair the stale prompt"
         );
     }
 

--- a/hitl-bridge/src/bridge.rs
+++ b/hitl-bridge/src/bridge.rs
@@ -1,0 +1,277 @@
+//! Orchestration: polls the gateway for new approval requests, notifies chat,
+//! and resolves interactions through the lock registry, gateway, audit trail,
+//! and chat notifier — in that order, so a lock win is always followed by a
+//! durable record before the chat message is updated.
+
+use anyhow::Result;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use crate::audit::{AuditDecision, AuditRecord, BridgeAuditTrail};
+use crate::gateway::ApprovalGateway;
+use crate::lock::{ClaimOutcome, Decision, SessionLockRegistry};
+use crate::notifier::{ApprovalNotification, ChatNotifier};
+
+fn epoch_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Wires the gateway, notifier, lock registry, and audit trail together.
+///
+/// Shared between the polling loop ([`Bridge::poll_once`]) and the HTTP
+/// handler ([`Bridge::resolve`]) — both paths funnel through `resolve` so the
+/// "claim, mutate, audit, respond" ordering is enforced exactly once.
+pub struct Bridge {
+    gateway: Arc<dyn ApprovalGateway>,
+    notifier: Arc<dyn ChatNotifier>,
+    locks: SessionLockRegistry,
+    audit: BridgeAuditTrail,
+    /// Maps a request ID to the notifier-issued token for its prompt message,
+    /// so [`Bridge::resolve`] can update the original message in place.
+    tokens: Mutex<std::collections::HashMap<Uuid, String>>,
+}
+
+impl Bridge {
+    pub fn new(
+        gateway: Arc<dyn ApprovalGateway>,
+        notifier: Arc<dyn ChatNotifier>,
+        audit: BridgeAuditTrail,
+    ) -> Self {
+        Self {
+            gateway,
+            notifier,
+            locks: SessionLockRegistry::new(),
+            audit,
+            tokens: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Checks for a pending request and, if it has not been notified yet,
+    /// posts the prompt and remembers the resulting token.
+    ///
+    /// Returns the request ID that was newly notified, if any.
+    pub fn poll_once(&self) -> Result<Option<Uuid>> {
+        let Some(pending) = self.gateway.pending_request() else {
+            return Ok(None);
+        };
+
+        {
+            let tokens = self.tokens.lock().expect("token map mutex poisoned");
+            if tokens.contains_key(&pending.id) {
+                return Ok(None);
+            }
+        }
+
+        let notification = ApprovalNotification {
+            id: pending.id,
+            rule_id: pending.rule_id.clone(),
+            action: pending.action.clone(),
+            outcome: pending.outcome.clone(),
+            som_image_png: None,
+        };
+        let token = self.notifier.notify(&notification)?;
+
+        self.tokens
+            .lock()
+            .expect("token map mutex poisoned")
+            .insert(pending.id, token);
+
+        Ok(Some(pending.id))
+    }
+
+    /// Resolves the request `id` as `decision`, attributed to `decided_by`.
+    ///
+    /// Enforces the session-level exclusive lock first: if another reviewer
+    /// already claimed this request, no gateway/audit/notifier mutation
+    /// happens and an error describing the existing resolution is returned —
+    /// callers should surface this as "already resolved by @X" rather than a
+    /// generic failure.
+    pub fn resolve(&self, id: Uuid, decision: Decision, decided_by: &str) -> Result<()> {
+        match self.locks.try_claim(id, decided_by, decision) {
+            ClaimOutcome::Won => {}
+            ClaimOutcome::LostTo {
+                decided_by,
+                decision,
+            } => {
+                anyhow::bail!("request {id} was already resolved by {decided_by} ({decision:?})");
+            }
+        }
+
+        let outcome_projection = self.gateway.pending_request().and_then(|pending| {
+            if pending.id == id {
+                pending.outcome
+            } else {
+                None
+            }
+        });
+
+        match decision {
+            Decision::Approved => self.gateway.approve(id)?,
+            Decision::Rejected => self.gateway.reject(id)?,
+        }
+
+        self.audit.record(&AuditRecord {
+            id,
+            decision: AuditDecision::from(decision),
+            decided_by: decided_by.to_string(),
+            decided_at_ms: epoch_millis(),
+            outcome_projection,
+        })?;
+
+        if let Some(token) = self
+            .tokens
+            .lock()
+            .expect("token map mutex poisoned")
+            .remove(&id)
+        {
+            self.notifier.respond(&token, decision, decided_by)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Runs [`Bridge::poll_once`] on a fixed interval until `should_stop` returns
+/// `true`. Polling errors are logged and do not stop the loop — a transient
+/// failure to reach the gateway should not take the bridge down.
+pub fn run_poll_loop(bridge: &Bridge, interval: Duration, mut should_stop: impl FnMut() -> bool) {
+    while !should_stop() {
+        if let Err(err) = bridge.poll_once() {
+            tracing::warn!(error = %err, "poll cycle failed");
+        }
+        std::thread::sleep(interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::mock::MockGateway;
+    use crate::gateway::PendingApproval;
+    use crate::notifier::mock::{Call, MockNotifier};
+    use core_runtime::{ApprovalScope, OutcomeProjection, RiskLevel};
+    use tempfile::tempdir;
+
+    fn sample_pending(id: Uuid) -> PendingApproval {
+        PendingApproval {
+            id,
+            rule_id: "approve-pay".to_string(),
+            action: "click".to_string(),
+            target_signature: "sig-123".to_string(),
+            scope: ApprovalScope::ActionOnly,
+            outcome: Some(OutcomeProjection {
+                projected_amount: Some(900.0),
+                risk_level: RiskLevel::High,
+            }),
+        }
+    }
+
+    fn bridge_with(
+        id: Uuid,
+        dir: &tempfile::TempDir,
+    ) -> (Bridge, Arc<MockGateway>, Arc<MockNotifier>) {
+        let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+        let notifier = Arc::new(MockNotifier::new());
+        let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            notifier.clone() as Arc<dyn ChatNotifier>,
+            audit,
+        );
+        (bridge, gateway, notifier)
+    }
+
+    #[test]
+    fn poll_once_notifies_new_request_and_remembers_token() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let (bridge, _gateway, notifier) = bridge_with(id, &dir);
+
+        let notified = bridge.poll_once().expect("poll should succeed");
+
+        assert_eq!(notified, Some(id));
+        assert_eq!(notifier.calls().len(), 1);
+        assert!(matches!(notifier.calls()[0], Call::Notify(_)));
+    }
+
+    #[test]
+    fn poll_once_does_not_renotify_the_same_request() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let (bridge, _gateway, notifier) = bridge_with(id, &dir);
+
+        bridge.poll_once().expect("first poll");
+        let second = bridge.poll_once().expect("second poll");
+
+        assert_eq!(second, None);
+        assert_eq!(
+            notifier.calls().len(),
+            1,
+            "notify must be called exactly once"
+        );
+    }
+
+    #[test]
+    fn resolve_approves_audits_and_responds_exactly_once() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let (bridge, gateway, notifier) = bridge_with(id, &dir);
+
+        bridge.poll_once().expect("poll");
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("resolve should succeed");
+
+        assert_eq!(gateway.resolutions().len(), 1);
+        let records = bridge_audit_records(&dir);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].decided_by, "alice");
+        assert_eq!(records[0].decision, AuditDecision::Approved);
+        assert!(records[0].outcome_projection.is_some());
+
+        let respond_count = notifier
+            .calls()
+            .iter()
+            .filter(|call| matches!(call, Call::Respond { .. }))
+            .count();
+        assert_eq!(respond_count, 1);
+    }
+
+    #[test]
+    fn second_resolve_attempt_loses_lock_and_does_not_double_mutate() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let (bridge, gateway, _notifier) = bridge_with(id, &dir);
+
+        bridge.poll_once().expect("poll");
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("first resolve wins");
+        let second = bridge.resolve(id, Decision::Rejected, "bob");
+
+        assert!(
+            second.is_err(),
+            "second resolution must be rejected by the lock"
+        );
+        assert_eq!(
+            gateway.resolutions().len(),
+            1,
+            "gateway must be mutated exactly once"
+        );
+        assert_eq!(
+            bridge_audit_records(&dir).len(),
+            1,
+            "audit trail must have exactly one record"
+        );
+    }
+
+    fn bridge_audit_records(dir: &tempfile::TempDir) -> Vec<AuditRecord> {
+        BridgeAuditTrail::new(dir.path().join("audit.ndjson"))
+            .read_all()
+            .expect("read audit trail")
+    }
+}

--- a/hitl-bridge/src/gateway.rs
+++ b/hitl-bridge/src/gateway.rs
@@ -58,35 +58,61 @@ struct RequestKey {
     action: String,
 }
 
-/// [`ApprovalGateway`] backed by a live `core_runtime::PageSession`.
+/// Single-slot cache mapping the most recently observed [`RequestKey`] to a
+/// bridge-minted [`Uuid`].
 ///
-/// Mints and remembers a [`Uuid`] for the most recently observed pending
-/// request. Because the underlying session only ever tracks a single pending
-/// request at a time, a single-slot cache (rather than a full map) is
-/// sufficient and avoids unbounded growth.
+/// Because the underlying session only ever tracks a single pending request at
+/// a time, a single slot (rather than a full map) is sufficient and avoids
+/// unbounded growth. The slot is cleared whenever no request is pending — see
+/// [`clear`](Self::clear) — so that a *later* approval cycle on the same
+/// control (same `rule_id`/`target_signature`/`action`) mints a fresh ID
+/// rather than reusing one the lock registry has already recorded as resolved.
+#[derive(Default)]
+struct MintedIdCache {
+    slot: Option<(RequestKey, Uuid)>,
+}
+
+impl MintedIdCache {
+    fn id_for(&mut self, key: &RequestKey) -> Uuid {
+        if let Some((existing_key, id)) = &self.slot {
+            if existing_key == key {
+                return *id;
+            }
+        }
+        let id = Uuid::new_v4();
+        self.slot = Some((key.clone(), id));
+        id
+    }
+
+    /// Drops the cached ID. Call when no request is pending, so a future
+    /// request with the same key — a fresh approval cycle on the same
+    /// control — mints a new UUID instead of reusing one the lock registry
+    /// already considers resolved (which would make the bridge treat a brand
+    /// new request as a stale, already-decided interaction).
+    fn clear(&mut self) {
+        self.slot = None;
+    }
+}
+
+/// [`ApprovalGateway`] backed by a live `core_runtime::PageSession`.
 pub struct PageSessionGateway {
     session: Arc<PageSession>,
-    minted: std::sync::Mutex<Option<(RequestKey, Uuid)>>,
+    minted: std::sync::Mutex<MintedIdCache>,
 }
 
 impl PageSessionGateway {
     pub fn new(session: Arc<PageSession>) -> Self {
         Self {
             session,
-            minted: std::sync::Mutex::new(None),
+            minted: std::sync::Mutex::new(MintedIdCache::default()),
         }
     }
 
     fn id_for(&self, key: &RequestKey) -> Uuid {
-        let mut minted = self.minted.lock().expect("minted-id mutex poisoned");
-        if let Some((existing_key, id)) = minted.as_ref() {
-            if existing_key == key {
-                return *id;
-            }
-        }
-        let id = Uuid::new_v4();
-        *minted = Some((key.clone(), id));
-        id
+        self.minted
+            .lock()
+            .expect("minted-id mutex poisoned")
+            .id_for(key)
     }
 
     /// Returns the bridge-minted ID for the current pending request, if `id`
@@ -105,7 +131,13 @@ impl PageSessionGateway {
 
 impl ApprovalGateway for PageSessionGateway {
     fn pending_request(&self) -> Option<PendingApproval> {
-        let pending = self.session.pending_policy_approval()?;
+        let Some(pending) = self.session.pending_policy_approval() else {
+            self.minted
+                .lock()
+                .expect("minted-id mutex poisoned")
+                .clear();
+            return None;
+        };
         let key = RequestKey {
             rule_id: pending.rule_id.clone(),
             target_signature: pending.target_signature.clone(),
@@ -229,6 +261,57 @@ mod tests {
                 risk_level: core_runtime::RiskLevel::High,
             }),
         }
+    }
+
+    fn sample_key() -> RequestKey {
+        RequestKey {
+            rule_id: "approve-pay".to_string(),
+            target_signature: "sig-123".to_string(),
+            action: "click".to_string(),
+        }
+    }
+
+    #[test]
+    fn minted_id_cache_returns_the_same_id_for_repeated_lookups_of_the_same_key() {
+        let mut cache = MintedIdCache::default();
+        let key = sample_key();
+
+        let first = cache.id_for(&key);
+        let second = cache.id_for(&key);
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn minted_id_cache_mints_a_distinct_id_for_a_different_key() {
+        let mut cache = MintedIdCache::default();
+        let other_key = RequestKey {
+            rule_id: "approve-pay".to_string(),
+            target_signature: "sig-456".to_string(),
+            action: "click".to_string(),
+        };
+
+        let first = cache.id_for(&sample_key());
+        let second = cache.id_for(&other_key);
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn minted_id_cache_mints_a_fresh_id_after_clear_for_a_new_approval_cycle_on_the_same_control() {
+        let mut cache = MintedIdCache::default();
+        let key = sample_key();
+
+        let first_cycle = cache.id_for(&key);
+        cache.clear();
+        let second_cycle = cache.id_for(&key);
+
+        assert_ne!(
+            first_cycle, second_cycle,
+            "a later approval cycle on the same (rule_id, target_signature, action) \
+             must mint a new ID — reusing the old one would make the lock registry \
+             treat the fresh request as already resolved"
+        );
     }
 
     #[test]

--- a/hitl-bridge/src/gateway.rs
+++ b/hitl-bridge/src/gateway.rs
@@ -1,0 +1,286 @@
+//! Abstraction over the running browser session that the bridge resolves
+//! human-approval requests against.
+//!
+//! [`ApprovalGateway`] lets the orchestration and HTTP layers be exercised in
+//! tests without a live Chrome instance — [`MockGateway`] drives the same
+//! trait surface from an in-memory queue.
+
+use anyhow::Result;
+use core_runtime::{ApprovalScope, OutcomeProjection, PageSession};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// A pending human-approval request, identified by a bridge-minted [`Uuid`].
+///
+/// `core_runtime::PolicyApprovalRequest` has no stable identifier of its own —
+/// the gateway mints `id` the first time it observes a given request (keyed by
+/// `(rule_id, target_signature, action)`) so the chat notification, the lock
+/// registry, and the audit trail can all refer to the same approval by ID.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingApproval {
+    pub id: Uuid,
+    pub rule_id: String,
+    pub action: String,
+    pub target_signature: String,
+    pub scope: ApprovalScope,
+    pub outcome: Option<OutcomeProjection>,
+}
+
+/// Resolves human-approval requests against a running session.
+///
+/// Implementors must be safe to share across the polling loop and the HTTP
+/// handler threads.
+pub trait ApprovalGateway: Send + Sync {
+    /// Returns the current pending approval request, if any, assigning it a
+    /// stable bridge-minted ID (reusing a previously-minted ID for the same
+    /// underlying request).
+    fn pending_request(&self) -> Option<PendingApproval>;
+
+    /// Approve the pending request identified by `id`.
+    ///
+    /// Returns an error if `id` no longer matches the current pending request
+    /// (e.g. it was already resolved or the underlying request changed).
+    fn approve(&self, id: Uuid) -> Result<()>;
+
+    /// Reject the pending request identified by `id`.
+    ///
+    /// Returns an error if `id` no longer matches the current pending request.
+    fn reject(&self, id: Uuid) -> Result<()>;
+}
+
+/// Identifies a [`core_runtime::PolicyApprovalRequest`] independent of the
+/// bridge-minted [`Uuid`], so repeated polls of the same request resolve to
+/// the same ID.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RequestKey {
+    rule_id: String,
+    target_signature: String,
+    action: String,
+}
+
+/// [`ApprovalGateway`] backed by a live `core_runtime::PageSession`.
+///
+/// Mints and remembers a [`Uuid`] for the most recently observed pending
+/// request. Because the underlying session only ever tracks a single pending
+/// request at a time, a single-slot cache (rather than a full map) is
+/// sufficient and avoids unbounded growth.
+pub struct PageSessionGateway {
+    session: Arc<PageSession>,
+    minted: std::sync::Mutex<Option<(RequestKey, Uuid)>>,
+}
+
+impl PageSessionGateway {
+    pub fn new(session: Arc<PageSession>) -> Self {
+        Self {
+            session,
+            minted: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn id_for(&self, key: &RequestKey) -> Uuid {
+        let mut minted = self.minted.lock().expect("minted-id mutex poisoned");
+        if let Some((existing_key, id)) = minted.as_ref() {
+            if existing_key == key {
+                return *id;
+            }
+        }
+        let id = Uuid::new_v4();
+        *minted = Some((key.clone(), id));
+        id
+    }
+
+    /// Returns the bridge-minted ID for the current pending request, if `id`
+    /// still matches it. Used to reject stale interactions (e.g. a button
+    /// press for a request that has since been superseded).
+    fn current_id(&self) -> Option<Uuid> {
+        let pending = self.session.pending_policy_approval()?;
+        let key = RequestKey {
+            rule_id: pending.rule_id,
+            target_signature: pending.target_signature,
+            action: pending.action,
+        };
+        Some(self.id_for(&key))
+    }
+}
+
+impl ApprovalGateway for PageSessionGateway {
+    fn pending_request(&self) -> Option<PendingApproval> {
+        let pending = self.session.pending_policy_approval()?;
+        let key = RequestKey {
+            rule_id: pending.rule_id.clone(),
+            target_signature: pending.target_signature.clone(),
+            action: pending.action.clone(),
+        };
+        let id = self.id_for(&key);
+        Some(PendingApproval {
+            id,
+            rule_id: pending.rule_id,
+            action: pending.action,
+            target_signature: pending.target_signature,
+            scope: pending.scope,
+            outcome: pending.outcome,
+        })
+    }
+
+    fn approve(&self, id: Uuid) -> Result<()> {
+        if self.current_id() != Some(id) {
+            anyhow::bail!("Approval request {id} is no longer pending");
+        }
+        self.session.approve_pending_policy_action()
+    }
+
+    fn reject(&self, id: Uuid) -> Result<()> {
+        if self.current_id() != Some(id) {
+            anyhow::bail!("Approval request {id} is no longer pending");
+        }
+        self.session.reject_pending_policy_action()
+    }
+}
+
+/// In-memory [`ApprovalGateway`] for tests — drives the same trait surface as
+/// [`PageSessionGateway`] without a browser.
+pub mod mock {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum Resolution {
+        Approved,
+        Rejected,
+    }
+
+    #[derive(Default)]
+    struct State {
+        pending: Option<PendingApproval>,
+        resolutions: Vec<(Uuid, Resolution)>,
+    }
+
+    /// Mock gateway seeded with a single pending request; records whatever
+    /// resolution (approve/reject) the bridge applies to it.
+    pub struct MockGateway {
+        state: Mutex<State>,
+    }
+
+    impl MockGateway {
+        pub fn new(pending: Option<PendingApproval>) -> Self {
+            Self {
+                state: Mutex::new(State {
+                    pending,
+                    resolutions: Vec::new(),
+                }),
+            }
+        }
+
+        /// Resolutions recorded so far, in application order.
+        pub fn resolutions(&self) -> Vec<(Uuid, Resolution)> {
+            self.state
+                .lock()
+                .expect("mock gateway mutex poisoned")
+                .resolutions
+                .clone()
+        }
+
+        fn resolve(&self, id: Uuid, resolution: Resolution) -> Result<()> {
+            let mut state = self.state.lock().expect("mock gateway mutex poisoned");
+            match &state.pending {
+                Some(pending) if pending.id == id => {
+                    state.pending = None;
+                    state.resolutions.push((id, resolution));
+                    Ok(())
+                }
+                _ => anyhow::bail!("Approval request {id} is no longer pending"),
+            }
+        }
+    }
+
+    impl ApprovalGateway for MockGateway {
+        fn pending_request(&self) -> Option<PendingApproval> {
+            self.state
+                .lock()
+                .expect("mock gateway mutex poisoned")
+                .pending
+                .clone()
+        }
+
+        fn approve(&self, id: Uuid) -> Result<()> {
+            self.resolve(id, Resolution::Approved)
+        }
+
+        fn reject(&self, id: Uuid) -> Result<()> {
+            self.resolve(id, Resolution::Rejected)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mock::{MockGateway, Resolution};
+    use super::*;
+
+    fn sample_pending(id: Uuid) -> PendingApproval {
+        PendingApproval {
+            id,
+            rule_id: "approve-pay".to_string(),
+            action: "click".to_string(),
+            target_signature: "sig-123".to_string(),
+            scope: ApprovalScope::ActionOnly,
+            outcome: Some(OutcomeProjection {
+                projected_amount: Some(900.0),
+                risk_level: core_runtime::RiskLevel::High,
+            }),
+        }
+    }
+
+    #[test]
+    fn mock_gateway_reports_seeded_pending_request() {
+        let id = Uuid::new_v4();
+        let gateway = MockGateway::new(Some(sample_pending(id)));
+
+        let pending = gateway.pending_request().expect("pending request");
+        assert_eq!(pending.id, id);
+        assert_eq!(pending.rule_id, "approve-pay");
+    }
+
+    #[test]
+    fn mock_gateway_approve_clears_pending_and_records_resolution() {
+        let id = Uuid::new_v4();
+        let gateway = MockGateway::new(Some(sample_pending(id)));
+
+        gateway.approve(id).expect("approve should succeed");
+
+        assert!(gateway.pending_request().is_none());
+        assert_eq!(gateway.resolutions(), vec![(id, Resolution::Approved)]);
+    }
+
+    #[test]
+    fn mock_gateway_reject_clears_pending_and_records_resolution() {
+        let id = Uuid::new_v4();
+        let gateway = MockGateway::new(Some(sample_pending(id)));
+
+        gateway.reject(id).expect("reject should succeed");
+
+        assert!(gateway.pending_request().is_none());
+        assert_eq!(gateway.resolutions(), vec![(id, Resolution::Rejected)]);
+    }
+
+    #[test]
+    fn mock_gateway_rejects_stale_id() {
+        let real_id = Uuid::new_v4();
+        let stale_id = Uuid::new_v4();
+        let gateway = MockGateway::new(Some(sample_pending(real_id)));
+
+        let result = gateway.approve(stale_id);
+
+        assert!(result.is_err());
+        assert!(gateway.pending_request().is_some());
+        assert!(gateway.resolutions().is_empty());
+    }
+
+    #[test]
+    fn mock_gateway_with_no_pending_request_resolves_to_none() {
+        let gateway = MockGateway::new(None);
+
+        assert!(gateway.pending_request().is_none());
+        assert!(gateway.approve(Uuid::new_v4()).is_err());
+    }
+}

--- a/hitl-bridge/src/lib.rs
+++ b/hitl-bridge/src/lib.rs
@@ -1,0 +1,16 @@
+//! Reference Slack/Teams HITL (Human-In-The-Loop) approval bridge.
+//!
+//! Polls a `core_runtime::PageSession` for pending policy-approval requests,
+//! relays them to a chat tool, and resolves the human's decision back into the
+//! session — enforcing a session-level exclusive lock so two reviewers cannot
+//! both act on the same request, and recording an immutable audit trail of
+//! who decided what, when, and against which Outcome Projection (spec ACT-05).
+//!
+//! See `docs/hitl-slack-bridge.md` for setup and message-format details.
+
+pub mod audit;
+pub mod bridge;
+pub mod gateway;
+pub mod lock;
+pub mod notifier;
+pub mod server;

--- a/hitl-bridge/src/lock.rs
+++ b/hitl-bridge/src/lock.rs
@@ -1,0 +1,136 @@
+//! Session-level exclusive lock preventing two reviewers from both resolving
+//! the same approval request (spec ACT-05 "HITL Concurrency & Safety").
+//!
+//! Exactly one of two concurrent `try_claim` calls for the same request ID
+//! wins; the loser learns who won and what they decided so the bridge can
+//! show them an "already resolved by @X" message instead of silently
+//! double-applying the decision.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    Approved,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Claim {
+    decided_by: String,
+    decision: Decision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    /// The caller is the first to resolve this request and may proceed.
+    Won,
+    /// Someone else already resolved this request first.
+    LostTo {
+        decided_by: String,
+        decision: Decision,
+    },
+}
+
+/// Registry of resolved approval-request IDs.
+///
+/// `try_claim` is the only mutator; it atomically checks-and-sets under a
+/// single mutex so two threads racing on the same ID can never both win.
+#[derive(Default)]
+pub struct SessionLockRegistry {
+    claims: Mutex<HashMap<Uuid, Claim>>,
+}
+
+impl SessionLockRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attempt to claim exclusive resolution rights for `id`.
+    ///
+    /// On [`ClaimOutcome::Won`], the caller is the sole resolver and must
+    /// proceed to mutate the gateway and write the audit record. On
+    /// [`ClaimOutcome::LostTo`], the caller must not mutate anything further —
+    /// another reviewer already resolved this request.
+    pub fn try_claim(&self, id: Uuid, decided_by: &str, decision: Decision) -> ClaimOutcome {
+        let mut claims = self.claims.lock().expect("lock registry mutex poisoned");
+        if let Some(existing) = claims.get(&id) {
+            return ClaimOutcome::LostTo {
+                decided_by: existing.decided_by.clone(),
+                decision: existing.decision,
+            };
+        }
+        claims.insert(
+            id,
+            Claim {
+                decided_by: decided_by.to_string(),
+                decision,
+            },
+        );
+        ClaimOutcome::Won
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn first_claim_wins_second_loses_to_first() {
+        let registry = SessionLockRegistry::new();
+        let id = Uuid::new_v4();
+
+        let first = registry.try_claim(id, "alice", Decision::Approved);
+        let second = registry.try_claim(id, "bob", Decision::Rejected);
+
+        assert_eq!(first, ClaimOutcome::Won);
+        assert_eq!(
+            second,
+            ClaimOutcome::LostTo {
+                decided_by: "alice".to_string(),
+                decision: Decision::Approved,
+            }
+        );
+    }
+
+    #[test]
+    fn different_ids_claim_independently() {
+        let registry = SessionLockRegistry::new();
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+
+        assert_eq!(
+            registry.try_claim(first_id, "alice", Decision::Approved),
+            ClaimOutcome::Won
+        );
+        assert_eq!(
+            registry.try_claim(second_id, "bob", Decision::Rejected),
+            ClaimOutcome::Won
+        );
+    }
+
+    #[test]
+    fn concurrent_claims_on_same_id_produce_exactly_one_winner() {
+        let registry = Arc::new(SessionLockRegistry::new());
+        let id = Uuid::new_v4();
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let registry = Arc::clone(&registry);
+                let name = format!("reviewer-{i}");
+                thread::spawn(move || registry.try_claim(id, &name, Decision::Approved))
+            })
+            .collect();
+
+        let outcomes: Vec<ClaimOutcome> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        let wins = outcomes.iter().filter(|o| **o == ClaimOutcome::Won).count();
+        let losses = outcomes.len() - wins;
+
+        assert_eq!(wins, 1, "exactly one claimant must win the lock");
+        assert_eq!(losses, 7);
+    }
+}

--- a/hitl-bridge/src/main.rs
+++ b/hitl-bridge/src/main.rs
@@ -1,0 +1,104 @@
+//! Reference Slack HITL bridge CLI.
+//!
+//! Wires a live `core_runtime::PageSession` to Slack: polls for pending
+//! human-approval requests, posts Block Kit prompts with Outcome Projection
+//! data, and serves `/slack/interactions` to relay Approve/Reject decisions
+//! back into the session under a session-level exclusive lock with an
+//! immutable audit trail (spec ACT-05). See `docs/hitl-slack-bridge.md`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use core_runtime::BrowserClient;
+
+use hitl_bridge::audit::BridgeAuditTrail;
+use hitl_bridge::bridge::{run_poll_loop, Bridge};
+use hitl_bridge::gateway::{ApprovalGateway, PageSessionGateway};
+use hitl_bridge::notifier::{ChatNotifier, SlackNotifier};
+use hitl_bridge::server::{router, ServerState};
+
+/// Reference implementation of the Slack/Teams HITL approval bridge (ACT-05 / ISSUE-15).
+#[derive(Parser, Debug)]
+#[command(name = "dragon-head-hitl-bridge", version, about)]
+struct Cli {
+    /// Address to bind the Slack interactivity webhook server to.
+    #[arg(long, default_value = "0.0.0.0:8787")]
+    bind_addr: String,
+
+    /// Slack app signing secret, used to verify `X-Slack-Signature` on inbound interactions.
+    #[arg(long, env = "SLACK_SIGNING_SECRET")]
+    slack_signing_secret: String,
+
+    /// Slack bot token (`xoxb-...`) used to post and update approval prompts.
+    #[arg(long, env = "SLACK_BOT_TOKEN")]
+    slack_bot_token: String,
+
+    /// Slack channel ID to post approval prompts into.
+    #[arg(long, env = "SLACK_CHANNEL")]
+    slack_channel: String,
+
+    /// Path to the append-only NDJSON audit trail file.
+    #[arg(long, default_value = "hitl-bridge-audit.ndjson")]
+    audit_log: std::path::PathBuf,
+
+    /// How often to poll the session for new pending approval requests.
+    #[arg(long, default_value_t = 1000)]
+    poll_interval_ms: u64,
+
+    /// Optional explicit Chrome binary path, forwarded to `BrowserClient`.
+    #[arg(long)]
+    chrome_path: Option<String>,
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+
+    let client = BrowserClient::new_with_chrome_path(cli.chrome_path.clone())
+        .context("failed to launch BrowserClient")?;
+    let session = Arc::new(
+        client
+            .new_page()
+            .context("failed to open a new page session")?,
+    );
+
+    let gateway: Arc<dyn ApprovalGateway> = Arc::new(PageSessionGateway::new(session));
+    let notifier: Arc<dyn ChatNotifier> = Arc::new(SlackNotifier::new(
+        cli.slack_bot_token.clone(),
+        cli.slack_channel.clone(),
+    ));
+    let audit = BridgeAuditTrail::new(cli.audit_log.clone());
+
+    let bridge = Arc::new(Bridge::new(gateway, notifier, audit));
+
+    let poll_bridge = Arc::clone(&bridge);
+    let poll_interval = Duration::from_millis(cli.poll_interval_ms);
+    let poll_handle = std::thread::spawn(move || {
+        run_poll_loop(&poll_bridge, poll_interval, || false);
+    });
+
+    let state = ServerState {
+        bridge,
+        signing_secret: Arc::new(cli.slack_signing_secret.clone()),
+    };
+    let app = router(state);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    runtime.block_on(async {
+        let listener = tokio::net::TcpListener::bind(&cli.bind_addr)
+            .await
+            .with_context(|| format!("failed to bind {}", cli.bind_addr))?;
+        tracing::info!(addr = %cli.bind_addr, "hitl-bridge listening for Slack interactions");
+        axum::serve(listener, app)
+            .await
+            .context("Slack interactions server failed")
+    })?;
+
+    poll_handle.join().expect("poll thread panicked");
+    Ok(())
+}

--- a/hitl-bridge/src/notifier.rs
+++ b/hitl-bridge/src/notifier.rs
@@ -237,11 +237,25 @@ pub mod mock {
     #[derive(Default)]
     pub struct MockNotifier {
         calls: Mutex<Vec<Call>>,
+        /// When `true`, [`respond`](ChatNotifier::respond) returns an error
+        /// without recording the call — simulates a transient chat-API
+        /// failure (e.g. a network error updating the Slack message) so
+        /// tests can assert the bridge preserves recoverable state.
+        fail_respond: std::sync::atomic::AtomicBool,
     }
 
     impl MockNotifier {
         pub fn new() -> Self {
             Self::default()
+        }
+
+        /// Builds a notifier whose `respond` calls always fail — for testing
+        /// how the bridge behaves when the chat-update step errors out.
+        pub fn new_failing_respond() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_respond: std::sync::atomic::AtomicBool::new(true),
+            }
         }
 
         pub fn calls(&self) -> Vec<Call> {
@@ -263,6 +277,9 @@ pub mod mock {
         }
 
         fn respond(&self, token: &str, decision: Decision, decided_by: &str) -> Result<()> {
+            if self.fail_respond.load(std::sync::atomic::Ordering::SeqCst) {
+                anyhow::bail!("mock notifier: simulated chat-update failure");
+            }
             self.calls
                 .lock()
                 .expect("mock notifier mutex poisoned")

--- a/hitl-bridge/src/notifier.rs
+++ b/hitl-bridge/src/notifier.rs
@@ -1,0 +1,372 @@
+//! Relays approval requests to a chat tool and posts back the resolution.
+//!
+//! [`ChatNotifier`] is the trait boundary the rest of the bridge depends on;
+//! [`SlackNotifier`] is the reference Slack Block Kit implementation. A Teams
+//! notifier is a documented extension point — implement the same trait against
+//! the Teams Adaptive Cards API.
+
+use anyhow::{Context, Result};
+use core_runtime::{OutcomeProjection, RiskLevel};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::lock::Decision;
+
+/// Everything the notifier needs to render an approval prompt.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApprovalNotification {
+    pub id: Uuid,
+    pub rule_id: String,
+    pub action: String,
+    pub outcome: Option<OutcomeProjection>,
+    /// Set-of-Mark screenshot of the page at the moment the request was
+    /// raised, if available. Rendered as an inline base64 data URL in the
+    /// reference implementation — production deployments should upload via
+    /// `files.upload` and reference the returned URL instead (see
+    /// `docs/hitl-slack-bridge.md`).
+    pub som_image_png: Option<Vec<u8>>,
+}
+
+/// Sends approval prompts to a chat tool and updates them once resolved.
+///
+/// Implementors must be safe to share across the polling loop and the HTTP
+/// handler threads.
+pub trait ChatNotifier: Send + Sync {
+    /// Post a new approval prompt. Returns an opaque token (e.g. a Slack
+    /// `channel:ts` pair) that [`respond`](Self::respond) uses to update the
+    /// original message.
+    fn notify(&self, notification: &ApprovalNotification) -> Result<String>;
+
+    /// Replace the original prompt with the final resolution.
+    fn respond(&self, token: &str, decision: Decision, decided_by: &str) -> Result<()>;
+}
+
+fn risk_label(level: &RiskLevel) -> &'static str {
+    match level {
+        RiskLevel::Low => "Low",
+        RiskLevel::Medium => "Medium",
+        RiskLevel::High => "High",
+        RiskLevel::Critical => "Critical",
+    }
+}
+
+fn outcome_field_text(outcome: &Option<OutcomeProjection>) -> String {
+    match outcome {
+        Some(projection) => {
+            let amount = projection
+                .projected_amount
+                .map(|amount| format!("${amount:.2}"))
+                .unwrap_or_else(|| "(none detected)".to_string());
+            format!(
+                "*Outcome Projection*\nProjected amount: {amount}\nRisk level: {}",
+                risk_label(&projection.risk_level)
+            )
+        }
+        None => "*Outcome Projection*\n(not available)".to_string(),
+    }
+}
+
+/// Builds the Slack Block Kit message body for an approval prompt.
+///
+/// Exposed so tests (and `MockNotifier`) can assert on the exact JSON shape
+/// without going over the network.
+pub fn build_approval_blocks(notification: &ApprovalNotification) -> Value {
+    let mut blocks = vec![
+        json!({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": format!(
+                    "*Human approval requested*\n*Reason:* rule `{}` requires approval\n*Action intent:* `{}`",
+                    notification.rule_id, notification.action,
+                ),
+            },
+        }),
+        json!({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": outcome_field_text(&notification.outcome),
+            },
+        }),
+    ];
+
+    if let Some(image_png) = &notification.som_image_png {
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(image_png);
+        blocks.push(json!({
+            "type": "image",
+            "image_url": format!("data:image/png;base64,{encoded}"),
+            "alt_text": "Set-of-Mark capture of the page at the time of the request",
+        }));
+    }
+
+    blocks.push(json!({
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Approve" },
+                "style": "primary",
+                "action_id": "approve",
+                "value": notification.id.to_string(),
+            },
+            {
+                "type": "button",
+                "text": { "type": "plain_text", "text": "Reject" },
+                "style": "danger",
+                "action_id": "reject",
+                "value": notification.id.to_string(),
+            },
+        ],
+    }));
+
+    json!({ "blocks": blocks })
+}
+
+/// Builds the Slack Block Kit message body for a resolved prompt — replaces
+/// the interactive buttons with a static resolution line.
+pub fn build_resolution_blocks(decision: Decision, decided_by: &str) -> Value {
+    let verb = match decision {
+        Decision::Approved => "approved",
+        Decision::Rejected => "rejected",
+    };
+    json!({
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": format!("*Resolved:* {verb} by *{decided_by}*"),
+                },
+            },
+        ],
+    })
+}
+
+/// Reference Slack implementation of [`ChatNotifier`].
+///
+/// Posts via `chat.postMessage` and updates via `chat.update`, both of which
+/// accept the same Block Kit body shape — the resolution token is the
+/// `"{channel}:{ts}"` pair Slack returns from `postMessage`.
+pub struct SlackNotifier {
+    client: reqwest::blocking::Client,
+    bot_token: String,
+    channel: String,
+}
+
+impl SlackNotifier {
+    pub fn new(bot_token: impl Into<String>, channel: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::blocking::Client::new(),
+            bot_token: bot_token.into(),
+            channel: channel.into(),
+        }
+    }
+
+    fn post(&self, method: &str, body: &Value) -> Result<Value> {
+        let response = self
+            .client
+            .post(format!("https://slack.com/api/{method}"))
+            .bearer_auth(&self.bot_token)
+            .json(body)
+            .send()
+            .with_context(|| format!("failed to call Slack API method '{method}'"))?;
+
+        let payload: Value = response
+            .json()
+            .with_context(|| format!("failed to parse Slack API response for '{method}'"))?;
+
+        if payload.get("ok").and_then(Value::as_bool) != Some(true) {
+            anyhow::bail!(
+                "Slack API method '{method}' returned an error: {}",
+                payload
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+            );
+        }
+
+        Ok(payload)
+    }
+}
+
+impl ChatNotifier for SlackNotifier {
+    fn notify(&self, notification: &ApprovalNotification) -> Result<String> {
+        let mut body = build_approval_blocks(notification);
+        body["channel"] = json!(self.channel);
+
+        let payload = self.post("chat.postMessage", &body)?;
+        let ts = payload
+            .get("ts")
+            .and_then(Value::as_str)
+            .context("Slack chat.postMessage response missing 'ts'")?;
+
+        Ok(format!("{}:{ts}", self.channel))
+    }
+
+    fn respond(&self, token: &str, decision: Decision, decided_by: &str) -> Result<()> {
+        let (channel, ts) = token
+            .split_once(':')
+            .context("malformed Slack resolution token; expected 'channel:ts'")?;
+
+        let mut body = build_resolution_blocks(decision, decided_by);
+        body["channel"] = json!(channel);
+        body["ts"] = json!(ts);
+
+        self.post("chat.update", &body)?;
+        Ok(())
+    }
+}
+
+/// In-memory [`ChatNotifier`] for tests — records every call.
+pub mod mock {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Call {
+        Notify(ApprovalNotification),
+        Respond {
+            token: String,
+            decision: Decision,
+            decided_by: String,
+        },
+    }
+
+    #[derive(Default)]
+    pub struct MockNotifier {
+        calls: Mutex<Vec<Call>>,
+    }
+
+    impl MockNotifier {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn calls(&self) -> Vec<Call> {
+            self.calls
+                .lock()
+                .expect("mock notifier mutex poisoned")
+                .clone()
+        }
+    }
+
+    impl ChatNotifier for MockNotifier {
+        fn notify(&self, notification: &ApprovalNotification) -> Result<String> {
+            let token = format!("mock-channel:{}", notification.id);
+            self.calls
+                .lock()
+                .expect("mock notifier mutex poisoned")
+                .push(Call::Notify(notification.clone()));
+            Ok(token)
+        }
+
+        fn respond(&self, token: &str, decision: Decision, decided_by: &str) -> Result<()> {
+            self.calls
+                .lock()
+                .expect("mock notifier mutex poisoned")
+                .push(Call::Respond {
+                    token: token.to_string(),
+                    decision,
+                    decided_by: decided_by.to_string(),
+                });
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_notification() -> ApprovalNotification {
+        ApprovalNotification {
+            id: Uuid::new_v4(),
+            rule_id: "approve-pay".to_string(),
+            action: "click".to_string(),
+            outcome: Some(OutcomeProjection {
+                projected_amount: Some(900.5),
+                risk_level: RiskLevel::High,
+            }),
+            som_image_png: Some(vec![1, 2, 3, 4]),
+        }
+    }
+
+    #[test]
+    fn approval_blocks_include_reason_action_and_outcome_text() {
+        let notification = sample_notification();
+        let body = build_approval_blocks(&notification);
+        let rendered = body.to_string();
+
+        assert!(rendered.contains("approve-pay"));
+        assert!(rendered.contains("`click`"));
+        assert!(rendered.contains("Projected amount: $900.50"));
+        assert!(rendered.contains("Risk level: High"));
+    }
+
+    #[test]
+    fn approval_blocks_wire_button_action_ids_and_values_to_the_request_id() {
+        let notification = sample_notification();
+        let body = build_approval_blocks(&notification);
+        let blocks = body["blocks"].as_array().expect("blocks array");
+
+        let actions = blocks
+            .iter()
+            .find(|block| block["type"] == "actions")
+            .expect("an actions block must be present");
+        let elements = actions["elements"].as_array().expect("elements array");
+
+        assert_eq!(elements.len(), 2);
+        assert_eq!(elements[0]["action_id"], "approve");
+        assert_eq!(elements[0]["value"], notification.id.to_string());
+        assert_eq!(elements[1]["action_id"], "reject");
+        assert_eq!(elements[1]["value"], notification.id.to_string());
+    }
+
+    #[test]
+    fn approval_blocks_render_som_image_as_inline_data_url_when_present() {
+        let notification = sample_notification();
+        let body = build_approval_blocks(&notification);
+        let blocks = body["blocks"].as_array().expect("blocks array");
+
+        let image = blocks
+            .iter()
+            .find(|block| block["type"] == "image")
+            .expect("an image block must be present when SoM data is attached");
+        assert!(image["image_url"]
+            .as_str()
+            .expect("image_url string")
+            .starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn approval_blocks_omit_image_block_when_som_capture_is_absent() {
+        let mut notification = sample_notification();
+        notification.som_image_png = None;
+        let body = build_approval_blocks(&notification);
+        let blocks = body["blocks"].as_array().expect("blocks array");
+
+        assert!(!blocks.iter().any(|block| block["type"] == "image"));
+    }
+
+    #[test]
+    fn approval_blocks_render_placeholder_when_outcome_projection_missing() {
+        let mut notification = sample_notification();
+        notification.outcome = None;
+        let body = build_approval_blocks(&notification);
+
+        assert!(body
+            .to_string()
+            .contains("Outcome Projection*\\n(not available)"));
+    }
+
+    #[test]
+    fn resolution_blocks_state_who_decided_and_what() {
+        let approved = build_resolution_blocks(Decision::Approved, "alice");
+        let rejected = build_resolution_blocks(Decision::Rejected, "bob");
+
+        assert!(approved.to_string().contains("approved by *alice*"));
+        assert!(rejected.to_string().contains("rejected by *bob*"));
+    }
+}

--- a/hitl-bridge/src/server.rs
+++ b/hitl-bridge/src/server.rs
@@ -1,0 +1,315 @@
+//! Inbound HTTP surface: Slack interactivity webhook.
+//!
+//! `POST /slack/interactions` is an external trust boundary — every request
+//! must carry a valid `X-Slack-Signature` HMAC-SHA256 over
+//! `v0:{timestamp}:{body}` (Slack's signing-secret scheme). Verification
+//! fails closed: malformed, unsigned, stale, or mis-signed requests are
+//! rejected before any gateway/lock/audit state is touched.
+
+use anyhow::{Context, Result};
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::post,
+    Router,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+use crate::bridge::Bridge;
+use crate::lock::Decision;
+
+/// Maximum age of a signed request before it is rejected as a replay.
+///
+/// Matches Slack's documented recommendation of five minutes.
+const MAX_REQUEST_AGE_SECS: u64 = 60 * 5;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone)]
+pub struct ServerState {
+    pub bridge: Arc<Bridge>,
+    pub signing_secret: Arc<String>,
+}
+
+pub fn router(state: ServerState) -> Router {
+    Router::new()
+        .route("/slack/interactions", post(handle_interaction))
+        .with_state(state)
+}
+
+/// Verifies `v0={hmac_sha256(signing_secret, "v0:{timestamp}:{body}")}` against
+/// the `X-Slack-Signature` header, and rejects requests whose `X-Slack-Request-Timestamp`
+/// is missing, malformed, or older than [`MAX_REQUEST_AGE_SECS`].
+///
+/// Returns `Ok(())` only when every check passes; any failure is reported as
+/// a descriptive error so the caller can respond `401 Unauthorized` without
+/// touching gateway, lock, or audit state (fail closed).
+fn verify_slack_signature(headers: &HeaderMap, body: &[u8], signing_secret: &str) -> Result<()> {
+    let timestamp_header = headers
+        .get("x-slack-request-timestamp")
+        .and_then(|value| value.to_str().ok())
+        .context("missing X-Slack-Request-Timestamp header")?;
+    let timestamp: u64 = timestamp_header
+        .parse()
+        .context("X-Slack-Request-Timestamp header is not a valid integer")?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_secs();
+    let age = now
+        .checked_sub(timestamp)
+        .unwrap_or_else(|| timestamp - now);
+    if age > MAX_REQUEST_AGE_SECS {
+        anyhow::bail!(
+            "request timestamp {timestamp} is too far from server time {now} (age={age}s)"
+        );
+    }
+
+    let signature_header = headers
+        .get("x-slack-signature")
+        .and_then(|value| value.to_str().ok())
+        .context("missing X-Slack-Signature header")?;
+    let expected_hex = signature_header
+        .strip_prefix("v0=")
+        .context("X-Slack-Signature header is missing the 'v0=' version prefix")?;
+    let expected_bytes =
+        hex::decode(expected_hex).context("X-Slack-Signature header is not valid hex")?;
+
+    let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes())
+        .context("HMAC can take a key of any length")?;
+    mac.update(b"v0:");
+    mac.update(timestamp_header.as_bytes());
+    mac.update(b":");
+    mac.update(body);
+
+    // `verify_slice` performs a constant-time comparison internally.
+    mac.verify_slice(&expected_bytes)
+        .map_err(|_| anyhow::anyhow!("signature mismatch"))?;
+
+    Ok(())
+}
+
+/// Slack `block_actions` interaction payload — only the fields the bridge
+/// needs are modeled; everything else is ignored.
+#[derive(Debug, serde::Deserialize)]
+struct BlockActionsPayload {
+    user: InteractingUser,
+    actions: Vec<BlockAction>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InteractingUser {
+    id: String,
+    #[serde(default)]
+    username: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct BlockAction {
+    action_id: String,
+    value: String,
+}
+
+fn parse_interaction(body: &[u8]) -> Result<(Uuid, Decision, String)> {
+    let form: Vec<(String, String)> = serde_urlencoded::from_bytes(body)
+        .context("failed to parse interaction body as form data")?;
+    let payload_json = form
+        .into_iter()
+        .find(|(key, _)| key == "payload")
+        .map(|(_, value)| value)
+        .context("interaction body is missing the 'payload' field")?;
+
+    let payload: BlockActionsPayload =
+        serde_json::from_str(&payload_json).context("failed to parse interaction payload JSON")?;
+    let action = payload
+        .actions
+        .into_iter()
+        .next()
+        .context("interaction payload contains no actions")?;
+
+    let decision = match action.action_id.as_str() {
+        "approve" => Decision::Approved,
+        "reject" => Decision::Rejected,
+        other => anyhow::bail!("unrecognized action_id '{other}'"),
+    };
+    let id: Uuid = action
+        .value
+        .parse()
+        .context("action value is not a valid request ID")?;
+    let decided_by = payload.user.username.unwrap_or(payload.user.id);
+
+    Ok((id, decision, decided_by))
+}
+
+async fn handle_interaction(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    if let Err(err) = verify_slack_signature(&headers, &body, &state.signing_secret) {
+        tracing::warn!(error = %err, "rejected Slack interaction: signature verification failed");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let (id, decision, decided_by) = match parse_interaction(&body) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            tracing::warn!(error = %err, "rejected Slack interaction: malformed payload");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    match state.bridge.resolve(id, decision, &decided_by) {
+        Ok(()) => StatusCode::OK,
+        Err(err) => {
+            tracing::warn!(error = %err, %id, "failed to resolve approval request");
+            StatusCode::CONFLICT
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signed_headers(timestamp: u64, body: &[u8], secret: &str) -> HeaderMap {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(b"v0:");
+        mac.update(timestamp.to_string().as_bytes());
+        mac.update(b":");
+        mac.update(body);
+        let signature = format!("v0={}", hex::encode(mac.finalize().into_bytes()));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-slack-request-timestamp",
+            timestamp.to_string().parse().unwrap(),
+        );
+        headers.insert("x-slack-signature", signature.parse().unwrap());
+        headers
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn valid_signature_with_fresh_timestamp_passes() {
+        let body = b"payload=test-body";
+        let headers = signed_headers(now_secs(), body, "shh-secret");
+
+        assert!(verify_slack_signature(&headers, body, "shh-secret").is_ok());
+    }
+
+    #[test]
+    fn signature_computed_with_wrong_secret_is_rejected() {
+        let body = b"payload=test-body";
+        let headers = signed_headers(now_secs(), body, "wrong-secret");
+
+        assert!(verify_slack_signature(&headers, body, "shh-secret").is_err());
+    }
+
+    #[test]
+    fn tampered_body_is_rejected() {
+        let original_body = b"payload=test-body";
+        let headers = signed_headers(now_secs(), original_body, "shh-secret");
+
+        let tampered_body = b"payload=tampered-body";
+        assert!(verify_slack_signature(&headers, tampered_body, "shh-secret").is_err());
+    }
+
+    #[test]
+    fn stale_timestamp_is_rejected() {
+        let body = b"payload=test-body";
+        let stale_timestamp = now_secs() - MAX_REQUEST_AGE_SECS - 60;
+        let headers = signed_headers(stale_timestamp, body, "shh-secret");
+
+        assert!(verify_slack_signature(&headers, body, "shh-secret").is_err());
+    }
+
+    #[test]
+    fn missing_signature_header_is_rejected() {
+        let body = b"payload=test-body";
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-slack-request-timestamp",
+            now_secs().to_string().parse().unwrap(),
+        );
+
+        assert!(verify_slack_signature(&headers, body, "shh-secret").is_err());
+    }
+
+    #[test]
+    fn missing_version_prefix_is_rejected() {
+        let body = b"payload=test-body";
+        let mut mac = HmacSha256::new_from_slice(b"shh-secret").unwrap();
+        mac.update(b"v0:");
+        mac.update(now_secs().to_string().as_bytes());
+        mac.update(b":");
+        mac.update(body);
+        let raw_hex = hex::encode(mac.finalize().into_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-slack-request-timestamp",
+            now_secs().to_string().parse().unwrap(),
+        );
+        headers.insert("x-slack-signature", raw_hex.parse().unwrap());
+
+        assert!(verify_slack_signature(&headers, body, "shh-secret").is_err());
+    }
+
+    #[test]
+    fn parse_interaction_extracts_id_decision_and_actor() {
+        let id = Uuid::new_v4();
+        let payload = serde_json::json!({
+            "user": { "id": "U999", "username": "alice" },
+            "actions": [{ "action_id": "approve", "value": id.to_string() }],
+        })
+        .to_string();
+        let body = serde_urlencoded::to_string([("payload", payload)]).unwrap();
+
+        let (parsed_id, decision, decided_by) = parse_interaction(body.as_bytes()).unwrap();
+
+        assert_eq!(parsed_id, id);
+        assert_eq!(decision, Decision::Approved);
+        assert_eq!(decided_by, "alice");
+    }
+
+    #[test]
+    fn parse_interaction_falls_back_to_user_id_when_username_absent() {
+        let id = Uuid::new_v4();
+        let payload = serde_json::json!({
+            "user": { "id": "U999" },
+            "actions": [{ "action_id": "reject", "value": id.to_string() }],
+        })
+        .to_string();
+        let body = serde_urlencoded::to_string([("payload", payload)]).unwrap();
+
+        let (_, decision, decided_by) = parse_interaction(body.as_bytes()).unwrap();
+
+        assert_eq!(decision, Decision::Rejected);
+        assert_eq!(decided_by, "U999");
+    }
+
+    #[test]
+    fn parse_interaction_rejects_unknown_action_id() {
+        let payload = serde_json::json!({
+            "user": { "id": "U999" },
+            "actions": [{ "action_id": "snooze", "value": Uuid::new_v4().to_string() }],
+        })
+        .to_string();
+        let body = serde_urlencoded::to_string([("payload", payload)]).unwrap();
+
+        assert!(parse_interaction(body.as_bytes()).is_err());
+    }
+}

--- a/hitl-bridge/tests/bridge_flow.rs
+++ b/hitl-bridge/tests/bridge_flow.rs
@@ -1,0 +1,233 @@
+//! Integration coverage for the HITL bridge orchestration.
+//!
+//! The fast suite (`cargo test -p hitl-bridge`) exercises the full
+//! gateway → lock → audit → notifier pipeline against `MockGateway` /
+//! `MockNotifier` — including the concurrency scenario from spec ACT-05
+//! ("複数人による同時承認リクエストの競合回避検証": concurrent approvals of
+//! the same request must not double-apply). One `#[ignore]`d test wires a
+//! real `BrowserClient` end to end; run it explicitly with a live Chrome via
+//! `cargo test -p hitl-bridge -- --include-ignored`.
+
+use std::sync::Arc;
+use std::thread;
+
+use core_runtime::{ApprovalScope, OutcomeProjection, RiskLevel};
+use hitl_bridge::audit::{AuditDecision, BridgeAuditTrail};
+use hitl_bridge::bridge::Bridge;
+use hitl_bridge::gateway::mock::MockGateway;
+use hitl_bridge::gateway::{ApprovalGateway, PendingApproval};
+use hitl_bridge::lock::Decision;
+use hitl_bridge::notifier::mock::MockNotifier;
+use hitl_bridge::notifier::ChatNotifier;
+use uuid::Uuid;
+
+fn sample_pending(id: Uuid) -> PendingApproval {
+    PendingApproval {
+        id,
+        rule_id: "approve-pay".to_string(),
+        action: "click".to_string(),
+        target_signature: "sig-123".to_string(),
+        scope: ApprovalScope::ActionOnly,
+        outcome: Some(OutcomeProjection {
+            projected_amount: Some(900.0),
+            risk_level: RiskLevel::High,
+        }),
+    }
+}
+
+/// Two reviewers race to resolve the same request — exactly one mutation must
+/// land on the gateway, exactly one audit record must be written, and the
+/// loser must come back with an error rather than silently no-op'ing.
+#[test]
+fn concurrent_resolutions_of_the_same_request_apply_exactly_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = Uuid::new_v4();
+
+    let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+    let notifier = Arc::new(MockNotifier::new());
+    let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+    let bridge = Arc::new(Bridge::new(
+        gateway.clone() as Arc<dyn ApprovalGateway>,
+        notifier.clone() as Arc<dyn ChatNotifier>,
+        audit,
+    ));
+
+    bridge.poll_once().expect("initial poll should notify");
+
+    let decisions = [
+        ("alice", Decision::Approved),
+        ("bob", Decision::Rejected),
+        ("carol", Decision::Approved),
+        ("dave", Decision::Rejected),
+    ];
+
+    let handles: Vec<_> = decisions
+        .into_iter()
+        .map(|(name, decision)| {
+            let bridge = Arc::clone(&bridge);
+            thread::spawn(move || bridge.resolve(id, decision, name))
+        })
+        .collect();
+
+    let results: Vec<anyhow::Result<()>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let successes = results.iter().filter(|r| r.is_ok()).count();
+    let failures = results.iter().filter(|r| r.is_err()).count();
+
+    assert_eq!(successes, 1, "exactly one resolution attempt must succeed");
+    assert_eq!(
+        failures, 3,
+        "the rest must lose the lock and report an error"
+    );
+
+    assert_eq!(
+        gateway.resolutions().len(),
+        1,
+        "the gateway must be mutated exactly once regardless of contention"
+    );
+
+    let records = BridgeAuditTrail::new(dir.path().join("audit.ndjson"))
+        .read_all()
+        .expect("read audit trail");
+    assert_eq!(records.len(), 1, "exactly one audit record must be written");
+    assert!(
+        matches!(
+            records[0].decision,
+            AuditDecision::Approved | AuditDecision::Rejected
+        ),
+        "the single audit record must reflect the winning decision"
+    );
+    assert!(
+        decisions
+            .iter()
+            .any(|(name, _)| *name == records[0].decided_by),
+        "the audit record must attribute the decision to one of the contending reviewers"
+    );
+    assert!(
+        records[0].outcome_projection.is_some(),
+        "ACT-05 requires the audit record to carry Outcome Projection data"
+    );
+}
+
+#[test]
+fn poll_then_resolve_drives_notifier_through_prompt_and_resolution() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = Uuid::new_v4();
+
+    let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+    let notifier = Arc::new(MockNotifier::new());
+    let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+    let bridge = Bridge::new(
+        gateway.clone() as Arc<dyn ApprovalGateway>,
+        notifier.clone() as Arc<dyn ChatNotifier>,
+        audit,
+    );
+
+    let notified = bridge.poll_once().expect("poll should succeed");
+    assert_eq!(notified, Some(id));
+
+    bridge
+        .resolve(id, Decision::Approved, "alice")
+        .expect("resolve should succeed");
+
+    let calls = notifier.calls();
+    assert_eq!(calls.len(), 2, "exactly one notify followed by one respond");
+    assert!(matches!(
+        calls[0],
+        hitl_bridge::notifier::mock::Call::Notify(_)
+    ));
+    assert!(matches!(
+        calls[1],
+        hitl_bridge::notifier::mock::Call::Respond {
+            decision: Decision::Approved,
+            ..
+        }
+    ));
+}
+
+/// End-to-end wiring against a live session: raises a real `HumanApprovalRequired`,
+/// resolves it through `PageSessionGateway`, and confirms the action stays
+/// blocked until approved. Mirrors `bench/`'s `#[ignore]` browser test pattern —
+/// run explicitly with `cargo test -p hitl-bridge -- --include-ignored`.
+#[test]
+#[ignore]
+fn page_session_gateway_resolves_a_real_pending_approval() -> anyhow::Result<()> {
+    use core_runtime::sre::{normalize_dom, LoadProfile, SemanticState};
+    use core_runtime::{ActionError, BrowserClient, PolicyAction, PolicyRule};
+    use hitl_bridge::gateway::PageSessionGateway;
+
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = Arc::new(client.new_page()?);
+    page.set_policy_rules(vec![PolicyRule {
+        id: "approve-pay".to_string(),
+        domain: None,
+        path_prefix: None,
+        role: Some("button".to_string()),
+        text_regex: Some("(?i)pay".to_string()),
+        context_regex: None,
+        action: PolicyAction::RequireHumanApproval,
+        scope: Some(ApprovalScope::ActionOnly),
+        outcome_projector: None,
+    }])?;
+
+    let html = r#"
+        <html>
+            <body>
+                <button id="pay" onclick="document.body.dataset.paid = 'true'">Pay</button>
+            </body>
+        </html>
+    "#;
+    let url = format!("data:text/html,{}", urlencoding::encode(html));
+    page.navigate(&url)?;
+
+    let root = page.get_document_node()?;
+    let sem = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(sem, LoadProfile::Interactive);
+    let (target_id, target_key) = find_button(state.root()).expect("button must be present");
+
+    let first_attempt = page.act(Some(target_id), Some(&target_key), "click", None);
+    assert!(first_attempt.is_err(), "approval should be required first");
+    let err = first_attempt.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<ActionError>(),
+        Some(ActionError::HumanApprovalRequired { .. })
+    ));
+
+    let gateway = PageSessionGateway::new(Arc::clone(&page));
+    let pending = gateway
+        .pending_request()
+        .expect("gateway should observe the pending request");
+
+    gateway.approve(pending.id)?;
+    assert!(page.pending_policy_approval().is_none());
+
+    let retry = page.act(Some(target_id), Some(&target_key), "click", None);
+    assert!(retry.is_ok(), "approved action should now succeed");
+
+    let paid = page
+        .evaluate_script("document.body.dataset.paid")?
+        .value
+        .and_then(|v| v.as_str().map(ToOwned::to_owned));
+    assert_eq!(paid.as_deref(), Some("true"));
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn find_button(node: &core_runtime::sre::state::SemanticNode) -> Option<(i64, String)> {
+    if node.role == "button" {
+        return Some((
+            node.backend_node_id,
+            node.stable_key.clone().unwrap_or_default(),
+        ));
+    }
+    for child in &node.children {
+        if let Some(found) = find_button(child) {
+            return Some(found);
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Summary

- Adds `hitl-bridge`, a standalone reference crate implementing spec section ACT-05 ("HITL Concurrency & Safety"): a Slack App bridge that polls `PageSession` for pending `ask_human` approvals, posts Block Kit prompts (rule/action intent, Outcome Projection risk+amount, optional Set-of-Mark capture) with Approve/Reject buttons, and resolves them via a signature-verified `POST /slack/interactions` webhook (HMAC-SHA256, fail-closed, constant-time compare, ≤5min staleness window).
- `SessionLockRegistry` (session-level exclusive lock) guarantees exactly one of N concurrent reviewers can resolve a request — "first decision wins"; losers are told who decided what and no gateway/audit/notifier mutation occurs on the losing path.
- `BridgeAuditTrail` writes an `fsync`'d, append-only NDJSON record of every resolution (approver user ID, timestamp, Outcome Projection) — kept separate from the shared `core_runtime::AuditEvent` enum to avoid widening it for a reference-only consumer.
- Adds `reject_pending_policy_action` to `core-runtime::PageSession` — the missing counterpart to `approve_pending_policy_action` (previously `ask_human` could only be approved or left pending). Also extends `PolicyApprovalRequest`/`GrantedPolicyApproval` with `outcome: Option<OutcomeProjection>` so the bridge can surface and audit the Guardian Angel projection alongside the approval prompt (a deliberate, additive extension beyond the original plan scope — verified via grep that no `Eq`-bound dependents exist and there is a single construction site).
- New `docs/hitl-slack-bridge.md`: Slack App setup, message format, session-lock semantics, audit-trail format, running instructions (incl. a `curl` recipe for exercising `/slack/interactions` locally with a signed payload), and an explicit Teams extension-point note (the trait boundary makes a Teams `ChatNotifier` a small follow-up).
- Fixes two pre-existing, unrelated clippy lint failures surfaced by `-D warnings` on the touched crates (`needless_borrows_for_generic_args` in `audit_sink.rs` test, `redundant_closure` in `audit_logging.rs` integration test) — both one-line fixes needed to keep the lint gate green.

Closes #75

## Test plan

- [x] `cargo test -p hitl-bridge --lib` — 31 unit tests pass (gateway, lock concurrency, notifier Block Kit payload assertions, audit NDJSON round-trip, server HMAC verification + interaction parsing, bridge orchestration)
- [x] `cargo test -p hitl-bridge --test bridge_flow` — integration suite: `concurrent_resolutions_of_the_same_request_apply_exactly_once` (4 reviewers race; exactly 1 mutation/audit-record/chat-update), `poll_then_resolve_drives_notifier_through_prompt_and_resolution`; one `#[ignore]`d browser-backed test documenting real `PageSessionGateway` wiring (mirrors `bench/`'s pattern, gated by `should_skip_browser_tests()`)
- [x] `cargo test -p core-runtime --test policy_enforcement test_reject_pending_policy_action_keeps_action_blocked` — new reject-path regression test passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manually exercised `/slack/interactions` with a crafted HMAC-signed `block_actions` payload against a locally running instance — confirmed `200`/`409`/`401` paths per `docs/hitl-slack-bridge.md`'s recipe