### PR TITLE
[ISSUE-149] Chrome crash/disconnect recovery for long-running MCP sessions

### DIFF
--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -68,6 +68,14 @@ pub enum AuditEvent {
         reason: Option<String>,
         timestamp: u64,
     },
+    /// Emitted when the Chrome process disconnected and the session was
+    /// automatically relaunched with a fresh page (ISSUE-149).
+    #[serde(rename = "BROWSER_RESTART")]
+    BrowserRestart {
+        reason: String,
+        restart_count: u64,
+        timestamp: u64,
+    },
 }
 
 /// Handle to the metrics of a persistent `MeteredSink<RollingFileSink>`.

--- a/core-runtime/src/audit_replay.rs
+++ b/core-runtime/src/audit_replay.rs
@@ -180,11 +180,12 @@ pub fn replay_events(events: &[AuditEvent]) -> Result<ReplayReport, ReplayError>
                 });
             }
 
-            // Visual captures and plugin events don't contribute to the state chain
-            // or decision records but are counted in total_events.
+            // Visual captures, plugin events, and browser restarts don't contribute
+            // to the state chain or decision records but are counted in total_events.
             AuditEvent::VisualCapture { .. }
             | AuditEvent::PluginStateTransform { .. }
-            | AuditEvent::PluginPolicyDecision { .. } => {}
+            | AuditEvent::PluginPolicyDecision { .. }
+            | AuditEvent::BrowserRestart { .. } => {}
         }
     }
 

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -149,6 +149,7 @@ pub struct BrowserClient {
     vault: Arc<dyn SessionVault>,
     plugin_hooks: Arc<PluginHookConfig>,
     viewport_size: Option<(u32, u32)>,
+    chrome_path: Option<String>,
 }
 
 impl BrowserClient {
@@ -216,8 +217,8 @@ impl BrowserClient {
     ) -> Result<Self> {
         let mut builder = LaunchOptions::default_builder();
         builder.headless(true);
-        if let Some(path) = chrome_path {
-            builder.path(Some(path.into()));
+        if let Some(path) = chrome_path.as_ref() {
+            builder.path(Some(path.clone().into()));
         }
         let options = builder.build().context("Failed to build launch options")?;
 
@@ -227,6 +228,7 @@ impl BrowserClient {
             vault,
             plugin_hooks: Arc::new(plugin_hooks),
             viewport_size: None,
+            chrome_path,
         })
     }
 
@@ -245,6 +247,7 @@ impl BrowserClient {
             vault,
             plugin_hooks: Arc::new(PluginHookConfig::default()),
             viewport_size: Some((width, height)),
+            chrome_path: None,
         })
     }
 
@@ -276,6 +279,74 @@ impl BrowserClient {
             dom_signature_cache: Arc::new(DOMSignatureCache::new()),
         })
     }
