### PR TITLE
[ISSUE-148] CLI: add --version/--help, reject unknown flags

### DIFF
--- a/mcp-server/src/cli.rs
+++ b/mcp-server/src/cli.rs
@@ -38,6 +38,16 @@ const RECOGNIZED_FLAGS: &[&str] = &["--help", "--version", "--doctor", "--init"]
 
 /// Parses CLI arguments (excluding the program name) into a [`CliAction`].
 pub fn parse_args(args: &[String]) -> CliAction {
+    // --help/--version win even if an unrecognized flag is also present,
+    // so a typo doesn't block a user trying to get usage or version info.
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return CliAction::Help;
+    }
+
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        return CliAction::Version;
+    }
+
     let init_pos = args.iter().position(|a| a == "--init");
     // Index of the argument consumed as --init's client name, if any.
     let init_client_idx = init_pos.and_then(|pos| {
@@ -57,14 +67,6 @@ pub fn parse_args(args: &[String]) -> CliAction {
         }
     }) {
         return CliAction::UnknownFlag(flag.clone());
-    }
-
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        return CliAction::Help;
-    }
-
-    if args.iter().any(|a| a == "--version" || a == "-V") {
-        return CliAction::Version;
     }
 
     if args.iter().any(|a| a == "--doctor") {
@@ -139,6 +141,19 @@ mod tests {
         assert_eq!(
             parse_args(&args(&["--init", "codex", "--bogus"])),
             CliAction::UnknownFlag("--bogus".to_string())
+        );
+    }
+
+    #[test]
+    fn help_wins_over_an_unrelated_unknown_flag() {
+        assert_eq!(parse_args(&args(&["--help", "--bogus"])), CliAction::Help);
+    }
+
+    #[test]
+    fn version_wins_over_an_unrelated_unknown_flag() {
+        assert_eq!(
+            parse_args(&args(&["--version", "--bogus"])),
+            CliAction::Version
         );
     }
 

--- a/mcp-server/src/cli.rs
+++ b/mcp-server/src/cli.rs
@@ -1,0 +1,141 @@
+//! Command-line argument parsing for the `dragon-head-mcp` binary.
+
+/// Usage text shown for `--help`/`-h` and on unrecognized-flag errors.
+pub const USAGE: &str = "\
+dragon-head-mcp - AI-native headless browser runtime MCP server
+
+USAGE:
+    dragon-head-mcp [FLAGS]
+
+FLAGS:
+    --doctor          Check Chrome detection and configuration, then exit
+    --init [CLIENT]   Print an MCP client config snippet and exit
+                      CLIENT: claude-code, claude-desktop, codex, generic
+    -V, --version     Print version information and exit
+    -h, --help        Print this help message and exit
+
+With no flags, starts the stdio MCP server.";
+
+/// The action requested via command-line arguments.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CliAction {
+    /// Start the stdio MCP server (default).
+    RunServer,
+    /// Run Chrome/config diagnostics and exit.
+    Doctor,
+    /// Print an MCP client config snippet for the given client (or all clients).
+    Init(Option<String>),
+    /// Print version information and exit.
+    Version,
+    /// Print usage information and exit.
+    Help,
+    /// An unrecognized `--flag` was passed.
+    UnknownFlag(String),
+}
+
+/// Parses CLI arguments (excluding the program name) into a [`CliAction`].
+pub fn parse_args(args: &[String]) -> CliAction {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return CliAction::Help;
+    }
+
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        return CliAction::Version;
+    }
+
+    if args.iter().any(|a| a == "--doctor") {
+        return CliAction::Doctor;
+    }
+
+    if let Some(pos) = args.iter().position(|a| a == "--init") {
+        let client = args.get(pos + 1).filter(|s| !s.starts_with('-')).cloned();
+        return CliAction::Init(client);
+    }
+
+    if let Some(flag) = args.iter().find(|a| a.starts_with("--")) {
+        return CliAction::UnknownFlag(flag.clone());
+    }
+
+    CliAction::RunServer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_args_runs_server() {
+        assert_eq!(parse_args(&args(&[])), CliAction::RunServer);
+    }
+
+    #[test]
+    fn doctor_flag_returns_doctor() {
+        assert_eq!(parse_args(&args(&["--doctor"])), CliAction::Doctor);
+    }
+
+    #[test]
+    fn init_without_client_returns_init_none() {
+        assert_eq!(parse_args(&args(&["--init"])), CliAction::Init(None));
+    }
+
+    #[test]
+    fn init_with_client_returns_init_some() {
+        assert_eq!(
+            parse_args(&args(&["--init", "claude-code"])),
+            CliAction::Init(Some("claude-code".to_string()))
+        );
+    }
+
+    #[test]
+    fn doctor_takes_precedence_over_init() {
+        assert_eq!(
+            parse_args(&args(&["--init", "--doctor"])),
+            CliAction::Doctor
+        );
+    }
+
+    #[test]
+    fn init_does_not_consume_following_flag_as_client() {
+        assert_eq!(
+            parse_args(&args(&["--init", "--bogus"])),
+            CliAction::Init(None)
+        );
+    }
+
+    #[test]
+    fn version_long_flag_returns_version() {
+        assert_eq!(parse_args(&args(&["--version"])), CliAction::Version);
+    }
+
+    #[test]
+    fn version_short_flag_returns_version() {
+        assert_eq!(parse_args(&args(&["-V"])), CliAction::Version);
+    }
+
+    #[test]
+    fn help_long_flag_returns_help() {
+        assert_eq!(parse_args(&args(&["--help"])), CliAction::Help);
+    }
+
+    #[test]
+    fn help_short_flag_returns_help() {
+        assert_eq!(parse_args(&args(&["-h"])), CliAction::Help);
+    }
+
+    #[test]
+    fn unknown_flag_is_rejected() {
+        assert_eq!(
+            parse_args(&args(&["--bogus"])),
+            CliAction::UnknownFlag("--bogus".to_string())
+        );
+    }
+
+    #[test]
+    fn help_takes_precedence_over_other_flags() {
+        assert_eq!(parse_args(&args(&["--doctor", "--help"])), CliAction::Help);
+    }
+}

