### PR TITLE
feat(npm): add npm distribution package skeleton

### DIFF
--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 *.tgz
-platform/*/bin/
+
+# Real binaries are staged here only at CI publish time — never commit one.
+# Listed by filename (not a blanket bin/ ignore) so dragon-head-mcp/bin/run.js
+# stays tracked.
+platform/*/bin/dragon-head-mcp
+platform/*/bin/dragon-head-mcp.exe
+dragon-head-mcp/bin/dragon-head-mcp
+dragon-head-mcp/bin/dragon-head-mcp.exe

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.tgz
+platform/*/bin/

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,31 @@
+# npm distribution (dragon-head-mcp)
+
+Implements the optionalDependencies-per-platform pattern (same approach as
+esbuild/swc/turbo): a thin wrapper package with a `bin` shim, plus one tiny
+package per platform containing only the prebuilt binary. npm selects the
+right platform package automatically via the `os`/`cpu` fields — there is no
+postinstall script and no install-time network fetch.
+
+```
+npm/
+  dragon-head-mcp/        # published as "dragon-head-mcp" — the package users install
+    package.json
+    bin/run.js            # resolves the platform package and execs the real binary
+  platform/
+    darwin-arm64/package.json
+    darwin-x64/package.json
+    linux-x64/package.json
+    linux-arm64/package.json
+    win32-x64/package.json
+```
+
+Each `platform/*/package.json` is a template only — **no binary is committed
+to git**. CI copies the matching release artifact into
+`platform/<name>/bin/dragon-head-mcp[.exe]` at publish time, immediately
+before `npm publish` for that package, then discards the staged binary. The
+`dragonHeadBinary` field in each platform package.json tells `bin/run.js`
+where to find it relative to that package's own `package.json`.
+
+See [issue #167](https://github.com/takurot/dragon-head/issues/167) for the
+full rollout plan, including the npm Trusted Publishing (OIDC) setup this
+depends on and the CI integration work still to be done.

--- a/npm/README.md
+++ b/npm/README.md
@@ -29,3 +29,13 @@ where to find it relative to that package's own `package.json`.
 See [issue #167](https://github.com/takurot/dragon-head/issues/167) for the
 full rollout plan, including the npm Trusted Publishing (OIDC) setup this
 depends on and the CI integration work still to be done.
+
+## For the future CI publish step
+
+`.github/workflows/release.yml`'s existing build job already runs
+`chmod +x` on the release artifact, but `actions/upload-artifact` /
+`actions/download-artifact` do not reliably preserve the executable bit.
+Whichever job stages a binary into `platform/<name>/bin/` **must re-apply
+`chmod +x` (all platforms except `win32-x64`) after staging, before
+`npm publish`** — otherwise `npm install` succeeds but the installed binary
+fails to spawn with `EACCES`.

--- a/npm/dragon-head-mcp/bin/run.js
+++ b/npm/dragon-head-mcp/bin/run.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const PLATFORM_PACKAGES = {
+  'darwin,arm64': 'dragon-head-mcp-darwin-arm64',
+  'darwin,x64': 'dragon-head-mcp-darwin-x64',
+  'linux,x64': 'dragon-head-mcp-linux-x64',
+  'linux,arm64': 'dragon-head-mcp-linux-arm64',
+  'win32,x64': 'dragon-head-mcp-win32-x64',
+};
+
+function resolveBinaryPath() {
+  const key = `${process.platform},${process.arch}`;
+  const pkgName = PLATFORM_PACKAGES[key];
+
+  if (!pkgName) {
+    const isLinux = process.platform === 'linux';
+    const muslHint = isLinux
+      ? ' Note: only glibc Linux builds are published (no musl/Alpine support yet).'
+      : '';
+    console.error(
+      `dragon-head-mcp: unsupported platform "${key}".${muslHint}\n` +
+        'Use scripts/install.sh or build from source: https://github.com/takurot/dragon-head#install'
+    );
+    process.exit(1);
+  }
+
+  // Resolve via the platform package's own package.json rather than guessing
+  // a node_modules path directly, so this also works under non-flat layouts
+  // (pnpm, yarn PnP) where require.resolve still honors the resolver's own
+  // module map even without a literal node_modules tree.
+  let pkgJsonPath;
+  try {
+    pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+  } catch {
+    console.error(
+      `dragon-head-mcp: optional dependency "${pkgName}" is not installed.\n` +
+        'Re-run npm install, or check that npm config (ignore-scripts / os-cpu ' +
+        'mismatch) did not skip optionalDependencies.'
+    );
+    process.exit(1);
+  }
+
+  const pkgJson = require(pkgJsonPath);
+  const relativeBinaryPath = pkgJson.dragonHeadBinary;
+  if (!relativeBinaryPath) {
+    console.error(`dragon-head-mcp: "${pkgName}" is missing its dragonHeadBinary field.`);
+    process.exit(1);
+  }
+
+  const binaryPath = path.join(path.dirname(pkgJsonPath), relativeBinaryPath);
+  if (!fs.existsSync(binaryPath)) {
+    console.error(`dragon-head-mcp: binary not found at ${binaryPath} (corrupt install?).`);
+    process.exit(1);
+  }
+
+  return binaryPath;
+}
+
+function main() {
+  const binaryPath = resolveBinaryPath();
+  const child = spawn(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
+
+  const forwardSignal = (signal) => {
+    child.kill(signal);
+  };
+  process.on('SIGINT', forwardSignal);
+  process.on('SIGTERM', forwardSignal);
+
+  child.on('error', (err) => {
+    console.error(`dragon-head-mcp: failed to start binary: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      // Re-raise the same signal on this process so a wrapping supervisor
+      // sees the real termination cause instead of a synthetic exit code.
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+}
+
+main();

--- a/npm/dragon-head-mcp/bin/run.js
+++ b/npm/dragon-head-mcp/bin/run.js
@@ -5,6 +5,11 @@ const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
 
+// Keep this map in sync with the wrapper package.json's optionalDependencies
+// and the 5 npm/platform/*/package.json names (see test/run.test.js, which
+// asserts all three agree). scripts/install.sh and .github/workflows/release.yml
+// maintain their own parallel platform lists in different languages/formats —
+// check those too when adding or removing a platform here.
 const PLATFORM_PACKAGES = {
   'darwin,arm64': 'dragon-head-mcp-darwin-arm64',
   'darwin,x64': 'dragon-head-mcp-darwin-x64',
@@ -13,15 +18,21 @@ const PLATFORM_PACKAGES = {
   'win32,x64': 'dragon-head-mcp-win32-x64',
 };
 
-function resolveBinaryPath() {
-  const key = `${process.platform},${process.arch}`;
+// Architectures we publish glibc Linux builds for. Used only to decide
+// whether the musl/Alpine hint below is relevant — an unsupported Linux
+// architecture outside this set (e.g. ia32, arm) is an arch problem, not a
+// libc problem, and the hint would be misleading there.
+const SUPPORTED_LINUX_ARCHS = new Set(['x64', 'arm64']);
+
+function resolveBinaryPath(platform = process.platform, arch = process.arch) {
+  const key = `${platform},${arch}`;
   const pkgName = PLATFORM_PACKAGES[key];
 
   if (!pkgName) {
-    const isLinux = process.platform === 'linux';
-    const muslHint = isLinux
-      ? ' Note: only glibc Linux builds are published (no musl/Alpine support yet).'
-      : '';
+    const muslHint =
+      platform === 'linux' && SUPPORTED_LINUX_ARCHS.has(arch)
+        ? ' Note: only glibc Linux builds are published (no musl/Alpine support yet).'
+        : '';
     console.error(
       `dragon-head-mcp: unsupported platform "${key}".${muslHint}\n` +
         'Use scripts/install.sh or build from source: https://github.com/takurot/dragon-head#install'
@@ -45,7 +56,17 @@ function resolveBinaryPath() {
     process.exit(1);
   }
 
-  const pkgJson = require(pkgJsonPath);
+  let pkgJson;
+  try {
+    pkgJson = require(pkgJsonPath);
+  } catch (err) {
+    console.error(
+      `dragon-head-mcp: "${pkgName}"'s package.json is corrupted (${err.message}).\n` +
+        'Re-run npm install to repair it.'
+    );
+    process.exit(1);
+  }
+
   const relativeBinaryPath = pkgJson.dragonHeadBinary;
   if (!relativeBinaryPath) {
     console.error(`dragon-head-mcp: "${pkgName}" is missing its dragonHeadBinary field.`);
@@ -87,4 +108,8 @@ function main() {
   });
 }
 
-main();
+module.exports = { PLATFORM_PACKAGES, resolveBinaryPath };
+
+if (require.main === module) {
+  main();
+}

--- a/npm/dragon-head-mcp/package.json
+++ b/npm/dragon-head-mcp/package.json
@@ -11,6 +11,9 @@
   "files": [
     "bin/run.js"
   ],
+  "scripts": {
+    "test": "node --test test/run.test.js"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/npm/dragon-head-mcp/package.json
+++ b/npm/dragon-head-mcp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dragon-head-mcp",
+  "version": "0.1.0",
+  "description": "AI-native headless browser runtime MCP server (npm distribution wrapper)",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "homepage": "https://github.com/takurot/dragon-head",
+  "bin": {
+    "dragon-head-mcp": "bin/run.js"
+  },
+  "files": [
+    "bin/run.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "dragon-head-mcp-darwin-arm64": "0.1.0",
+    "dragon-head-mcp-darwin-x64": "0.1.0",
+    "dragon-head-mcp-linux-x64": "0.1.0",
+    "dragon-head-mcp-linux-arm64": "0.1.0",
+    "dragon-head-mcp-win32-x64": "0.1.0"
+  }
+}

--- a/npm/dragon-head-mcp/test/run.test.js
+++ b/npm/dragon-head-mcp/test/run.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { execFileSync, spawnSync } = require('node:child_process');
+
+const { PLATFORM_PACKAGES, resolveBinaryPath } = require('../bin/run.js');
+
+const WRAPPER_PKG = require('../package.json');
+const PLATFORM_ROOT = path.join(__dirname, '..', '..', 'platform');
+
+function platformPackageJson(dirName) {
+  return require(path.join(PLATFORM_ROOT, dirName, 'package.json'));
+}
+
+// Run `fn`, capturing the message passed to the first `process.exit` call
+// instead of actually exiting the test process. Mirrors the project's Rust
+// convention of injecting test seams rather than mutating real global state
+// (see CLAUDE.md #11) — here the seam is a temporarily stubbed process.exit.
+function captureExit(fn) {
+  const originalExit = process.exit;
+  const originalError = console.error;
+  let exitCode;
+  let errorOutput = '';
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error('__test_process_exit__');
+  };
+  console.error = (msg) => {
+    errorOutput += `${msg}\n`;
+  };
+  try {
+    fn();
+  } catch (err) {
+    if (err.message !== '__test_process_exit__') throw err;
+  } finally {
+    process.exit = originalExit;
+    console.error = originalError;
+  }
+  return { exitCode, errorOutput };
+}
+
+test('PLATFORM_PACKAGES, wrapper optionalDependencies, and platform package names all agree', () => {
+  const platformDirs = fs
+    .readdirSync(PLATFORM_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+
+  const namesFromPlatformPackages = platformDirs
+    .map((dir) => platformPackageJson(dir).name)
+    .sort();
+
+  const namesFromRunJs = Object.values(PLATFORM_PACKAGES).sort();
+  const namesFromOptionalDeps = Object.keys(WRAPPER_PKG.optionalDependencies).sort();
+
+  assert.deepEqual(
+    namesFromRunJs,
+    namesFromOptionalDeps,
+    'run.js PLATFORM_PACKAGES values must exactly match wrapper package.json optionalDependencies keys'
+  );
+  assert.deepEqual(
+    namesFromRunJs,
+    namesFromPlatformPackages,
+    'run.js PLATFORM_PACKAGES values must exactly match every npm/platform/*/package.json "name" field'
+  );
+});
+
+test('every optionalDependency version is exact-pinned (no ^ or ~ range)', () => {
+  for (const version of Object.values(WRAPPER_PKG.optionalDependencies)) {
+    assert.doesNotMatch(version, /^[\^~]/, `optionalDependency version "${version}" must be exact-pinned`);
+  }
+});
+
+test('win32 platform package is the only one with an .exe dragonHeadBinary', () => {
+  for (const dir of fs.readdirSync(PLATFORM_ROOT)) {
+    const pkg = platformPackageJson(dir);
+    if (dir.startsWith('win32-')) {
+      assert.match(pkg.dragonHeadBinary, /\.exe$/, `${dir} should declare an .exe binary`);
+    } else {
+      assert.doesNotMatch(pkg.dragonHeadBinary, /\.exe$/, `${dir} should not declare an .exe binary`);
+    }
+  }
+});
+
+test('resolveBinaryPath rejects an unsupported platform with exit code 1', () => {
+  const { exitCode, errorOutput } = captureExit(() => resolveBinaryPath('freebsd', 'x64'));
+  assert.equal(exitCode, 1);
+  assert.match(errorOutput, /unsupported platform "freebsd,x64"/);
+});
+
+test('unsupported-platform message only hints at musl/Alpine for a supported Linux arch', () => {
+  const { errorOutput: x64Output } = captureExit(() => resolveBinaryPath('linux', 'x64'));
+  // linux,x64 IS supported, so force an unsupported combo on a supported arch
+  // by using an arch that isn't in PLATFORM_PACKAGES at all but IS musl-relevant:
+  const { errorOutput: armOutput } = captureExit(() => resolveBinaryPath('linux', 'arm'));
+  const { errorOutput: ia32Output } = captureExit(() => resolveBinaryPath('linux', 'ia32'));
+
+  assert.doesNotMatch(x64Output, /unsupported platform/); // linux,x64 is supported — no error at all
+  assert.doesNotMatch(armOutput, /musl\/Alpine/, '32-bit arm is an architecture gap, not a libc gap');
+  assert.doesNotMatch(ia32Output, /musl\/Alpine/, 'ia32 is an architecture gap, not a libc gap');
+});
+
+test('resolveBinaryPath errors when the optional dependency is not installed', () => {
+  const { exitCode, errorOutput } = captureExit(() => resolveBinaryPath('darwin', 'arm64'));
+  // In this test environment the platform optional dependency is never
+  // actually installed (it's only staged by CI at publish time), so this
+  // exercises the "not installed" branch end-to-end.
+  assert.equal(exitCode, 1);
+  assert.match(errorOutput, /optional dependency "dragon-head-mcp-darwin-arm64" is not installed/);
+});
+
+test('end-to-end: packed wrapper + platform tarballs resolve and exec a fake binary with correct exit code', (t) => {
+  const platform = os.platform();
+  const arch = os.arch();
+  const platformDir = `${platform}-${arch}`;
+  if (!fs.existsSync(path.join(PLATFORM_ROOT, platformDir))) {
+    t.skip(`no platform package for ${platformDir} on this CI runner`);
+    return;
+  }
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dragon-head-mcp-e2e-'));
+  const fakeBinaryDir = path.join(tmpRoot, 'fakebin');
+  fs.mkdirSync(fakeBinaryDir, { recursive: true });
+
+  // Stage a fake binary into a throwaway copy of the platform package so we
+  // never touch the real npm/platform/*/bin (which must stay binary-free in git).
+  const stagedPlatformDir = path.join(tmpRoot, 'platform-src');
+  fs.cpSync(path.join(PLATFORM_ROOT, platformDir), stagedPlatformDir, { recursive: true });
+  const pkg = require(path.join(stagedPlatformDir, 'package.json'));
+  const binaryName = path.basename(pkg.dragonHeadBinary);
+  const stagedBinaryPath = path.join(stagedPlatformDir, 'bin', binaryName);
+  fs.mkdirSync(path.dirname(stagedBinaryPath), { recursive: true });
+  fs.writeFileSync(stagedBinaryPath, '#!/usr/bin/env bash\necho FAKE_BINARY_RAN "$@"\nexit 7\n');
+  fs.chmodSync(stagedBinaryPath, 0o755);
+
+  const packOutDir = path.join(tmpRoot, 'tarballs');
+  fs.mkdirSync(packOutDir);
+  const wrapperDir = path.join(__dirname, '..');
+
+  const packOne = (dir) => {
+    const out = execFileSync('npm', ['pack', '--silent', '--pack-destination', packOutDir], {
+      cwd: dir,
+    })
+      .toString()
+      .trim();
+    return path.join(packOutDir, out);
+  };
+
+  const wrapperTarball = packOne(wrapperDir);
+  const platformTarball = packOne(stagedPlatformDir);
+
+  const projectDir = path.join(tmpRoot, 'proj');
+  fs.mkdirSync(projectDir);
+  fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ name: 'e2e', version: '0.0.0' }));
+  execFileSync('npm', ['install', '--no-audit', '--no-fund', wrapperTarball, platformTarball], {
+    cwd: projectDir,
+  });
+
+  const result = spawnSync('node', [path.join(projectDir, 'node_modules', 'dragon-head-mcp', 'bin', 'run.js'), '--doctor'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 7, `expected the fake binary's exit code to propagate, got: ${result.stderr}`);
+  assert.match(result.stdout, /FAKE_BINARY_RAN --doctor/);
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});

--- a/npm/platform/darwin-arm64/package.json
+++ b/npm/platform/darwin-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dragon-head-mcp-darwin-arm64",
+  "version": "0.1.0",
+  "description": "dragon-head-mcp prebuilt binary for macOS (Apple Silicon)",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "dragonHeadBinary": "bin/dragon-head-mcp",
+  "files": [
+    "bin/dragon-head-mcp"
+  ]
+}

--- a/npm/platform/darwin-x64/package.json
+++ b/npm/platform/darwin-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dragon-head-mcp-darwin-x64",
+  "version": "0.1.0",
+  "description": "dragon-head-mcp prebuilt binary for macOS (Intel)",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "dragonHeadBinary": "bin/dragon-head-mcp",
+  "files": [
+    "bin/dragon-head-mcp"
+  ]
+}