+
+    /// OS process ID of the underlying Chrome process, if it was launched
+    /// (not connected to via an existing debugger URL).
+    ///
+    /// Used by integration tests to simulate a Chrome crash (ISSUE-149).
+    pub fn process_id(&self) -> Option<u32> {
+        self.inner.get_process_id()
+    }
+
+    /// Relaunches the Chrome process after a crash/disconnect and returns a
+    /// fresh [`PageSession`] (ISSUE-149: Chrome crash/disconnect recovery).
+    ///
+    /// Reuses the original `chrome_path` and `viewport_size` so the new
+    /// process matches the original launch configuration. The
+    /// [`SessionVault`] and plugin hooks are shared (`Arc`) and therefore
+    /// survive the relaunch unchanged; in-page navigation state, cookies
+    /// outside the vault, and DOM-level recovery caches are reset because the
+    /// returned `PageSession` is newly constructed.
+    ///
+    /// Emits an [`AuditEvent::BrowserRestart`] via `audit_logger` before
+    /// returning the new session.
+    pub fn relaunch(
+        &mut self,
+        audit_logger: AuditLogger,
+        reason: &str,
+        restart_count: u64,
+    ) -> Result<PageSession> {
+        let mut builder = LaunchOptions::default_builder();
+        builder.headless(true);
+        if let Some(path) = self.chrome_path.as_ref() {
+            builder.path(Some(path.clone().into()));
+        }
+        if let Some((width, height)) = self.viewport_size {
+            builder.window_size(Some((width, height)));
+        }
+        let options = builder.build().context("Failed to build launch options")?;
+
+        self.inner = Browser::new(options).context("Failed to relaunch browser")?;
+
+        let page = self.new_page_with_audit_logger(audit_logger)?;
+        page.audit_logger.log(AuditEvent::BrowserRestart {
+            reason: reason.to_string(),
+            restart_count,
+            timestamp: epoch_millis_u64(),
+        });
+        Ok(page)
+    }
+}
+
+/// Returns `true` if `err`'s error chain indicates that the underlying Chrome
+/// process disconnected (crashed, was killed, or the CDP websocket dropped),
+/// as opposed to a page-level error (ISSUE-149).
+pub fn is_browser_disconnected(err: &anyhow::Error) -> bool {
+    if err.chain().any(|source| {
+        source
+            .downcast_ref::<headless_chrome::browser::ConnectionClosed>()
+            .is_some()
+    }) {
+        return true;
+    }
+
+    let markers = [
+        "connection is closed",
+        "broken pipe",
+        "connection reset",
+        "not connected",
+    ];
+    error_chain_contains_any(err, &markers)
 }
 
 fn apply_viewport_size(tab: &headless_chrome::Tab, width: u32, height: u32) -> Result<()> {
@@ -789,6 +860,26 @@ impl PageSession {
             .lock()
             .ok()
             .and_then(|index| index.get(stable_key).and_then(|entry| entry.alias.clone()))
+    }
+
+    /// Returns a clone of this session's [`AuditLogger`] handle.
+    ///
+    /// Used to carry the same audit logger (and its persistent sink) into the
+    /// fresh [`PageSession`] created by [`BrowserClient::relaunch`] (ISSUE-149).
+    pub fn audit_logger_handle(&self) -> AuditLogger {
+        (*self.audit_logger).clone()
+    }
+
+    /// Returns the currently configured policy rules for this page session.
+    ///
+    /// Used to reapply policy configuration to the fresh `PageSession`
+    /// created by [`BrowserClient::relaunch`] (ISSUE-149).
+    pub fn policy_rules(&self) -> Result<Vec<PolicyRule>> {
+        let guard = self
+            .policy_engine
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock policy engine"))?;
+        Ok(guard.rules().to_vec())
     }
 
     /// Replace policy rules for this page session.
@@ -2639,6 +2730,41 @@ mod tests {
             index.get("root/#document/html/body/section/input"),
             Some(&vec![0, 0, 2, 0])
         );
+    }
+
+    #[test]
+    fn is_browser_disconnected_detects_connection_closed_error() {
+        let err = anyhow::Error::new(headless_chrome::browser::ConnectionClosed {});
+        assert!(is_browser_disconnected(&err));
+    }
+
+    #[test]
+    fn is_browser_disconnected_detects_connection_closed_in_chain() {
+        let err = anyhow::Error::new(headless_chrome::browser::ConnectionClosed {})
+            .context("Failed to capture semantic state");
+        assert!(is_browser_disconnected(&err));
+    }
+
+    #[test]
+    fn is_browser_disconnected_detects_io_markers() {
+        for marker in [
+            "Connection is closed",
+            "Broken pipe",
+            "connection reset by peer",
+            "transport not connected",
+        ] {
+            let err = anyhow::anyhow!("{marker}");
+            assert!(
+                is_browser_disconnected(&err),
+                "expected disconnect marker '{marker}' to be detected"
+            );
+        }
+    }
+
+    #[test]
+    fn is_browser_disconnected_ignores_page_level_errors() {
+        let err = anyhow::anyhow!("Could not find node with given id");
+        assert!(!is_browser_disconnected(&err));
     }
 }
 

--- a/core-runtime/src/error.rs
+++ b/core-runtime/src/error.rs
@@ -40,3 +40,48 @@ pub enum WaitError {
     #[error("Timed out waiting for {operation} after {timeout_ms}ms")]
     Timeout { operation: String, timeout_ms: u64 },
 }
+
+/// Errors surfaced when the underlying Chrome process disconnects mid-session
+/// (ISSUE-149: Chrome crash/disconnect recovery).
+#[derive(Error, Debug)]
+pub enum SessionError {
+    /// The Chrome process disconnected and the session was automatically
+    /// restarted with a fresh page. Navigation state, in-page cookies, and
+    /// unsaved form data were reset, and any pending or previously granted
+    /// human-approval requests were discarded.
+    #[error(
+        "Chrome process disconnected; the session was automatically restarted (restart #{restart_count}). \
+         Navigation state, in-page cookies, and unsaved form data were reset, and any pending or \
+         previously granted human-approval requests were discarded — retry the request and \
+         re-request approval if needed."
+    )]
+    BrowserRestarted { restart_count: u64 },
+
+    /// The Chrome process disconnected and automatic restart could not recover the session.
+    #[error("Chrome process disconnected and automatic restart failed: {reason}")]
+    BrowserRestartFailed { reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_restarted_message_includes_restart_count_and_reset_notice() {
+        let err = SessionError::BrowserRestarted { restart_count: 3 };
+        let message = err.to_string();
+        assert!(message.contains("restart #3"));
+        assert!(message.contains("automatically restarted"));
+        assert!(message.contains("retry the request"));
+    }
+
+    #[test]
+    fn browser_restart_failed_message_includes_reason() {
+        let err = SessionError::BrowserRestartFailed {
+            reason: "no managed BrowserClient".to_string(),
+        };
+        let message = err.to_string();
+        assert!(message.contains("automatic restart failed"));
+        assert!(message.contains("no managed BrowserClient"));
+    }
+}

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -19,13 +19,13 @@ pub use sre::{
 };
 
 pub use browser::{
-    ActionLogEntry, BrowserClient, PageSession, SemanticTarget, SemanticWaitOptions,
-    SemanticWaitState, SomMark, SomTrigger, VisualCapture,
+    is_browser_disconnected, ActionLogEntry, BrowserClient, PageSession, SemanticTarget,
+    SemanticWaitOptions, SemanticWaitState, SomMark, SomTrigger, VisualCapture,
 };
 pub mod error;
 pub use audit_sink::DurabilityMode;
 pub use chrome_detection::chrome_available;