--- a/mcp-server/src/cli.rs
+++ b/mcp-server/src/cli.rs
@@ -33,8 +33,32 @@ pub enum CliAction {
     UnknownFlag(String),
 }
 
+/// `--`-prefixed flags recognized by [`parse_args`].
+const RECOGNIZED_FLAGS: &[&str] = &["--help", "--version", "--doctor", "--init"];
+
 /// Parses CLI arguments (excluding the program name) into a [`CliAction`].
 pub fn parse_args(args: &[String]) -> CliAction {
+    let init_pos = args.iter().position(|a| a == "--init");
+    // Index of the argument consumed as --init's client name, if any.
+    let init_client_idx = init_pos.and_then(|pos| {
+        args.get(pos + 1)
+            .filter(|s| !s.starts_with('-'))
+            .map(|_| pos + 1)
+    });
+
+    if let Some(flag) = args.iter().enumerate().find_map(|(i, a)| {
+        if Some(i) == init_client_idx {
+            return None;
+        }
+        if a.starts_with("--") && !RECOGNIZED_FLAGS.contains(&a.as_str()) {
+            Some(a)
+        } else {
+            None
+        }
+    }) {
+        return CliAction::UnknownFlag(flag.clone());
+    }
+
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return CliAction::Help;
     }
@@ -47,13 +71,9 @@ pub fn parse_args(args: &[String]) -> CliAction {
         return CliAction::Doctor;
     }
 