--- a/npm/platform/linux-arm64/package.json
+++ b/npm/platform/linux-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dragon-head-mcp-linux-arm64",
+  "version": "0.1.0",
+  "description": "dragon-head-mcp prebuilt binary for Linux arm64 (glibc)",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "dragonHeadBinary": "bin/dragon-head-mcp",
+  "files": [
+    "bin/dragon-head-mcp"
+  ]
+}

--- a/npm/platform/linux-x64/package.json
+++ b/npm/platform/linux-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dragon-head-mcp-linux-x64",
+  "version": "0.1.0",
+  "description": "dragon-head-mcp prebuilt binary for Linux x86-64 (glibc)",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "dragonHeadBinary": "bin/dragon-head-mcp",
+  "files": [
+    "bin/dragon-head-mcp"
+  ]
+}

--- a/npm/platform/win32-x64/package.json
+++ b/npm/platform/win32-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dragon-head-mcp-win32-x64",
+  "version": "0.1.0",
+  "description": "dragon-head-mcp prebuilt binary for Windows x86-64",
+  "license": "MIT",
+  "repository": "github:takurot/dragon-head",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "dragonHeadBinary": "bin/dragon-head-mcp.exe",
+  "files": [
+    "bin/dragon-head-mcp.exe"
+  ]
+}