-pub use error::{ActionError, VerifyError, WaitError};
+pub use error::{ActionError, SessionError, VerifyError, WaitError};
 pub use plugin_hooks::PluginHookConfig;
 pub use policy::{
     ApprovalScope, OutcomeProjection, OutcomeProjectorConfig, PolicyAction, PolicyContext,

--- a/core-runtime/tests/browser_recovery.rs
+++ b/core-runtime/tests/browser_recovery.rs
@@ -1,0 +1,65 @@
+//! Integration tests for Chrome crash/disconnect recovery (ISSUE-149).
+//!
+//! These tests kill the underlying Chrome process to simulate a crash, then
+//! verify that `is_browser_disconnected` detects the resulting CDP error and
+//! that `BrowserClient::relaunch` recovers with a fresh process and page.
+use anyhow::Context;
+use core_runtime::audit::AuditLogger;
+use core_runtime::{is_browser_disconnected, BrowserClient};
+use std::time::Duration;
+
+#[test]
+fn relaunch_recovers_session_after_chrome_process_is_killed() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let mut client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.navigate("https://example.com")?;
+
+    let pid_before = client
+        .process_id()
+        .expect("launched BrowserClient should have a process id");
+
+    std::process::Command::new("kill")
+        .arg("-9")
+        .arg(pid_before.to_string())
+        .status()
+        .context("failed to signal the Chrome process")?;
+
+    // The CDP transport's background thread needs a moment to notice the
+    // closed websocket. Bounded retry: 10 attempts / 200ms apart / 2s total.
+    let mut disconnect_err = None;
+    for _ in 0..10 {
+        match page.get_document_node() {
+            Ok(_) => std::thread::sleep(Duration::from_millis(200)),
+            Err(err) => {
+                if is_browser_disconnected(&err) {
+                    disconnect_err = Some(err);
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+    }
+    let disconnect_err =
+        disconnect_err.expect("expected a disconnect error after killing the Chrome process");
+    assert!(is_browser_disconnected(&disconnect_err));
+
+    let new_page = client.relaunch(AuditLogger::new(), "chrome process killed in test", 1)?;
+
+    let pid_after = client
+        .process_id()
+        .expect("relaunched BrowserClient should have a process id");
+    assert_ne!(
+        pid_before, pid_after,
+        "relaunch should start a new Chrome process"
+    );
+
+    new_page.navigate("https://example.com")?;
+    let title = new_page.get_title()?;
+    assert!(!title.is_empty(), "relaunched page should be usable");
+
+    Ok(())
+}

--- a/core-runtime/tests/browser_recovery.rs
+++ b/core-runtime/tests/browser_recovery.rs
@@ -8,6 +8,8 @@ use core_runtime::audit::AuditLogger;
 use core_runtime::{is_browser_disconnected, BrowserClient};
 use std::time::Duration;
 
+// Uses the Unix `kill` command to simulate a Chrome crash; not supported on Windows.
+#[cfg(unix)]
 #[test]
 fn relaunch_recovers_session_after_chrome_process_is_killed() -> anyhow::Result<()> {
     if test_bench_support::should_skip_browser_tests() {

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -171,6 +171,27 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 - Exit Criteria
   - [x] `config.toml` で `chrome_path` / `prompt_injection.mode` / `policy.file` / `audit.*` がユーザー設定可能になり、`--doctor` がその内容を検証する。
 
+### PR-30: Chrome Crash/Disconnect Recovery in Long-Running MCP Sessions
+- Status: `DONE`
+- Spec Ref: ISSUE-149
+- Dependencies: PR-21
+- 実装タスク
+  - [x] `SessionError::{BrowserRestarted, BrowserRestartFailed}`（`core-runtime/src/error.rs`）と `AuditEvent::BrowserRestart`（`audit.rs`）を追加。
+  - [x] `is_browser_disconnected`（`headless_chrome::browser::ConnectionClosed` の型判定 + IOマーカーのフォールバック）と `BrowserClient::{process_id, relaunch}` を実装。
+  - [x] `mcp-server`: `McpServer::call_tool` が disconnect を検出した呼び出しを `CoreRuntimeBackend::handle_browser_disconnect` にディスパッチし、`SessionError::BrowserRestarted`/`BrowserRestartFailed` を `-32000` で返却。
+  - [x] 60秒に3回までのレート制限（`RESTART_RATE_LIMIT_MAX`/`RESTART_RATE_LIMIT_WINDOW`）で再起動ストームを防止。
+  - [x] `get_usage_report` に `browser_restarts` フィールドを追加。
+  - [x] `main.rs` を `CoreRuntimeBackend::new_with_client` / `set_policy_rules` に更新し、再起動後のページにポリシーを再適用。
+- テストタスク
+  - [x] `error.rs` / `browser.rs` の単体テスト6件（メッセージ・disconnect判定・relaunch構成）。
+  - [x] `mcp-server/src/lib.rs` の単体テスト5件（call_tool の disconnect 介入・レート制限対象外・usage report）。
+  - [x] 統合テスト: Chrome プロセスを kill して `process_id()` の変化・`relaunch` 後のページ動作・`call_tool` のリカバリ・レート制限到達を検証（`core-runtime/tests/browser_recovery.rs`, `mcp-server/tests/mcp_browser_recovery.rs`、`should_skip_browser_tests` でガード）。
+- Exit Criteria
+  - [x] Dead/disconnected な Chrome プロセスをページレベルエラーと区別して検出できる（型付きエラー）。
+  - [x] 検出時に自動再起動 + 新規ページを試行し、進行中の呼び出しに対してナビゲーション状態・Cookie・承認状態がリセットされたことを伝える構造化 JSON-RPC エラーを返す。
+  - [x] `get_usage_report` に再起動回数を表すフィールドを追加する。
+  - [x] 統合テスト: 実行中セッションで Chrome プロセスを kill し、直後の `get_state` が回復することを確認する（既存の browser-test skip helper でガード）。
+
 ### PR-00: Test Strategy & CI Foundation
 - Status: `DONE` (Local)
 - Spec Ref: Section 6（NFR 全体の測定可能性）

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -4,9 +4,9 @@ pub mod doctor;
 use anyhow::{Context, Result};
 use core_runtime::{
     sre::{LoadProfile, SemanticNode},
-    ActionError, ApprovalScope, DeltaPolicy, PageSession, PromptInjectionMode,
-    PromptInjectionSanitizer, PromptInjectionSanitizerConfig, SemanticState, SemanticTarget,
-    SemanticWaitState, StateUpdate, VerifyError,
+    ActionError, ApprovalScope, BrowserClient, DeltaPolicy, PageSession, PolicyRule,
+    PromptInjectionMode, PromptInjectionSanitizer, PromptInjectionSanitizerConfig, SemanticState,
+    SemanticTarget, SemanticWaitState, SessionError, StateUpdate, VerifyError,
 };
 use plugin_host::{ExtractionRule, SchemaRegistry};
 use serde::{Deserialize, Serialize};
@@ -17,8 +17,8 @@ use skills_engine::{
     SkillEngine, SkillRunStatus, SkillRuntime, VerifyStep, WaitStep,
 };
 use std::{
-    collections::{BTreeMap, HashMap},
-    time::Duration,
+    collections::{BTreeMap, HashMap, VecDeque},
+    time::{Duration, Instant},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -70,6 +70,9 @@ pub struct UsageReport {
     pub hitl_events: u64,
     pub audit_retention: AuditRetentionSnapshot,
     pub cost_microusd: UsageCostBreakdown,
+    /// Number of times the underlying Chrome process was automatically
+    /// restarted after a crash/disconnect (ISSUE-149).
+    pub browser_restarts: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -99,6 +102,7 @@ impl UsageMeters {
         &self,
         plan_tier: PlanTier,
         audit_retention: AuditRetentionSnapshot,
+        browser_restarts: u64,
     ) -> UsageReport {
         let cost_microusd = estimate_usage_cost(
             plan_tier,
@@ -117,6 +121,7 @@ impl UsageMeters {
             hitl_events: self.hitl_events,
             audit_retention,
             cost_microusd,
+            browser_restarts,
         }
     }
 }
@@ -275,6 +280,22 @@ pub trait McpBackend {
     fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
         SkillUsageDelta::default()
     }
+
+    /// Called when [`McpServer::call_tool`] detects that the underlying Chrome
+    /// process disconnected (ISSUE-149). On success, returns the updated
+    /// restart count; on failure, returns a human-readable reason.
+    ///
+    /// The default implementation reports that restart is not supported,
+    /// preserving backward compatibility for backends without a managed
+    /// browser process.
+    fn handle_browser_disconnect(&mut self) -> std::result::Result<u64, String> {
+        Err("browser restart not supported".to_string())
+    }
+
+    /// Total number of automatic browser restarts performed so far.
+    fn browser_restart_count(&self) -> u64 {
+        0
+    }
 }
 
 pub struct McpServer<B> {
@@ -359,6 +380,18 @@ impl<B: McpBackend> McpServer<B> {
             "run_skill" => self.backend.run_skill(arguments.clone()),
             "extract" => self.backend.extract(arguments.clone()),
             _ => anyhow::bail!("unknown MCP tool: {name}"),
+        };
+
+        let result = match result {
+            Err(err) if core_runtime::is_browser_disconnected(&err) => {
+                match self.backend.handle_browser_disconnect() {
+                    Ok(restart_count) => {
+                        Err(SessionError::BrowserRestarted { restart_count }.into())
+                    }
+                    Err(reason) => Err(SessionError::BrowserRestartFailed { reason }.into()),
+                }
+            }
+            other => other,
         };
 
         if let Ok(payload) = &result {
@@ -474,6 +507,7 @@ impl<B: McpBackend> McpServer<B> {
         let report = self.usage_meters.to_report(
             self.plan_tier,
             self.backend.audit_retention_snapshot().unwrap_or_default(),
+            self.backend.browser_restart_count(),
         );
         serde_json::to_value(report).context("failed to serialize usage report")
     }
@@ -814,6 +848,14 @@ pub struct ExternalInteractiveElement {
     pub security_flags: Vec<String>,
 }
 
+/// Maximum number of automatic browser restarts allowed within
+/// [`RESTART_RATE_LIMIT_WINDOW`] before [`CoreRuntimeBackend::handle_browser_disconnect`]
+/// gives up and reports a persistent failure (ISSUE-149 restart-storm guard).
+const RESTART_RATE_LIMIT_MAX: usize = 3;
+
+/// Sliding window over which [`RESTART_RATE_LIMIT_MAX`] restarts are counted.
+const RESTART_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
 pub struct CoreRuntimeBackend {
     page: PageSession,
     state_cache: Option<ExternalSemanticState>,
@@ -824,6 +866,16 @@ pub struct CoreRuntimeBackend {
     schema_registry: SchemaRegistry,
     /// Prompt-injection sanitizer applied before any SemanticState is exposed to the LLM.
     injection_sanitizer: PromptInjectionSanitizer,
+    /// Managed Chrome process, used to relaunch on disconnect (ISSUE-149).
+    /// `None` for backends constructed via [`CoreRuntimeBackend::new`] (e.g. tests),
+    /// which cannot recover from a browser disconnect.
+    client: Option<BrowserClient>,
+    /// Policy rules to reapply to the page created by a browser restart.
+    policy_rules: Vec<PolicyRule>,
+    /// Total number of successful automatic browser restarts.
+    browser_restarts: u64,
+    /// Timestamps of recent restart attempts, used for rate limiting.
+    restart_history: VecDeque<Instant>,
 }
 
 impl CoreRuntimeBackend {
@@ -839,6 +891,20 @@ impl CoreRuntimeBackend {
             injection_sanitizer: PromptInjectionSanitizer::new(PromptInjectionSanitizerConfig {
                 mode: PromptInjectionMode::ReportOnly,
             }),
+            client: None,
+            policy_rules: Vec::new(),
+            browser_restarts: 0,
+            restart_history: VecDeque::new(),
+        }
+    }
+
+    /// Like [`new`](Self::new), but retains the managed [`BrowserClient`] so that
+    /// the session can be automatically relaunched after a Chrome crash or
+    /// disconnect (ISSUE-149).
+    pub fn new_with_client(client: BrowserClient, page: PageSession) -> Self {
+        Self {
+            client: Some(client),
+            ..Self::new(page)
         }
     }
 
@@ -847,6 +913,14 @@ impl CoreRuntimeBackend {
     pub fn set_injection_mode(&mut self, mode: PromptInjectionMode) {
         self.injection_sanitizer =
             PromptInjectionSanitizer::new(PromptInjectionSanitizerConfig { mode });
+    }
+
+    /// Applies `rules` to the current page session and stores them so they can be
+    /// reapplied to the page created by a future browser restart (ISSUE-149).
+    pub fn set_policy_rules(&mut self, rules: Vec<PolicyRule>) -> Result<()> {
+        self.page.set_policy_rules(rules.clone())?;
+        self.policy_rules = rules;
+        Ok(())
     }
 
     pub fn register_extraction_rule(&mut self, name: &str, value: &Value) -> Result<()> {
@@ -1267,6 +1341,51 @@ impl McpBackend for CoreRuntimeBackend {
 
     fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
         std::mem::take(&mut self.last_skill_delta)
+    }
+
+    fn handle_browser_disconnect(&mut self) -> std::result::Result<u64, String> {
+        let Some(client) = self.client.as_mut() else {
+            return Err("browser restart unavailable: no managed BrowserClient".to_string());
+        };
+
+        let now = Instant::now();
+        while let Some(oldest) = self.restart_history.front() {
+            if now.duration_since(*oldest) > RESTART_RATE_LIMIT_WINDOW {
+                self.restart_history.pop_front();
+            } else {
+                break;
+            }
+        }
+        if self.restart_history.len() >= RESTART_RATE_LIMIT_MAX {
+            return Err(format!(
+                "browser restart rate limit exceeded ({RESTART_RATE_LIMIT_MAX} restarts within \
+                 {}s); the Chrome process may be crash-looping",
+                RESTART_RATE_LIMIT_WINDOW.as_secs()
+            ));
+        }
+
+        let audit_logger = self.page.audit_logger_handle();
+        let restart_count = self.browser_restarts + 1;
+        let new_page = client
+            .relaunch(audit_logger, "chrome process disconnected", restart_count)
+            .map_err(|err| format!("relaunch failed: {err}"))?;
+
+        if !self.policy_rules.is_empty() {
+            new_page
+                .set_policy_rules(self.policy_rules.clone())
+                .map_err(|err| format!("failed to reapply policy rules after restart: {err}"))?;
+        }
+
+        self.page = new_page;
+        self.state_cache = None;
+        self.previous_semantic_state = None;
+        self.restart_history.push_back(now);
+        self.browser_restarts = restart_count;
+        Ok(self.browser_restarts)
+    }
+
+    fn browser_restart_count(&self) -> u64 {
+        self.browser_restarts
     }
 }
 
@@ -2103,6 +2222,157 @@ mod tests {
         // oneOf ensures exactly one of rule_name or inline is required
         assert!(schema["oneOf"].is_array());
         assert_eq!(schema["oneOf"].as_array().unwrap().len(), 2);
+    }
+
+    // --- browser disconnect/restart interception (ISSUE-149) ---
+
+    /// Backend whose `get_state` simulates a Chrome disconnect on the first
+    /// call (a `ConnectionClosed`-shaped error), and whose
+    /// `handle_browser_disconnect` returns a configurable outcome.
+    struct RestartMockBackend {
+        fail_get_state_with_disconnect: bool,
+        disconnect_outcome: std::result::Result<u64, String>,
+        browser_restarts: u64,
+    }
+
+    impl McpBackend for RestartMockBackend {
+        fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
+            if self.fail_get_state_with_disconnect {
+                self.fail_get_state_with_disconnect = false;
+                return Err(anyhow::anyhow!("connection is closed"));
+            }
+            Ok(json!({}))
+        }
+        fn act(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+        fn verify(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+        fn get_visual(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+        fn ask_human(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+        fn run_skill(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+        fn extract(&mut self, _: Value) -> anyhow::Result<Value> {
+            Ok(json!({}))
+        }
+
+        fn handle_browser_disconnect(&mut self) -> std::result::Result<u64, String> {
+            match &self.disconnect_outcome {
+                Ok(count) => {
+                    self.browser_restarts = *count;
+                    Ok(*count)
+                }
+                Err(reason) => Err(reason.clone()),
+            }
+        }
+
+        fn browser_restart_count(&self) -> u64 {
+            self.browser_restarts
+        }
+    }
+
+    #[test]
+    fn call_tool_intercepts_disconnect_and_reports_restart() {
+        let mut server = McpServer::new(RestartMockBackend {
+            fail_get_state_with_disconnect: true,
+            disconnect_outcome: Ok(1),
+            browser_restarts: 0,
+        });
+
+        let err = server
+            .call_tool("get_state", json!({}))
+            .expect_err("disconnect should surface as an error");
+        let message = err.to_string();
+        assert!(message.contains("restart #1"), "message: {message}");
+        assert!(
+            message.contains("automatically restarted"),
+            "message: {message}"
+        );
+    }
+
+    #[test]
+    fn call_tool_reports_restart_failure_when_relaunch_fails() {
+        let mut server = McpServer::new(RestartMockBackend {
+            fail_get_state_with_disconnect: true,
+            disconnect_outcome: Err("relaunch failed: Failed to launch browser".to_string()),
+            browser_restarts: 0,
+        });
+
+        let err = server
+            .call_tool("get_state", json!({}))
+            .expect_err("relaunch failure should surface as an error");
+        let message = err.to_string();
+        assert!(
+            message.contains("automatic restart failed"),
+            "message: {message}"
+        );
+        assert!(message.contains("relaunch failed"), "message: {message}");
+    }
+
+    #[test]
+    fn call_tool_does_not_intercept_page_level_errors() {
+        struct PageErrorBackend;
+        impl McpBackend for PageErrorBackend {
+            fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
+                Err(anyhow::anyhow!("Could not find node with given id"))
+            }
+            fn act(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+            fn verify(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+            fn get_visual(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+            fn ask_human(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+            fn run_skill(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+            fn extract(&mut self, _: Value) -> anyhow::Result<Value> {
+                Ok(json!({}))
+            }
+        }
+
+        let mut server = McpServer::new(PageErrorBackend);
+        let err = server
+            .call_tool("get_state", json!({}))
+            .expect_err("page-level error should propagate");
+        assert_eq!(err.to_string(), "Could not find node with given id");
+    }
+
+    #[test]
+    fn get_usage_report_includes_browser_restarts() {
+        let mut server = McpServer::new(RestartMockBackend {
+            fail_get_state_with_disconnect: false,
+            disconnect_outcome: Ok(0),
+            browser_restarts: 2,
+        });
+
+        let payload = server
+            .call_tool("get_usage_report", json!({}))
+            .expect("usage report should succeed");
+        assert_eq!(payload["browser_restarts"], 2);
+    }
+
+    #[test]
+    fn default_handle_browser_disconnect_reports_unsupported() {
+        let mut backend = MockBackend {
+            extract_result: None,
+        };
+        assert_eq!(
+            backend.handle_browser_disconnect(),
+            Err("browser restart not supported".to_string())
+        );
+        assert_eq!(backend.browser_restart_count(), 0);
     }
 
     #[test]

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -902,8 +902,12 @@ impl CoreRuntimeBackend {
     /// the session can be automatically relaunched after a Chrome crash or
     /// disconnect (ISSUE-149).
     pub fn new_with_client(client: BrowserClient, page: PageSession) -> Self {
+        // Capture any policy rules already configured on `page` so they
+        // survive a future browser restart (ISSUE-149 review feedback).
+        let policy_rules = page.policy_rules().unwrap_or_default();
         Self {
             client: Some(client),
+            policy_rules,
             ..Self::new(page)
         }
     }
@@ -1364,6 +1368,11 @@ impl McpBackend for CoreRuntimeBackend {
             ));
         }
 
+        // Record this attempt before the fallible relaunch so that repeated
+        // failures (e.g. a crash-looping Chrome that can't relaunch) are
+        // still counted against the rate limit, not just successes.
+        self.restart_history.push_back(now);
+
         let audit_logger = self.page.audit_logger_handle();
         let restart_count = self.browser_restarts + 1;
         let new_page = client
@@ -1379,7 +1388,6 @@ impl McpBackend for CoreRuntimeBackend {
         self.page = new_page;
         self.state_cache = None;
         self.previous_semantic_state = None;
-        self.restart_history.push_back(now);
         self.browser_restarts = restart_count;
         Ok(self.browser_restarts)
     }

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -77,13 +77,14 @@ fn main() -> anyhow::Result<()> {
     let client = BrowserClient::new_with_chrome_path(resolved.chrome_path.clone())?;
     let page = client.new_page_with_audit_logger(audit_logger)?;
 
+    let mut backend = CoreRuntimeBackend::new_with_client(client, page);
+
     if let Some(policy_path) = &resolved.policy_file {
         let engine = PolicyEngine::try_from_file(policy_path)
             .with_context(|| format!("failed to load policy file {}", policy_path.display()))?;
-        page.set_policy_rules(engine.rules().to_vec())?;
+        backend.set_policy_rules(engine.rules().to_vec())?;
     }
 
-    let mut backend = CoreRuntimeBackend::new(page);
     backend.set_injection_mode(resolved.injection_mode);
     let mut server = McpServer::new(backend);
     eprintln!("dragon-head-mcp: ready, listening on stdio");

--- a/mcp-server/tests/mcp_browser_recovery.rs
+++ b/mcp-server/tests/mcp_browser_recovery.rs
@@ -1,0 +1,110 @@
+//! Integration tests for Chrome crash/disconnect recovery (ISSUE-149).
+use anyhow::Context;
+use core_runtime::BrowserClient;
+use mcp_server::{CoreRuntimeBackend, McpBackend, McpServer};
+use serde_json::json;
+use std::time::Duration;
+
+#[test]
+fn call_tool_recovers_from_chrome_crash_and_relaunches() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.navigate("https://example.com")?;
+
+    let pid_before = client
+        .process_id()
+        .expect("launched BrowserClient should have a process id");
+
+    let mut server = McpServer::new(CoreRuntimeBackend::new_with_client(client, page));
+
+    std::process::Command::new("kill")
+        .arg("-9")
+        .arg(pid_before.to_string())
+        .status()
+        .context("failed to signal the Chrome process")?;
+
+    // Bounded retry: 10 attempts / 200ms apart / 2s total, matching
+    // core-runtime/tests/browser_recovery.rs, until the CDP transport
+    // observes the disconnect and call_tool relaunches the session.
+    let mut restarted_message = None;
+    for _ in 0..10 {
+        match server.call_tool("get_state", json!({})) {
+            Ok(_) => std::thread::sleep(Duration::from_millis(200)),
+            Err(err) => {
+                let message = err.to_string();
+                if message.contains("automatically restarted") {
+                    restarted_message = Some(message);
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+    }
+    let restarted_message =
+        restarted_message.expect("expected call_tool to report an automatic restart");
+    assert!(restarted_message.contains("restart #1"));
+
+    // The session should now be usable again on a freshly relaunched Chrome.
+    let state = server
+        .call_tool("get_state", json!({}))
+        .expect("get_state should succeed after relaunch");
+    assert!(state.is_object());
+
+    let usage = server
+        .call_tool("get_usage_report", json!({}))
+        .expect("get_usage_report should succeed");
+    assert_eq!(usage["browser_restarts"], 1);
+
+    Ok(())
+}
+
+#[test]
+fn handle_browser_disconnect_without_managed_client_reports_unsupported() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let mut backend = CoreRuntimeBackend::new(page);
+    let err = backend
+        .handle_browser_disconnect()
+        .expect_err("backend without a managed BrowserClient cannot restart");
+    assert!(err.contains("no managed BrowserClient"), "error: {err}");
+    assert_eq!(backend.browser_restart_count(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn handle_browser_disconnect_rate_limits_after_max_restarts() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+
+    let mut backend = CoreRuntimeBackend::new_with_client(client, page);
+
+    for expected_count in 1..=3 {
+        let restart_count = backend
+            .handle_browser_disconnect()
+            .expect("restart should succeed within the rate limit");
+        assert_eq!(restart_count, expected_count);
+    }
+
+    let err = backend
+        .handle_browser_disconnect()
+        .expect_err("a 4th restart within the window should be rate limited");
+    assert!(err.contains("rate limit"), "error: {err}");
+    assert!(err.contains("crash-looping"), "error: {err}");
+    assert_eq!(backend.browser_restart_count(), 3);
+
+    Ok(())
+}

--- a/mcp-server/tests/mcp_browser_recovery.rs
+++ b/mcp-server/tests/mcp_browser_recovery.rs
@@ -5,6 +5,8 @@ use mcp_server::{CoreRuntimeBackend, McpBackend, McpServer};
 use serde_json::json;
 use std::time::Duration;
 
+// Uses the Unix `kill` command to simulate a Chrome crash; not supported on Windows.
+#[cfg(unix)]
 #[test]
 fn call_tool_recovers_from_chrome_crash_and_relaunches() -> anyhow::Result<()> {
     if test_bench_support::should_skip_browser_tests() {


### PR DESCRIPTION
## Summary

- Adds typed Chrome-disconnect detection (`is_browser_disconnected`), distinguishing crashed/killed/CDP-dropped processes from ordinary page-level errors (`Could not find node with given id`, etc.).
- `BrowserClient::relaunch` rebuilds and replaces the underlying Chrome process, returning a fresh `PageSession` (resetting `stable_key_index`, `dom_signature_cache`, policy engine, navigation epoch) while preserving the shared `SessionVault` and plugin hooks.
- `McpServer::call_tool` intercepts disconnect errors on any tool call, triggers `CoreRuntimeBackend::handle_browser_disconnect`, and surfaces `SessionError::BrowserRestarted { restart_count }` (or `BrowserRestartFailed { reason }`) as a `-32000` JSON-RPC error — explicitly telling the agent that navigation state, cookies, and pending/granted HITL approvals were reset.
- Restart-storm guard: max 3 automatic restarts per 60s sliding window; beyond that, `handle_browser_disconnect` reports a "crash-looping" failure instead of restarting indefinitely.
- `get_usage_report` gains a `browser_restarts` counter.
- `AuditEvent::BrowserRestart` records each restart (reason, count, timestamp) in the audit trail via the *new* page's logger handle, preserving continuity.
- `main.rs` now uses `CoreRuntimeBackend::new_with_client` + `set_policy_rules` so the managed `BrowserClient` and policy rules survive a restart.

## Test plan

- [x] `cargo test -p core-runtime --lib` — new `SessionError` / `is_browser_disconnected` / relaunch unit tests pass.
- [x] `cargo test -p mcp-server --lib` — new `call_tool` disconnect-interception, restart-failure, and usage-report unit tests pass (71 tests).
- [x] `CHROME_INSTALLED=true cargo test -p core-runtime --test browser_recovery` — kills the live Chrome process, confirms `is_browser_disconnected` fires, `relaunch` produces a new PID and a working page.
- [x] `CHROME_INSTALLED=true cargo test -p mcp-server --test mcp_browser_recovery` — kills Chrome under a live `McpServer`/`CoreRuntimeBackend`, confirms `call_tool` reports `restart #1` then recovers, `get_usage_report.browser_restarts == 1`; verifies the `client: None` backward-compat path and the 3-restarts/60s rate limit.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo nextest run --workspace` — 630/630 passed.
- [x] `docs/PLAN.md` updated with PR-30 entry mirroring ISSUE-149's 4 exit criteria, all checked.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)