### PR TITLE
docs: refresh README and add AI agent onboarding doc set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dragon Head: Neural-Browser Runtime
 
-**Last updated:** 2026-05-10
+**Last updated:** 2026-06-24
 
 Dragon Head is an AI-native headless browser runtime for LLM and VLM agents.
 It exposes a browser session as a compact, structured **Semantic State** and
@@ -340,14 +340,20 @@ For the full specification see [docs/SPEC.md — SEC-03](docs/SPEC.md).
 Dragon Head is organized as a Rust workspace:
 
 - `core-runtime`: Chrome/CDP browser session, semantic state capture, action
-  execution, policy, audit, privacy, visual capture, and session vault.
+  execution, policy, audit, privacy, visual capture, speculative state
+  generation, and session vault.
 - `mcp-server`: stdio MCP server and tool contract.
 - `skills-engine`: declarative workflow execution.
 - `plugin-host`: Wasm plugin validation and runtime execution.
 - `marketplace`: plugin/domain-pack marketplace primitives.
+- `hitl-bridge`: Slack/Teams human-in-the-loop reference bridge for `ask_human`.
+- `bench`: NFR/ROI benchmarking harness and dashboard report generation.
+- `test-bench-support`: shared test helpers used across crate test suites.
 
 ## Secondary Distribution Paths
 