### PR DESCRIPTION
## Summary
- Implements the npm package skeleton from #167: a thin `dragon-head-mcp` wrapper package + 5 platform packages (`dragon-head-mcp-{darwin-arm64,darwin-x64,linux-x64,linux-arm64,win32-x64}`), following the optionalDependencies-per-platform pattern (esbuild/swc-style — no postinstall script, npm resolves the right binary via `os`/`cpu` fields).
- `bin/run.js` resolves the platform package's binary via that package's own `package.json` (`dragonHeadBinary` field) rather than guessing a `node_modules` path, so it works under pnpm and yarn PnP layouts, not just flat `npm install`. Uses async `spawn` with SIGINT/SIGTERM forwarding and signal/exit-code propagation (per review feedback on #167 — `spawnSync` would mishandle this for a long-running stdio MCP server).
- No binaries are committed to git (`npm/.gitignore` excludes `platform/*/bin/`) — real release binaries are staged into each platform package only by CI at publish time, per the plan in #167.
- This PR is the package skeleton only. CI publish integration (npm Trusted Publishing/OIDC, `--provenance`, job ordering, the one-time npm account-side bootstrap) is tracked separately in #167 and not yet implemented.

## Test plan
- [x] `node -c bin/run.js` — syntax check passes.
- [x] `npm pack --dry-run` on both the wrapper and a platform package — correct file lists (`bin/run.js` + `package.json` for the wrapper; `bin/dragon-head-mcp[.exe]` + `package.json` per platform).
- [x] End-to-end local smoke test: packed both tarballs, installed into a scratch project, ran via `node .../bin/run.js` and via the npm-linked `.bin/dragon-head-mcp` symlink, using a fake shell binary in place of the real release binary (which CI provides at publish time) — confirmed arg passthrough and exit code propagation (verified exit code 7 from the fake binary surfaces correctly).
- [x] Removed the optional dependency and reran — confirmed the "optional dependency is not installed" error path triggers with exit code 1 instead of a stack trace.
- [ ] Real binary end-to-end test (requires CI publish integration from #167, not yet built).