-    if let Some(pos) = args.iter().position(|a| a == "--init") {
-        let client = args.get(pos + 1).filter(|s| !s.starts_with('-')).cloned();
+    if init_pos.is_some() {
+        let client = init_client_idx.map(|idx| args[idx].clone());
         return CliAction::Init(client);
-    }
-
-    if let Some(flag) = args.iter().find(|a| a.starts_with("--")) {
-        return CliAction::UnknownFlag(flag.clone());
     }
 
     CliAction::RunServer
@@ -102,7 +122,23 @@ mod tests {
     fn init_does_not_consume_following_flag_as_client() {
         assert_eq!(
             parse_args(&args(&["--init", "--bogus"])),
-            CliAction::Init(None)
+            CliAction::UnknownFlag("--bogus".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_flag_after_recognized_action_is_rejected() {
+        assert_eq!(
+            parse_args(&args(&["--doctor", "--bogus"])),
+            CliAction::UnknownFlag("--bogus".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_flag_after_init_with_client_is_rejected() {
+        assert_eq!(
+            parse_args(&args(&["--init", "codex", "--bogus"])),
+            CliAction::UnknownFlag("--bogus".to_string())
         );
     }
 

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -390,7 +390,7 @@ impl<B: McpBackend> McpServer<B> {
                 },
                 "serverInfo": {
                     "name": "dragon-head-mcp",
-                    "version": "0.1.0"
+                    "version": env!("CARGO_PKG_VERSION")
                 }
             })),
             "notifications/initialized" => {

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -2,33 +2,41 @@ use core_runtime::BrowserClient;
 use mcp_server::{doctor, CoreRuntimeBackend, McpServer};
 use std::io::{self, BufRead, Write};
 
+mod cli;
 mod init;
 
 fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = std::env::args().skip(1).collect();
 
-    if args.iter().any(|a| a == "--init") {
-        let client = args.windows(2).find(|w| w[0] == "--init").and_then(|w| {
-            let s = w[1].as_str();
-            if s.starts_with('-') {
-                None
-            } else {
-                Some(s)
+    match cli::parse_args(&args) {
+        cli::CliAction::Help => {
+            println!("{}", cli::USAGE);
+            return Ok(());
+        }
+        cli::CliAction::Version => {
+            println!("dragon-head-mcp {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        cli::CliAction::Init(client) => {
+            if !init::print_init(client.as_deref()) {
+                std::process::exit(1);
             }
-        });
-        if !init::print_init(client) {
-            std::process::exit(1);
+            return Ok(());
         }
-        return Ok(());
-    }
-
-    if args.iter().any(|a| a == "--doctor") {
-        let report = doctor::run_doctor();
-        doctor::print_report(&report);
-        if !report.all_passed() {
-            std::process::exit(1);
+        cli::CliAction::Doctor => {
+            let report = doctor::run_doctor();
+            doctor::print_report(&report);
+            if !report.all_passed() {
+                std::process::exit(1);
+            }
+            return Ok(());
         }
-        return Ok(());
+        cli::CliAction::UnknownFlag(flag) => {
+            eprintln!("dragon-head-mcp: unrecognized flag '{flag}'\n");
+            eprintln!("{}", cli::USAGE);
+            std::process::exit(2);
+        }
+        cli::CliAction::RunServer => {}
     }
 
     let chrome_path = std::env::var("CHROME_PATH").ok();


### PR DESCRIPTION
## Summary
- Extracts CLI argument parsing into a new testable `cli::parse_args` function (`mcp-server/src/cli.rs`) returning a `CliAction` enum.
- Adds `--version`/`-V` (prints `dragon-head-mcp <CARGO_PKG_VERSION>`) and `--help`/`-h` (prints usage).
- Unrecognized `--flags` now print an error + usage and exit with code 2, instead of silently starting the server.
- Replaces the hardcoded `"version": "0.1.0"` in the `initialize` JSON-RPC response's `serverInfo` with `env!("CARGO_PKG_VERSION")`.

Closes #148

## Test plan
- [x] `cargo test -p mcp-server` — new `cli` unit tests pass (precedence: help > version > doctor > init > unknown-flag > run-server)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Manual: `dragon-head-mcp --version`, `--help`, `--bogus` (exit 2)