+- **GitHub Releases**: prebuilt binaries for macOS, Linux, and Windows are
+  published automatically (see [Install](#install) above).
 - **Homebrew**: A `takurot/tap` formula is planned.
 - **Docker**: A multi-platform image for CI and Linux evaluation is planned.
 - **cargo install**: Available once workspace crate publishing is ready.
@@ -360,12 +366,13 @@ Near-term:
 - Docker multi-platform image.
 - `cargo install` / crates.io publishing.
 
-Product roadmap:
+Already shipped:
 
 - Deep Lens zero-code extraction DSL.
 - Guardian Angel outcome projection for proactive policy decisions.
-- Speculative state generation for near-zero TTFT targets.
-- Slack/Teams HITL reference integration.
+- Speculative state generation for near-zero TTFT targets (wired into
+  `get_state`, with hit/miss metrics in `get_usage_report`).
+- Slack/Teams HITL reference integration (`hitl-bridge`).
 - Shared Wasm engine and module caching.
 
 ---

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -1,0 +1,130 @@
+# AI_CONTEXT.md
+
+> Read this file first. It is a map, not a manual — use it to decide which other
+> file to open next, instead of exploring the whole repo.
+
+## What this project is
+
+Dragon Head is an AI-native **headless browser runtime** for LLM/VLM agents. It
+wraps a Chrome/CDP session and exposes it to an agent as a compact, structured
+**Semantic State** (an accessibility-tree-like JSON, not raw HTML/DOM) via a
+stdio **MCP server** binary, `dragon-head-mcp`. The agent inspects pages, acts
+on elements, verifies outcomes, requests human approval, and runs declarative
+skills — all through 7 MCP tools.
+
+## Primary users
+
+- AI coding/browsing agents (Claude, GPT, etc.) connected via an MCP client
+  (Claude Desktop, Claude Code, Codex, or any MCP-compatible client).
+- Developers embedding `core-runtime` directly as a Rust library (no MCP).
+
+## Primary use cases
+
+- Web automation/testing driven by an LLM (navigate, click, fill forms, verify
+  text) without feeding raw HTML/screenshots into the model.
+- Human-in-the-loop (HITL) gated actions (e.g. financial transactions) via
+  policy rules + Slack/Teams approval (`hitl-bridge`).
+- Declarative, reusable browser workflows ("skills") instead of ad-hoc agent
+  exploration on every run.
+
+## Tech stack
+
+- **Language**: Rust (stable, see `rust-toolchain.toml`), workspace of 8 crates.
+- **Browser control**: `headless_chrome` (CDP), Chrome/Chromium required at
+  runtime (not vendored).
+- **Protocol**: MCP (JSON-RPC over stdio).
+- **Plugins**: WebAssembly via `wasmtime` (`plugin-host`).
+- **Testing**: `cargo nextest`, integration tests under `tests/` per crate.
+- **CI**: GitHub Actions (`.github/workflows/ci.yml`, `e2e.yml`, `release.yml`).
+
+## Key commands
+
+```bash
+just check              # cargo check --workspace
+just test               # cargo nextest run --workspace
+just test-ci             # nextest --profile ci (what CI runs)
+just lint                # cargo clippy --workspace -- -D warnings
+just fmt                 # cargo fmt --all
+just test-all            # test + lint + fmt
+cargo run -p mcp-server --bin dragon-head-mcp -- --doctor
+```
+See `DEVELOPMENT_GUIDE.md` for the full list.
+
+## Key directories
+
+| Path | What it is |
+|---|---|
+| `core-runtime/` | Chrome/CDP session, Semantic State, policy, audit, privacy, plugins, speculative state |
+| `mcp-server/` | The `dragon-head-mcp` stdio binary and tool dispatch — **start here for tool behavior** |
+| `skills-engine/` | Declarative skill (workflow) definitions and execution |
+| `plugin-host/` | Wasm plugin manifest validation + sandboxed execution |
+| `marketplace/` | Plugin/domain-pack metadata and revenue-share primitives |
+| `hitl-bridge/` | Slack/Teams human-approval bridge for `ask_human` |
+| `bench/`, `nfr-baseline/` | Performance benchmarking and regression baselines |
+| `docs/` | Spec, plan, and this onboarding doc set |
+| `examples/` | Runnable, Chrome-free examples (`cargo run --example quickstart`) |
+
+## Files to read before changing anything
+
+1. `AI_CONTEXT.md` (this file)
+2. `ARCHITECTURE.md` — component responsibilities and data flow
+3. `FILE_GUIDE.md` — where to find/change a specific thing
+4. `CLAUDE.md` (project root) — authoritative crate table + commands, kept up
+   to date by convention
+5. `docs/SPEC.md` — functional spec, referenced by code comments (e.g. `SEC-03`)
+6. `docs/PLAN.md` — PR-by-PR status; check before assuming a feature is "not
+   built yet"
+
+## Design principles to respect
+
+- **`SemanticState` is the contract.** Agents never see raw DOM/HTML. Any
+  change to `sre/` must keep `stable_key` identity stable across re-renders
+  (tests: `core-runtime/tests/stable_key_*`, `sre_determinism.rs`).
+- **Audit before execution, policy before mutation.** In `act`, the audit log
+  entry is written *before* policy enforcement, and policy enforcement runs
+  *before* any CDP mutation. Don't reorder this (see `core-runtime/src/browser.rs`
+  around `enforce_policy`).
+- **Capture state before propagating errors.** Don't let `?` silently drop
+  accumulated metering/audit/speculative state — see CLAUDE.md §12.
+- **No `std::env::set_var`/`remove_var` in tests** — inject env values as
+  function parameters instead (CLAUDE.md §11).
+- **Immutability by default** — return new values, don't mutate in place
+  (workspace-wide Rust convention).
+
+## Frequently changed areas
+
+- `mcp-server/src/lib.rs` — tool dispatch, usage metering, speculative wiring
+  (this file is large; expect most "new tool behavior" work to land here).
+- `core-runtime/src/sre/` — semantic capture/normalization tuning.
+- `core-runtime/src/policy.rs` — new policy rule shapes / Guardian Angel
+  thresholds.
+- `docs/PLAN.md` — updated every PR to track phase status.
+
+## High blast-radius areas (change with care, check tests first)
+
+- `core-runtime/src/sre/stable_key.rs` — identity hashing; a change here
+  silently breaks every agent's ability to re-target elements across page
+  re-renders.
+- `core-runtime/src/browser.rs` — `enforce_policy`/audit ordering in `act()`
+  and crash/disconnect recovery (`relaunch`, `is_browser_disconnected`).
+- `core-runtime/src/speculative/` — feeds `get_state`'s fast path; a bug here
+  causes agents to silently see stale state (`StateDelta::Mismatch` is the
+  safety net — don't remove it).
+- `core-runtime/src/prompt_injection.rs` — security-relevant; changes affect
+  `security_flags` and `Redact` mode page-text mutation.
+- `.config/nextest.toml` — CI's `[profile.ci]` does **not** inherit from
+  `[profile.default]`; every field must be repeated (CLAUDE.md §7).
+- `nfr-baseline/*.json` — only update via `scripts/update_nfr_baseline.sh`,
+  never hand-edit.
+
+## Checklist before starting work
+
+- [ ] Read `AI_CONTEXT.md`, `ARCHITECTURE.md`, and the relevant section of
+      `FILE_GUIDE.md` for the area you're touching.
+- [ ] Check `docs/PLAN.md` for existing status/PR history on this feature.
+- [ ] Identify the exact test files that exercise this code path
+      (`FILE_GUIDE.md` lists test directories per crate).
+- [ ] If touching `sre/`, `policy.rs`, or `browser.rs`'s `act`/`enforce_policy`
+      path, re-read the relevant "High blast-radius" note above.
+- [ ] Run `just check` and the targeted test file locally before considering
+      the change done; run `just test-all` before a PR.

--- a/docs/AI_TASK_GUIDE.md
+++ b/docs/AI_TASK_GUIDE.md
@@ -1,0 +1,116 @@
+# AI_TASK_GUIDE.md
+
+AIコーディングエージェントがこのリポジトリで作業する際のガイド。トークン
+消費を抑えるため、まず最小限のファイルセットだけを読み、タスク種別ごとに
+必要な範囲だけ追加で探索すること。
+
+## 最初に読むファイル(最小セット)
+
+1. `docs/AI_CONTEXT.md` — リポジトリの地図
+2. `docs/ARCHITECTURE.md` — コンポーネント責務とデータフロー
+3. `docs/FILE_GUIDE.md` — 「この機能を変えるならこのファイル」の対応表
+4. `CLAUDE.md`(リポジトリルート) — 正本のクレート表とコマンド一覧、
+   Rust固有の落とし穴(§1〜§14)
+5. 対象機能に関係する実装ファイル(`FILE_GUIDE.md` の「機能別に見るべき
+   場所」で特定する)
+6. 対象機能に関係するテストファイル(同上)
+
+`docs/SPEC.md` と `docs/PLAN.md` は必要になったときだけ参照する
+(全文を毎回読む必要はない — `PLAN.md` はPRステータスの確認に使う)。
+
+## タスク別ガイド
+
+### バグ修正
+1. 再現条件を確認する(可能ならテストで再現させる)。
+2. `FILE_GUIDE.md` で関連する実装ファイルとテストファイルを特定する。
+3. 同じファイル内に「兄弟パス」(同じ出力型を生成する他の関数/分岐)が
+   ないか `grep` で確認する — CLAUDE.md のBugfix Discipline参照。
+4. 最小範囲で修正する。`?` でエラーを伝播する箇所では、計測/監査用の
+   状態がエラー伝播の前にキャプチャされているか確認する(CLAUDE.md §12)。
+5. 修正対象のコードパスを直接アサートする回帰テストを追加する(集約した
+   呼び出し元ではなく、直接の出力に対して)。
+6. `just check` → 対象テスト → `just test-all` で確認。
+
+### 新機能追加
+1. `FILE_GUIDE.md`/`ARCHITECTURE.md` で既存の類似機能(似たツール、似た
+   ポリシー拡張など)を探す。
+2. 既存パターンに合わせる(例: 新しいMCPツールなら既存ツールの定義・
+   ディスパッチ・契約テストの3点セットをコピーして変更)。
+3. 影響範囲を確認する: MCPツール契約(`mcp-server/tests/mcp_*`)、Semantic
+   Stateスキーマ(`core-runtime/tests/sre_*`, `stable_key_*`)、ポリシー
+   スキーマ(`policy_schema_lint.rs`)、スキル/プラグインのスキーマ互換性
+   テスト。
+4. `docs/PLAN.md` に対応するPR/ISSUEがあれば状態を確認・更新する。
+5. テストを追加し、`docs/testing.md` のテストピラミッド方針に従う。
+
+### 設計変更・リファクタリング
+1. `docs/ARCHITECTURE.md` の「Easy to break」セクションを必ず確認する。
+2. 変更前後でテストが通ることを確認する(振る舞いを変えない場合)。
+3. 監査ログ順序(audit→policy→execution)や `stable_key` 生成方式など、
+   暗黙の契約を変えないこと。変える場合はユーザーに明示し、影響範囲
+   (互換性テスト一覧)を提示する。
+
+## テスト追加・更新の方針
+
+- バグ修正のテストは修正対象のコードパスを直接アサートする(集約した
+  呼び出し元経由のテストは弱い — CLAUDE.md「Test the Exact Path」)。
+- ブラウザ依存テストは `test_bench_support::should_skip_browser_tests()`
+  でスキップ可能にする。
+- 環境変数を読むテストでは `std::env::set_var`/`remove_var` を使わない。
+  関数を「envオプション引数を受け取る版」に分離し、テストはその引数に
+  直接値を渡す(CLAUDE.md §11)。
+- カバレッジ目標は80%(ユーザー個人ルール)。CIのカバレッジゲートは70%
+  (`.github/workflows/ci.yml` の `coverage` ジョブ)。
+
+## 既存設計を壊さないための注意
+
+- `core-runtime` は他のワークスペースクレートに依存しない(基盤クレート)。
+  この依存方向を逆転させる変更をしない。
+- `act` 内の「監査ログ→ポリシー評価→実行」の順序を変えない。
+- `SpeculativeEngine` のミスは必ず通常キャプチャにフォールバックする
+  仕組み(`StateDelta::Mismatch`)を維持する — キャッシュヒットを無条件に
+  信頼するコードを書かない。
+- `nfr-baseline/*.json` は直接編集しない(`scripts/update_nfr_baseline.sh`
+  経由)。
+- `.config/nextest.toml` の `[profile.ci]` は `[profile.default]` を
+  継承しないため、両方に必要なフィールドを明示的に複製する。
+
+## やってはいけないこと
+
+- 推測で `config.toml` の新フィールドを追加する(実際に
+  `mcp-server/src/config.rs` の `FileConfig` 構造を確認してから)。
+- `Cargo.lock` を手動編集する。
+- `target/` 配下のファイルを参照・編集する(ビルド出力)。
+- バイナリ/スナップショットフィクスチャ(`*.png`, `golden/*.json` 等)を
+  意図した視覚差分更新以外の理由で変更する。
+- CI/CD設定(`.github/workflows/*.yml`)を、`deny.toml` やnextestプロファイル
+  との整合性を確認せずに変更する。
+- 無関係なコードの整形・リファクタリング(ユーザーの依頼範囲外の変更)。
+
+## 推測で変更してはいけない箇所
+
+- `core-runtime/src/sre/stable_key.rs` のハッシュ/識別ロジック
+  — 既存エージェント統合の要素識別が壊れる。
+- `core-runtime/src/policy.rs` のenum/構造体のシリアライズ形式
+  — `PolicyRule`/`PolicyDecision` のJSONスキーマはツール契約に含まれる。
+- `deny.toml` のRUSTSEC例外リスト — 根拠なく削除/追加しない。
+- 監査イベントのスキーマ(`audit_schema.rs` がテストする形式)。
+
+## 大きな変更をする前に確認すべきこと
+
+- `docs/PLAN.md` で同等の作業が既に計画/完了していないか。
+- 変更対象のクレートに対応する `tests/` ディレクトリの一覧
+  (`FILE_GUIDE.md` 参照)で、影響を受けるテストファイルを把握しているか。
+- MCPツールのスキーマや`SemanticState`の構造を変える場合、
+  `examples/mcp_examples/*.json` や `README.md` の表も更新が必要か。
+- ユーザー個人ルール(`~/.claude/rules/`)の「Surgical Changes」原則
+  ——変更は依頼内容に直接トレースできる範囲に留める。
+
+## トークン削減のため、まず読むべき最小ファイルセット
+
+| タスク種別 | 最小限読むファイル |
+|---|---|
+| バグ修正(範囲が明確) | `AI_CONTEXT.md` + 対象実装ファイル1〜2つ + 対応テスト |
+| 新規MCPツール | `AI_CONTEXT.md` + `ARCHITECTURE.md`(データフロー節) + `mcp-server/src/lib.rs` + 既存ツールの契約テスト1例 |
+| ポリシー/Guardian Angel変更 | `AI_CONTEXT.md` + `DOMAIN_MODEL.md`(該当エンティティ) + `core-runtime/src/policy.rs` + `policy_engine.rs`/`policy_enforcement.rs` |
+| ドキュメント更新のみ | 対象ドキュメントと、その記述が参照する実装ファイルのみ(全文探索しない) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# ARCHITECTURE.md
+
+## Overview
+
+Dragon Head sits between an MCP client (an AI agent) and a real Chrome
+process. The MCP client speaks JSON-RPC over stdio to `dragon-head-mcp`;
+`dragon-head-mcp` drives Chrome over CDP and translates the live DOM into a
+compact **Semantic State** the agent can reason about, instead of raw
+HTML/screenshots.
+
+```mermaid
+flowchart TD
+    Agent["MCP client (AI agent)"] -->|JSON-RPC / stdio| MCP["mcp-server\nMcpServer::handle_jsonrpc"]
+    MCP --> Backend["CoreRuntimeBackend"]
+    Backend --> PageSession["core-runtime::browser::PageSession"]
+    PageSession -->|CDP / websocket| Chrome["Chrome / Chromium process"]
+
+    PageSession --> SRE["sre:: capture + normalize\n(SemanticState, stable_key)"]
+    SRE --> Sanitizer["PromptInjectionSanitizer"]
+    Sanitizer --> Spec["speculative:: SpeculativeEngine\n(pre-staged state cache)"]
+    Spec --> MCP
+
+    PageSession --> Policy["PolicyEngine\n(+ Guardian Angel OutcomeProjection)"]
+    Policy -->|Block / RequireHumanApproval| HITL["hitl-bridge\n(Slack/Teams ask_human)"]
+    PageSession --> Audit["AuditLogger -> AuditSink\n(RollingFileSink / WebhookSink)"]
+    PageSession --> Vault["SessionVault\n(cookies/credentials)"]
+    PageSession --> Plugins["plugin_hooks -> plugin-host\n(Wasm OnState/BeforeAct)"]
+
+    MCP --> Skills["skills-engine::SkillEngine\n(run_skill)"]
+    Skills --> PageSession
+```
+
+## Components and responsibilities
+
+| Component | Responsibility |
+|---|---|
+| `mcp-server` | stdio JSON-RPC server; tool contract (7 tools); config loading; `--doctor`/`--init`; usage metering and plan-tier gating |
+| `core-runtime::browser` | Owns the Chrome process and per-tab `PageSession`; executes actions; crash/disconnect detection and relaunch |
+| `core-runtime::sre` | DOM → `SemanticState`/`SemanticNode` capture and normalization; `stable_key` identity; delta computation |
+| `core-runtime::policy` | `PolicyEngine` — rule-based action gating (Allow/Block/RequireHumanApproval) and Guardian Angel outcome projection |
+| `core-runtime::audit` / `audit_sink` | Structured, PII-redacted action log; `RollingFileSink` (NDJSON) and `WebhookSink` |
+| `core-runtime::privacy` | Regex-based PII detection/redaction applied to audit events |
+| `core-runtime::prompt_injection` | Flags/redacts indirect prompt-injection patterns in `SemanticNode` content |
+| `core-runtime::session_vault` | Encrypted storage/restoration of session cookies/credentials |
+| `core-runtime::speculative` | Predicts the next action and pre-stages the resulting state for near-zero-TTFT `get_state` |
+| `core-runtime::dom_signature` | Fuzzy DOM-signature fallback when `stable_key`/`target_id` lookup misses (self-healing recovery) |
+| `core-runtime::plugin_hooks` | Trait boundary letting `plugin-host` plugins observe state / intercept actions |
+| `skills-engine` | Parses and runs declarative `SkillDefinition` workflows (Locate/Verify/Act/Wait/Extract/Handoff steps) |
+| `plugin-host` | Validates Wasm plugin manifests (signature, SBOM, capabilities) and executes them via `wasmtime` |
+| `marketplace` | Plugin/domain-pack metadata and revenue-share primitives |
+| `hitl-bridge` | Standalone binary: Slack/Teams webhook server resolving pending `ask_human` approvals |
+| `bench` | NFR/ROI benchmarking harness producing markdown dashboards |
+| `test-bench-support` | Shared `should_skip_browser_tests()` helper for Chrome-dependent tests |
+
+## Dependency direction
+
+`mcp-server` depends on `core-runtime`, `skills-engine`, and `plugin-host`.
+`core-runtime` has no dependency on the other workspace crates — it's the
+foundation. `hitl-bridge`, `bench`, and `marketplace` are independent
+binaries/libraries that don't feed back into `core-runtime`. There is no
+cyclic dependency between workspace crates.
+
+## Data flow: `get_state`
+
+1. Return the cached `SemanticState` if present and `force_refresh` isn't set.
+2. `resolve_speculative_state`: ask `SpeculativeEngine` for a pre-staged
+   prediction (`pre_generate`/`predict`).
+3. **Hit** → serve the cached state directly (near-zero TTFT), mark it
+   unverified (`previous_state_verified = false`).
+4. **Miss** → `PageSession::capture_semantic_state(LoadProfile)` → sanitize
+   with `PromptInjectionSanitizer` → feed the observation back into
+   `SpeculativeEngine::observe_state`/`record_transition` → build response.
+5. For delta requests: `current.select_update(previous, DeltaPolicy)` produces
+   `StateUpdate::{Noop, Full, Delta}` (an RFC 6902 JSON Patch for `Delta`).
+
+`PolicyEngine` is **not** consulted on `get_state` — only `act` goes through
+policy.
+
+## Data flow: `act`
+
+1. If an unverified speculative hit is pending, verify it with a real capture
+   before mutating the page.
+2. `AuditEvent::ToolCall` is logged **before** policy enforcement or
+   execution — audit always sees the attempt, even if it's later blocked.
+3. `PolicyEngine::enforce_policy` runs next; it can short-circuit with
+   `ActionError::Blocked`, `HumanApprovalRequired` (escalates to `hitl-bridge`
+   via `ask_human`), or `VerifyRequired`, all before any CDP mutation.
+4. The CDP action executes against the resolved element. If `target_id`
+   lookup fails, it falls back to `stable_key`, then to
+   `dom_signature`'s fuzzy self-healing match — re-running policy enforcement
+   on whatever node is recovered.
+5. On success, the state cache is invalidated and the executed action is
+   recorded for the speculative engine's transition model.
+
+## State management
+
+- **Per-session state** lives inside `PageSession` (policy engine instance,
+  stable-key index, DOM-signature cache, speculative engine, state cache) —
+  not global; each `new_page`/`new_page_with_audit_logger` call creates fresh
+  state, sharing only the `SessionVault` and plugin hooks from the parent
+  `BrowserClient`.
+- **No external database.** All state is in-process or on local disk (audit
+  log files, session vault).
+- **Crash recovery**: `BrowserClient::relaunch` restarts the Chrome process
+  with the same config and rebuilds a `PageSession`; `is_browser_disconnected`
+  detects CDP websocket/IO disconnect errors to trigger this path.
+
+## External services / IO boundaries
+
+| Boundary | Mechanism | File |
+|---|---|---|
+| Chrome/Chromium | CDP over websocket (`headless_chrome` crate) | `core-runtime/src/browser.rs` |
+| Audit log files | NDJSON, rotated by size | `core-runtime/src/audit_sink.rs` (`RollingFileSink`) |
+| Audit webhook | HTTP POST per event | `core-runtime/src/audit_sink.rs` (`WebhookSink`) |
+| Slack/Teams HITL | Inbound HTTP webhook, HMAC-verified | `hitl-bridge/src/server.rs` |
+| Config file | `$XDG_CONFIG_HOME/dragon-head/config.toml` | `mcp-server/src/config.rs` |
+| Session credentials | Local encrypted vault | `core-runtime/src/session_vault.rs` |
+| Wasm plugins | `wasmtime` sandboxed execution | `plugin-host/src/lib.rs` |
+
+## Key design decisions
+
+- **Semantic State, not DOM.** Decouples agent reasoning from page markup
+  churn; `stable_key` (content hash + collision index) gives elements
+  identity across re-renders without relying on fragile DOM paths.
+- **Speculative pre-generation is additive, not load-bearing.** It *fronts*
+  the normal async capture pipeline rather than replacing it — a miss always
+  falls back to a real, correct capture (`StateDelta::Mismatch`).
+- **Policy decisions carry an `OutcomeProjection`** (Guardian Angel) so a
+  human approving an action sees the projected monetary/risk impact, not just
+  "approve this action?".
+- **Audit-before-policy-before-execution** ordering is deliberate: even a
+  blocked action attempt is auditable.
+- **Plugins and skills are declarative/sandboxed**, not arbitrary code in the
+  hot path — `plugin-host` runs Wasm under `wasmtime` with capability gating
+  (`ReadState`/`NetworkOut`/`VaultAccess`); `skills-engine` runs a fixed step
+  vocabulary (Locate/Verify/Act/Wait/Extract/Handoff), not a scripting
+  language.
+
+## Easy to extend
+
+- New policy rule shapes / outcome projectors (`core-runtime/src/policy.rs`)
+  — additive structs with `#[serde(default)]` fields.
+- New skill step types (`skills-engine`) — `SkillStep` is a closed enum but
+  designed to be extended; existing tests (`skill_conformance.rs`,
+  `skill_schema_compatibility.rs`) define the compatibility contract.
+- New audit sinks (`core-runtime/src/audit_sink.rs`) — implement the sink
+  trait alongside `RollingFileSink`/`WebhookSink`.
+- New MCP tools — register in `mcp-server/src/lib.rs`'s tool list + dispatch
+  match; contract tests in `mcp-server/tests/mcp_protocol_compliance.rs` and
+  `mcp_client_contract.rs` will need matching fixtures.
+
+## Easy to break
+
+- `stable_key` generation (`core-runtime/src/sre/stable_key.rs`) — any change
+  changes element identity for every existing agent integration.
+- The audit-before-policy-before-execution ordering in `browser.rs::act` — a
+  refactor that reorders these silently weakens the audit guarantee.
+- `SpeculativeEngine` cache invalidation — a stale-but-served prediction
+  means an agent acts on data that no longer matches the page.
+- Nextest profile inheritance (`.config/nextest.toml`) — `[profile.ci]` does
+  not inherit `[profile.default]`; a field added only to one silently
+  reverts to nextest's built-in default in the other.

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -97,7 +97,7 @@ release.ymlの全ジョブ詳細は未確認)。
 | `AUDIT_LOG_DIR` | 監査ログの永続化先ディレクトリ | 未設定(永続化なし) |
 | `AUDIT_LOG_MAX_BYTES` | ログローテーション閾値(バイト) | 10485760 (10MiB) |
 | `AUDIT_DURABILITY` | `flush` または `sync` | `flush` |
-| `AUDIT_LOG_STDOUT` | 標準出力への監査ログ出力 | 未確認(詳細仕様は要コード確認) |
+| `AUDIT_LOG_STDOUT` | 設定されていれば(値は任意)監査ログを標準出力にも出力 | 未設定(出力なし) |
 | `CHROME_INSTALLED` | CIでChrome利用可能を示すフラグ(テストゲート用) | 未設定 |
 | `CI` | 汎用CI検出 | — |
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -1,0 +1,153 @@
+# DEVELOPMENT_GUIDE.md
+
+すべてのコマンドは実際に存在するファイル(`Justfile`, `Cargo.toml`,
+`.github/workflows/*.yml`, `rust-toolchain.toml`)から確認済み。未確認の項目は
+明記する。
+
+## セットアップ
+
+- Rustツールチェイン: `rust-toolchain.toml` で `channel = "stable"` を指定。
+  `rustup` がインストール済みなら自動でstableが使われる。
+- Chrome/Chromium: 多くの統合テストとMCPサーバーの実行に必要。`CHROME_PATH`
+  で明示的に指定できる。
+- 開発コンテナ: `.devcontainer/Dockerfile` にChromeプリインストール済みの
+  Dockerイメージ定義がある(VS Code Dev Containers向け)。
+
+```bash
+git clone https://github.com/takurot/dragon-head.git
+cd dragon-head
+cargo build
+```
+
+## 依存関係のインストール
+
+Cargoが`Cargo.toml`/`Cargo.lock`から自動解決する。手動インストール手順は不要。
+ワークスペース共通バージョンは `[workspace.dependencies]`(root `Cargo.toml`)
+で固定: `tokio 1.36`, `anyhow 1.0`, `thiserror 1.0`, `tracing 0.1`,
+`tracing-subscriber 0.3`, `headless_chrome 1.0`, `serde 1.0`, `serde_json 1.0`,
+`toml 0.8`。
+
+## ローカル実行
+
+```bash
+# MCPサーバーのChrome検出確認
+cargo run -p mcp-server --bin dragon-head-mcp -- --doctor
+
+# MCPクライアント用設定スニペットを出力
+cargo run -p mcp-server --bin dragon-head-mcp -- --init claude-code
+
+# Chrome不要の開発用サンプル
+cargo run --example quickstart
+cargo run --example policy_cookbook
+```
+
+`dragon-head-mcp` は標準入力からJSON-RPCを受け取る前提のため、ターミナルで
+直接実行すると即終了する(MCPクライアント経由の起動を想定)。
+
+## テスト実行
+
+```bash
+just test            # cargo nextest run --workspace
+just test-ci          # cargo nextest run --workspace --profile ci (CIと同等)
+cargo test -p <crate> --test <file>   # 個別integrationテスト
+cargo test --workspace --doc          # doctest
+```
+
+ブラウザ依存テストは `test_bench_support::should_skip_browser_tests()` で
+Chrome未検出時に自動スキップされる。明示的に有効化するには:
+
+```bash
+CHROME_INSTALLED=true cargo test -p core-runtime --test semantic_wait
+```
+
+nextestのプロファイルは `.config/nextest.toml` に `default`/`ci` の2種類。
+**`ci` プロファイルは `default` を継承しないため全フィールドを repeat する
+必要がある**(CLAUDE.md §7)。
+
+## lint / format / typecheck
+
+```bash
+just fmt    # cargo fmt --all
+just lint   # cargo clippy --workspace -- -D warnings
+just check  # cargo check --workspace
+```
+
+`.rustfmt.toml`/`clippy.toml` は存在しない(デフォルト設定を使用)。
+warningはCIで `-D warnings` によりエラー扱い。
+
+## ビルド
+
+```bash
+cargo build
+cargo build -p mcp-server --bin dragon-head-mcp --release
+```
+
+リリースバイナリは `.github/workflows/release.yml` がタグpush(`v*`)時に
+macOS arm64/x64、Linux x64/arm64向けにクロスビルドし、sha256チェックサム付き
+でGitHub Releasesにアップロードする(Windows向けはREADMEに記載があるが、
+release.ymlの全ジョブ詳細は未確認)。
+
+## 環境変数
+
+| 変数 | 用途 | 既定値 |
+|---|---|---|
+| `CHROME_PATH` | Chrome/Chromiumバイナリパスの上書き | 自動検出 |
+| `PROMPT_INJECTION_MODE` | `prompt_injection.mode` の上書き(`off`/`report_only`/`redact`) | `report_only` |
+| `POLICY_FILE` | `policy.file` の上書き | 未設定 |
+| `AUDIT_LOG_DIR` | 監査ログの永続化先ディレクトリ | 未設定(永続化なし) |
+| `AUDIT_LOG_MAX_BYTES` | ログローテーション閾値(バイト) | 10485760 (10MiB) |
+| `AUDIT_DURABILITY` | `flush` または `sync` | `flush` |
+| `AUDIT_LOG_STDOUT` | 標準出力への監査ログ出力 | 未確認(詳細仕様は要コード確認) |
+| `CHROME_INSTALLED` | CIでChrome利用可能を示すフラグ(テストゲート用) | 未設定 |
+| `CI` | 汎用CI検出 | — |
+
+環境変数は常に `config.toml` の対応するキーより優先される
+(`mcp-server/src/config.rs`)。
+
+## よくあるエラーと対処
+
+- **`dragon-head-mcp` をターミナルで直接実行すると即終了する** —
+  仕様通り。MCPクライアント経由で起動すること。
+- **Chrome未検出でテストが失敗/スキップされる** — `--doctor` で検出状況を
+  確認し、`CHROME_PATH` を設定する。
+- **`cargo clippy` がwarningで失敗する** — `-D warnings` によりCIではエラー
+  扱い。ローカルでも `just lint` で同条件を再現できる。
+- ビルドエラーの解析手順は別途確立されていない(プロジェクト固有のFAQは
+  「未確認」)。
+
+## CI/CD概要
+
+`.github/workflows/`:
+
+- **`ci.yml`** — `main`/`feature/**`/`codex/**` へのpush、`main` へのPRで
+  起動。`lint`, `security-audit`(rustsec/audit-check, informational),
+  `cargo-deny`(`deny.toml` による強制ゲート), `shellcheck`, `test`
+  (nextest --profile ci + doctest), `coverage`(cargo-llvm-cov, 行カバレッジ
+  70%未満で失敗), 各種regression/compliance/schemaジョブ
+  (`sre-regression`, `policy-regression`, `mcp-protocol-compliance` 等),
+  `nfr-benchmark-short`, PR限定の `evaluation-bench-smoke`。nextestは
+  `nextest@0.9.133` 固定。
+- **`e2e.yml`**(Nightly) — 日次cron + 手動実行。`nfr-benchmark-long`,
+  `full-e2e`, `mcp-binary-e2e`, `evaluation-bench-full`。
+- **`release.yml`** — タグ `v*` push時にクロスビルド+チェックサム生成+
+  GitHub Release作成。
+
+## コードスタイル
+
+- Rust標準の `snake_case`/`PascalCase`/`SCREAMING_SNAKE_CASE` 命名。
+- `cargo fmt`(デフォルト設定)+ `cargo clippy -D warnings` を必須。
+- ライブラリ層は `thiserror`、アプリ層は `anyhow` でエラー型を扱う
+  (ユーザー個人ルール `~/.claude/rules/rust/coding-style.md` 準拠)。
+- 詳細はリポジトリの `CLAUDE.md` 末尾(§1〜§14)に蓄積されたRust固有の
+  落とし穴ガイドを参照。
+
+## ブランチ・コミット方針
+
+- 観測されたブランチ命名: `main`, `feature/**`, `codex/**`(CIトリガー設定
+  `ci.yml` より)。明文化されたブランチ規約ドキュメントは見つからず、
+  **未確認**。
+- コミットメッセージの規約ファイル(`CONTRIBUTING.md` 等)はリポジトリ内に
+  見つからず、**未確認**。直近のコミット例(`git log`)は
+  `[ISSUE-NNN] <要約> (#PR番号)` 形式が多く使われている。
+- `docs/PROMPT.md` にPR実装ワークフロー(計画→TDD→QAゲート→PR作成→レビュー
+  →マージ)の手順が定義されている。大きな変更を行う際は参照すること。

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -1,0 +1,142 @@
+# DOMAIN_MODEL.md
+
+## 用語集
+
+| 用語 | 意味 | 補足 |
+|---|---|---|
+| Semantic State | ページのDOMをアクセシビリティツリー風に正規化したJSON表現 | エージェントが受け取る唯一のページ表現。生DOM/HTMLは渡さない |
+| `stable_key` | `SemanticNode` の安定識別子(SHA-256ハッシュ+衝突インデックス) | 再描画後も同じ要素を指せるようにする |
+| Semantic Delta | 2つの `SemanticState` 間の差分(RFC 6902 JSON Patch) | `get_state` のdelta取得モードで使用 |
+| Load Profile | 状態キャプチャの解像度設定(`minimal`/`visual`/`interactive` 等) | 取得コストと情報量のトレードオフ |
+| Policy Rule | URL/role/テキストにマッチする許可・禁止・承認要求の規則 | `Allow`/`Block`/`RequireHumanApproval` |
+| Guardian Angel | ポリシールールに付与できる「結果予測」拡張機能 | 金額抽出+閾値で `Allow→Block/HITL` に動的昇格 |
+| Outcome Projection | Guardian Angelが生成する予測結果(金額・リスクレベル) | 人間承認時に表示される |
+| HITL (ask_human) | 人間によるアクション承認フロー | Slack/Teams経由(`hitl-bridge`) |
+| Speculative State Generation | 次のアクションと結果状態を事前予測してキャッシュする仕組み | `get_state` のTTFTをほぼゼロにする |
+| Skill | 宣言的なブラウザ操作ワークフロー定義(YAML/JSON) | Locate/Verify/Act/Wait/Extract/Handoffの固定ステップ語彙 |
+| Plugin | Wasmで実装された外部拡張(状態観測・アクション前フック) | 署名・SBOM・capability検証が必須 |
+| Audit Event | すべてのツール呼び出し・アクション・復旧イベントの構造化ログ | PII redaction済み、NDJSON/Webhookで永続化 |
+| Security Flag | プロンプトインジェクション疑いを示すノード上のフラグ | `ReportOnly`/`Redact`/`Off` モードで挙動が変わる |
+| Plan Tier | 課金プラン区分(`Developer`/`Pro`/`Enterprise`) | 使用量メータリングに影響 |
+
+## 主要エンティティ
+
+### SemanticState
+- 役割: ある時点のページ全体を表すスナップショット。
+- 主なフィールド: `page_instance_id`, `state_hash`, `timestamp`, `load_profile`, `root: SemanticNode`。
+- 関連する処理: `PageSession::capture_semantic_state`、`select_update`(前状態との差分計算)。
+
+### SemanticNode
+- 役割: アクセシビリティツリーの再帰的な1ノード(ボタン、テキスト、リンク等)。
+- 主なフィールド: `role`, `label`, `children`, `attributes`, `stable_key`, `ambiguous`, `alias`, `backend_node_id`, `security_flags`。
+- 関連する処理: DOM正規化(`sre/normalization.rs`)、プロンプトインジェクション検出。
+
+### SemanticDelta / StateUpdate
+- 役割: 2つの `SemanticState` 間の差分転送。
+- 主なフィールド: `previous_state_hash`, `next_state_hash`, `patch`(RFC 6902)。
+- 状態: `StateUpdate` は `Noop{state_hash}` / `Full{state}` / `Delta{delta}` の3種。
+
+### PolicyEngine / PolicyRule / PolicyDecision
+- 役割: アクション実行前のガード。
+- 主なフィールド(`PolicyRule`): `id`, `domain`, `path_prefix`, `role`, `text_regex`, `context_regex`, `action`, `scope`, `outcome_projector`。
+- 状態: `PolicyAction` は `Allow` / `Block` / `RequireHumanApproval`。`ApprovalScope` は `ActionOnly` / `UntilNavigation` / `Timeboxed{ms}`。
+
+### OutcomeProjection / RiskLevel
+- 役割: Guardian Angelが生成する予測。
+- 主なフィールド: `projected_amount: Option<f64>`, `risk_level`。
+- 状態: `RiskLevel` は `Low` → `Medium` → `High` → `Critical`(金額閾値で段階的にエスカレーション)。
+
+### SpeculativeEngine / SpeculativePrediction / StateDelta
+- 役割: 次のアクションと結果状態をセッション履歴から予測しキャッシュ。
+- 主なフィールド(`SpeculativePrediction`): `predicted_action`, `predicted_state_hash: Option<String>`, `confidence: f64`。
+- 状態: `StateDelta::{Match, Mismatch}` — 予測が外れた場合は通常キャプチャにフォールバック。
+
+### SkillDefinition / SkillStep
+- 役割: 宣言的なブラウザ操作ワークフロー。
+- 主なフィールド: `schema_version`, `name`, `steps: Vec<SkillStep>`。
+- 状態: `SkillStep` は `Locate` / `Verify` / `Act` / `Wait` / `Extract` / `Handoff` の固定バリアント。実行結果は `SkillRunReport`/`OperationTrace`。
+
+### PluginManifest / PluginRuntime
+- 役割: Wasmプラグインの宣言と実行。
+- 主なフィールド: `plugin_id`, `version`, `entry_points: Vec<ExtensionPoint>`, `capabilities: Vec<Capability>`, `signature`, `sbom`。
+- 状態: `ExtensionPoint` は `OnState` / `BeforeAct` / `Connector`。`Capability` は `ReadState` / `NetworkOut` / `VaultAccess` でゲート。
+
+### UsageReport / PlanTier
+- 役割: MCPツール呼び出しの課金メータリング。
+- 主なフィールド: `plan_tier`, `state_generations`(fast/full/delta/speculative), `visual_captures`, `actions_executed`, `hitl_events`, `audit_retention`, `cost_microusd`, `browser_restarts`, `speculative_misses`。
+
+## エンティティ間の関係
+
+```
+PageSession 1--1 PolicyEngine
+PageSession 1--1 SpeculativeEngine
+PageSession 1--* SemanticState (時系列スナップショット)
+SemanticState 1--* SemanticNode (rootからの再帰木)
+SemanticState --diff--> SemanticDelta --> 次の SemanticState に適用可能
+PolicyRule --has--> OutcomeProjectorConfig --produces--> OutcomeProjection
+PolicyDecision --references--> PolicyRule, OutcomeProjection
+SkillDefinition 1--* SkillStep --executed_by--> SkillEngine --drives--> PageSession
+PluginManifest --validated_by--> plugin-host --hooks_into--> PageSession (plugin_hooks経由)
+AuditLogger --records--> AuditEvent (ToolCall, BrowserRestart, ...) --persisted_by--> AuditSink
+```
+
+## ビジネスルール
+
+- ポリシー評価より先にアクション試行を監査ログへ記録する(ブロックされた
+  試行も追跡可能にする)。
+- Guardian Angelの金額抽出は「最大値」を採用する。ページが小さい金額を
+  先に表示して閾値検知を回避することを防ぐため。
+- HITLイベントは `act` が `requires_human_approval` を返した時点と、
+  `ask_human` が `approved=true` を返した時点の **2回** カウントされる
+  (意図的な仕様。課金スペック §7.1)。
+- 投機的予測がヒットした場合、その状態は「未検証」としてマークされ、次の
+  `act` 実行前に実際のキャプチャで検証される。
+- プロンプトインジェクション検出は `ReportOnly` では本文を変更せず
+  `security_flags` のみ付与し、`Redact` では一致フレーズを
+  `[REDACTED_SECURITY]` に置換する。
+
+## 状態遷移
+
+- **Chrome接続**: 正常 → (CDP切断検知 `is_browser_disconnected`) → 再起動
+  (`BrowserClient::relaunch`)→ 新しい `PageSession` で復帰。
+  `AuditEvent::BrowserRestart` を記録。
+- **要素特定**: `stable_key` 一致 → 失敗時 `target_id` フォールバック →
+  失敗時 `dom_signature` による自己修復照合 → 復旧したノードに対して
+  ポリシーを再評価。
+- **投機的状態**: 予測 → ヒット(未検証で即応答)/ミス(通常キャプチャ) →
+  検証 → `Match`(確定)/`Mismatch`(ロールバック+ミスマッチログ記録)。
+
+## 入力と出力
+
+- **入力**: MCPクライアントからのJSON-RPCツール呼び出し(`get_state`,
+  `act`, `verify`, `get_visual`, `ask_human`, `run_skill`,
+  `get_usage_report`)、`config.toml`/環境変数、ポリシー/スキルJSONファイル。
+- **出力**: `SemanticState`/`StateUpdate`(JSON)、アクション実行結果、
+  監査ログ(NDJSON/Webhook)、使用量レポート(`UsageReport`)。
+
+## データのライフサイクル
+
+- `SemanticState` はセッション内でキャッシュされ、`act` 実行や明示的な
+  `force_refresh` で無効化される。永続化はされない(プロセス内のみ)。
+- 監査イベントは `AUDIT_LOG_DIR` 設定時のみディスクに永続化される
+  (NDJSON、`AUDIT_LOG_MAX_BYTES` でローテーション)。未設定時は永続化なし。
+- 投機的エンジンの `mismatch_log`(最大32件)と `snapshot_cache`
+  (最大64件)はセッション内で古いものから自動的に破棄される(無制限増加
+  を防ぐため)。
+- セッション認証情報(クッキー等)は `SessionVault` に暗号化保存され、
+  `BrowserClient` 単位で共有される。
+
+## 開発時に誤解しやすい概念
+
+- **Semantic Stateはアクセシビリティツリーに似ているが、CDPの
+  Accessibilityドメインそのものではない** — 独自の正規化パイプライン
+  (`sre/normalization.rs`)を経由する。
+- **`stable_key` は要素の「位置」ではなく「内容ベースのハッシュ+衝突
+  インデックス」** — DOM構造が変わっても同一要素なら基本的に維持される
+  が、内容が変われば変化しうる。
+- **投機的状態のヒットは「サーバー内の予測キャッシュ」であり、ブラウザ側を
+  先行操作しているわけではない** — 実際のDOM操作は通常の `act` 経路でのみ
+  発生する。
+- **HITLの2重カウントは課金上の意図的仕様**であり、バグではない。
+- **Guardian Angelはポリシールールの「付加機能」**であり、独立した別の
+  承認エンジンではない(`PolicyRule.outcome_projector` として埋め込まれる)。

--- a/docs/FILE_GUIDE.md
+++ b/docs/FILE_GUIDE.md
@@ -1,0 +1,153 @@
+# FILE_GUIDE.md
+
+## Directory overview
+
+| パス | 役割 | 変更頻度 | 注意点 |
+|---|---|---:|---|
+| `core-runtime/src/` | Chrome/CDP session, Semantic State, policy, audit, privacy, plugins, speculative state | 高 | `stable_key.rs`/`browser.rs` は影響範囲が大きい |
+| `core-runtime/tests/` | core-runtime の統合テスト(35ファイル) | 高 | 機能変更時は対応するテストファイルを必ず確認 |
+| `mcp-server/src/` | `dragon-head-mcp` バイナリ、MCPツールディスパッチ、設定読み込み | 高 | `lib.rs` が巨大、ツール追加はここに集約 |
+| `mcp-server/tests/` | MCPプロトコル/契約テスト(12ファイル) | 中 | ツール追加時はフィクスチャ更新が必要 |
+| `skills-engine/src/` | 宣言的スキル(ワークフロー)定義と実行 | 低〜中 | `lib.rs` 単一ファイル |
+| `plugin-host/src/` | Wasmプラグインの検証・実行 | 低 | 署名/SBOM検証ロジックは慎重に |
+| `marketplace/src/` | プラグイン/ドメインパックのメタデータ | 低 | |
+| `hitl-bridge/src/` | Slack/Teams HITLブリッジ(独立バイナリ) | 低 | `lock.rs`/`server.rs` のHMAC検証は変更注意 |
+| `bench/src/` | NFR/ROIベンチマークハーネス | 低 | |
+| `test-bench-support/src/` | テスト用Chrome検出ヘルパー | 低 | |
+| `examples/` | Chrome不要のサンプル+MCPリクエスト/レスポンスJSON | 低 | READMEの説明と同期させる |
+| `docs/` | 仕様・計画・本ドキュメント群 | 中 | `PLAN.md` はPRごとに更新 |
+| `scripts/` | インストーラ/ベンチ集計/NFRトレンド等のPythonスクリプト | 低 | |
+| `nfr-baseline/*.json` | NFR回帰検出の基準値 | 低 | `scripts/update_nfr_baseline.sh` 経由のみで更新 |
+| `.github/workflows/` | CI/CD定義 | 低 | 変更は慎重に、`deny.toml`/nextestプロファイルと連動 |
+
+## 主要ファイルの役割
+
+### core-runtime/src/
+- `lib.rs` — クレートルート、公開API再エクスポート
+- `browser.rs` — `BrowserClient`(Chromeプロセス管理)、`PageSession`(タブ単位の操作: act/verify/capture/policy/audit/recovery)
+- `chrome_detection.rs` — Chromeバイナリ検出
+- `dom_signature.rs` — Self-Healing Context Recovery(`stable_key`照合失敗時のフォールバック)
+- `policy.rs` — `PolicyEngine`, `PolicyRule`, `PolicyDecision`, Guardian Angel (`OutcomeProjection`)
+- `privacy.rs` — PII検出/redaction正規表現
+- `prompt_injection.rs` — プロンプトインジェクション検出/redaction (`PromptInjectionSanitizer`)
+- `audit.rs` / `audit_sink.rs` / `audit_replay.rs` — 構造化監査ログ、永続化シンク、リプレイ
+- `session_vault.rs` — セッション認証情報の暗号化保存
+- `plugin_hooks.rs` — プラグイン用フックトレイト境界
+- `speculative/{mod,model,codec}.rs` — 投機的状態生成パイプライン
+- `sre/{state,normalization,pipeline,profile,stable_key}.rs` — Semantic Rendering Engine本体
+
+### mcp-server/src/
+- `main.rs` — バイナリエントリポイント
+- `lib.rs` — ツール定義/ディスパッチ、使用量メータリング、投機的状態の組み込み(巨大ファイル)
+- `config.rs` — `config.toml` 読み込み + 環境変数オーバーライド
+- `doctor.rs` — `--doctor` の検証ロジック
+- `init.rs` — `--init <client>` のスニペット生成
+- `cli.rs` — CLI引数解析
+
+### skills-engine/src/
+- `lib.rs` — `SkillDefinition`, `SkillStep`(Locate/Verify/Act/Wait/Extract/Handoff), `SkillEngine`/`SkillRuntime`
+
+### plugin-host/src/
+- `lib.rs` — `PluginManifest`, `PluginRuntime`(wasmtime実行)
+- `schema_registry.rs` — 事前コンパイル済み抽出ルールのレジストリ
+
+### hitl-bridge/src/
+- `main.rs` — Slack HITLブリッジCLIエントリ
+- `server.rs` — `POST /slack/interactions` 受信、HMAC検証
+- `bridge.rs` — ゲートウェイポーリング→通知→解決のオーケストレーション
+- `lock.rs` — 二重解決防止の排他ロック
+- `gateway.rs` — ブラウザセッションへの抽象化
+- `notifier.rs` — 通知送信トレイト
+- `audit.rs` — HITL承認の追記専用監査トレイル
+
+## 機能別に見るべき場所
+
+### MCPツールの挙動を変更するとき
+- `mcp-server/src/lib.rs`(ツール定義・ディスパッチ・メータリング)
+- `mcp-server/tests/mcp_protocol_compliance.rs`, `mcp_client_contract.rs`, `mcp_schema_*.rs`
+- `examples/mcp_examples/*.json`(リクエスト/レスポンスサンプル、必要なら更新)
+- `README.md`「Available MCP Tools」表
+
+### Semantic State / DOM正規化を変更するとき
+- `core-runtime/src/sre/normalization.rs`, `sre/pipeline.rs`, `sre/state.rs`
+- `core-runtime/tests/sre_determinism.rs`, `sre_snapshot_regression.rs`, `sre_fast_full_state.rs`
+- `core-runtime/tests/fixtures/golden/*.json`, `fixtures/sre/minimal_regression_snapshot.json`
+
+### `stable_key` / 要素識別を変更するとき
+- `core-runtime/src/sre/stable_key.rs`
+- `core-runtime/tests/stable_key_*.rs`(generation/compliance/compatibility/quadrant_alias_index)
+- `core-runtime/tests/spa_stable_key_stress.rs`
+
+### ポリシー/承認ロジックを変更するとき
+- `core-runtime/src/policy.rs`
+- `core-runtime/tests/policy_engine.rs`, `policy_enforcement.rs`, `policy_schema_lint.rs`
+- `examples/policy_cookbook.rs`, `examples/sample_policy.json`
+
+### HITL(人間承認)を変更するとき
+- `hitl-bridge/src/*.rs`
+- `mcp-server/src/lib.rs` の `ask_human`/HITLイベント計測部分
+- `hitl-bridge/tests/bridge_flow.rs`
+- `mcp-server/tests/mcp_hitl_flow.rs`
+- `docs/hitl-slack-bridge.md`
+
+### 投機的状態生成(Speculative State Generation)を変更するとき
+- `core-runtime/src/speculative/{mod,model,codec}.rs`
+- `core-runtime/tests/speculative_pregeneration.rs`
+- `mcp-server/tests/speculative_get_state_ttft.rs`
+
+### 監査ログ/プライバシーを変更するとき
+- `core-runtime/src/audit.rs`, `audit_sink.rs`, `audit_replay.rs`, `privacy.rs`
+- `core-runtime/tests/audit_logging.rs`, `audit_persistence.rs`, `audit_schema.rs`, `pii_redaction.rs`, `pii_injection_composition.rs`
+- `scripts/audit_replay.py`
+
+### プロンプトインジェクション対策を変更するとき
+- `core-runtime/src/prompt_injection.rs`
+- `core-runtime/tests/prompt_injection_pipeline.rs`
+- `README.md`「Security: Prompt Injection Sanitization」
+
+### Wasmプラグインを変更するとき
+- `plugin-host/src/lib.rs`, `schema_registry.rs`
+- `core-runtime/src/plugin_hooks.rs`
+- `plugin-host/tests/plugin_runtime.rs`, `plugin_signature_verification.rs`, `plugin_sbom_validation.rs`
+
+### スキル(宣言的ワークフロー)を変更するとき
+- `skills-engine/src/lib.rs`
+- `skills-engine/tests/skill_conformance.rs`, `skill_schema_compatibility.rs`
+- `skills-engine/tests/fixtures/skill/skill_definition.schema.json`
+- `examples/sample_skill.json`
+
+### Chromeクラッシュ復旧/接続管理を変更するとき
+- `core-runtime/src/browser.rs`(`relaunch`, `is_browser_disconnected`)
+- `core-runtime/tests/browser_recovery.rs`, `cdp_connectivity.rs`
+- `mcp-server/tests/mcp_browser_recovery.rs`
+
+### 課金/使用量メータリングを変更するとき
+- `mcp-server/src/lib.rs`(`UsageMeters`, `UsageReport`, `PlanTier`)
+- `mcp-server/tests/mcp_billing_plan_gating.rs`, `mcp_usage_metering_gaps.rs`, `mcp_pricing_snapshot.rs`
+
+### NFR/パフォーマンスベンチマークを変更するとき
+- `bench/src/{harness,metrics,report}.rs`
+- `core-runtime/tests/nfr_*.rs`
+- `nfr-baseline/*.json`(`scripts/update_nfr_baseline.sh` 経由のみ更新)
+- `scripts/nfr_trend.py`, `scripts/nfr_dashboard.py`
+
+## 変更してはいけない、または慎重に扱うべきファイル
+
+- `Cargo.lock` — 手動編集禁止。`cargo build`/`cargo update` で再生成。
+- `target/` 以下すべて — ビルド出力(`nfr-dashboard*.md`, `som-artifacts/*.png` 含む)。
+- `nfr-baseline/*.json` — `scripts/update_nfr_baseline.sh` 経由でのみ更新。
+- `core-runtime/tests/fixtures/som/som_visual_baseline.png` などのバイナリ/スナップショットフィクスチャ — 意図した視覚差分更新以外では変更しない。
+- `.github/workflows/*.yml` — `deny.toml`、`.config/nextest.toml` と連動するため変更は影響範囲を確認してから。
+- `deny.toml` — RUSTSEC ID除外には必ず根拠コメントが付与されている。削除/追加は理由を明記する。
+
+## 自動生成ファイル・設定ファイルの扱い
+
+| ファイル | 種別 | 扱い |
+|---|---|---|
+| `Cargo.lock` | 自動生成 | 編集禁止、コマンドで再生成 |
+| `target/**` | ビルド出力 | 無視、コミットしない |
+| `core-runtime/target/nfr-dashboard*.md` | ベンチ出力 | 無視 |
+| `rust-toolchain.toml` | 設定(`channel = "stable"`) | 変更時はCI全体に影響、慎重に |
+| `deny.toml` | 設定(cargo-deny advisories) | 例外追加時は根拠を明記 |
+| `.config/nextest.toml` | 設定(`default`/`ci`プロファイル) | プロファイル非継承に注意(CLAUDE.md §7) |
+| `nfr-baseline/*.json` | ベースラインデータ | スクリプト経由のみ更新 |


### PR DESCRIPTION
## Summary
- Sync README.md with the current workspace: add missing crates (`hitl-bridge`, `bench`, `test-bench-support`) to Architecture, move Deep Lens / Guardian Angel / speculative state generation / Slack-Teams HITL / shared Wasm engine from "planned roadmap" to "already shipped" (confirmed DONE in docs/PLAN.md), and note the existing GitHub Releases binary distribution.
- Add six onboarding docs under `docs/` for future AI coding agents: `AI_CONTEXT.md`, `ARCHITECTURE.md` (with Mermaid diagram), `FILE_GUIDE.md`, `DEVELOPMENT_GUIDE.md`, `DOMAIN_MODEL.md`, `AI_TASK_GUIDE.md` — intended to reduce repo re-exploration cost on future sessions. No implementation changes.

## Test plan
- [x] Verified MCP tool list and config.toml fields in README against current code (no changes needed, already accurate)
- [x] Verified crate list against root `Cargo.toml` workspace members
- [x] Verified roadmap item status against `docs/PLAN.md`
- [ ] Docs-only change — no build/test required, but reviewer should skim for factual accuracy against current code

🤖 Generated with [Claude Code](https://claude.com/claude-code)