### PR TITLE
[ISSUE-167] npm OIDC Trusted Publishing CI jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,137 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  npm-publish-platforms:
+    name: Publish npm platform packages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # npm >= 11.5.1 is the minimum version that supports OIDC trusted
+      # publishing (no long-lived NPM_TOKEN needed). Node 22 ships with npm
+      # 10.x, so we upgrade explicitly.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Verify checksums
+        shell: bash
+        run: |
+          cd dist
+          for f in *.sha256; do
+            sha256sum -c "$f"
+          done
+
+      # Each entry is "artifact-filename:npm-platform-dir:binary-name-in-pkg".
+      # Keep this list in sync with the build matrix above and with
+      # npm/dragon-head-mcp/bin/run.js PLATFORM_PACKAGES map.
+      - name: Stage binaries and publish platform packages
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          NPM_VERSION="${VERSION#v}"
+
+          PLATFORMS=(
+            "dragon-head-mcp-macos-arm64:darwin-arm64:dragon-head-mcp"
+            "dragon-head-mcp-macos-x64:darwin-x64:dragon-head-mcp"
+            "dragon-head-mcp-linux-x64:linux-x64:dragon-head-mcp"
+            "dragon-head-mcp-linux-arm64:linux-arm64:dragon-head-mcp"
+            "dragon-head-mcp-windows-x64.exe:win32-x64:dragon-head-mcp.exe"
+          )
+
+          for entry in "${PLATFORMS[@]}"; do
+            IFS=':' read -r artifact platform_dir bin_name <<< "$entry"
+            pkg_dir="npm/platform/${platform_dir}"
+            bin_dir="${pkg_dir}/bin"
+
+            mkdir -p "$bin_dir"
+            cp "dist/${artifact}" "${bin_dir}/${bin_name}"
+            # chmod is a no-op on .exe but harmless; the || true prevents
+            # the step from failing on the Windows binary.
+            chmod +x "${bin_dir}/${bin_name}" 2>/dev/null || true
+
+            PKG_DIR="$pkg_dir" NPM_VERSION="$NPM_VERSION" node -e "
+              const fs = require('fs');
+              const p = process.env.PKG_DIR + '/package.json';
+              const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+              pkg.version = process.env.NPM_VERSION;
+              fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+            "
+
+            for attempt in 1 2 3; do
+              if npm publish "${pkg_dir}" --access public --provenance; then
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "Attempt $attempt failed for ${platform_dir}, retrying in 15s..."
+                sleep 15
+              else
+                echo "::error::All 3 publish attempts failed for ${platform_dir}"
+                exit 1
+              fi
+            done
+          done
+
+  publish-npm-wrapper:
+    name: Publish npm wrapper package
+    needs: npm-publish-platforms
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11
+
+      - name: Bump version and publish wrapper
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          NPM_VERSION="${VERSION#v}"
+          pkg_dir="npm/dragon-head-mcp"
+
+          PKG_DIR="$pkg_dir" NPM_VERSION="$NPM_VERSION" node -e "
+            const fs = require('fs');
+            const p = process.env.PKG_DIR + '/package.json';
+            const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+            pkg.version = process.env.NPM_VERSION;
+            for (const dep of Object.keys(pkg.optionalDependencies)) {
+              pkg.optionalDependencies[dep] = process.env.NPM_VERSION;
+            }
+            fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          for attempt in 1 2 3; do
+            if npm publish "${pkg_dir}" --access public --provenance; then
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Attempt $attempt failed for wrapper, retrying in 15s..."
+              sleep 15
+            else
+              echo "::error::All 3 publish attempts failed for wrapper"
+              exit 1
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -39,7 +39,20 @@ chmod +x dragon-head-mcp-macos-arm64
 sudo mv dragon-head-mcp-macos-arm64 /usr/local/bin/dragon-head-mcp
 ```
 
-### Option 2: Install script (macOS and Linux)
+### Option 2: npm (global install)
+
+Requires Node.js 18 or later. Works with npm, pnpm, and yarn.
+
+```bash
+npm install -g dragon-head-mcp
+dragon-head-mcp --doctor
+```
+
+The correct prebuilt binary for your platform is selected automatically via
+`optionalDependencies`. No postinstall script is involved, so it works in
+environments where `--ignore-scripts` is set.
+
+### Option 3: Install script (macOS and Linux)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/takurot/dragon-head/main/scripts/install.sh | bash
@@ -49,7 +62,7 @@ The script detects your platform, downloads the matching binary from the latest
 release, verifies the checksum, and installs to `/usr/local/bin`. Set
 `INSTALL_DIR` to install elsewhere.
 
-### Option 3: Build from source
+### Option 4: Build from source
 
 Requires Rust stable and Chrome or Chromium.
 
@@ -354,6 +367,8 @@ Dragon Head is organized as a Rust workspace:
 
 - **GitHub Releases**: prebuilt binaries for macOS, Linux, and Windows are
   published automatically (see [Install](#install) above).
+- **npm**: `npm install -g dragon-head-mcp` — shipped via OIDC Trusted
+  Publishing on every release tag (see [Install](#install) above).
 - **Homebrew**: A `takurot/tap` formula is planned.
 - **Docker**: A multi-platform image for CI and Linux evaluation is planned.
 - **cargo install**: Available once workspace crate publishing is ready.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -92,7 +92,35 @@ Artifacts to verify:
 
 ---
 
-## 5. Homebrew (deferred — not yet published)
+## 5. npm verification
+
+- [ ] Confirm the `npm-publish-platforms` and `publish-npm-wrapper` CI jobs completed green.
+- [ ] Verify the wrapper package is live and at the correct version:
+  ```bash
+  npm view dragon-head-mcp versions --json
+  ```
+- [ ] Smoke-test the wrapper install in a temporary directory:
+  ```bash
+  cd "$(mktemp -d)"
+  npm install dragon-head-mcp@X.Y.Z
+  ./node_modules/.bin/dragon-head-mcp --doctor
+  ```
+- [ ] Verify each platform package is also live:
+  ```bash
+  for pkg in dragon-head-mcp-darwin-arm64 dragon-head-mcp-darwin-x64 \
+              dragon-head-mcp-linux-x64 dragon-head-mcp-linux-arm64 \
+              dragon-head-mcp-win32-x64; do
+    npm view "$pkg" version
+  done
+  ```
+- [ ] Test global install (on at least one platform):
+  ```bash
+  npx dragon-head-mcp@X.Y.Z --doctor
+  ```
+
+---
+
+## 6. Homebrew (deferred — not yet published)
 
 > **Status:** Planned. A `takurot/tap` formula is tracked separately.
 >

--- a/npm/dragon-head-mcp/package.json
+++ b/npm/dragon-head-mcp/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "AI-native headless browser runtime MCP server (npm distribution wrapper)",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "homepage": "https://github.com/takurot/dragon-head",
   "bin": {
     "dragon-head-mcp": "bin/run.js"

--- a/npm/platform/darwin-arm64/package.json
+++ b/npm/platform/darwin-arm64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "dragon-head-mcp prebuilt binary for macOS (Apple Silicon)",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "os": [
     "darwin"
   ],

--- a/npm/platform/darwin-x64/package.json
+++ b/npm/platform/darwin-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "dragon-head-mcp prebuilt binary for macOS (Intel)",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "os": [
     "darwin"
   ],

--- a/npm/platform/linux-arm64/package.json
+++ b/npm/platform/linux-arm64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "dragon-head-mcp prebuilt binary for Linux arm64 (glibc)",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "os": [
     "linux"
   ],

--- a/npm/platform/linux-x64/package.json
+++ b/npm/platform/linux-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "dragon-head-mcp prebuilt binary for Linux x86-64 (glibc)",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "os": [
     "linux"
   ],

--- a/npm/platform/win32-x64/package.json
+++ b/npm/platform/win32-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "dragon-head-mcp prebuilt binary for Windows x86-64",
   "license": "MIT",
-  "repository": "github:takurot/dragon-head",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takurot/dragon-head.git"
+  },
   "os": [
     "win32"
   ],


### PR DESCRIPTION
Closes #167

## Summary

- Adds `npm-publish-platforms` CI job to `release.yml`: runs after `build`, downloads all 5 platform artifacts, verifies sha256 checksums, stages binaries, bumps package versions from the git tag, publishes each via `npm publish --provenance` (OIDC Trusted Publishing — no `NPM_TOKEN`). Retries up to 3× with 15 s backoff.
- Adds `publish-npm-wrapper` CI job: enforced by `needs: [npm-publish-platforms]` so all 5 platform packages are live before the wrapper publishes.
- Updates `README.md`: npm as Option 2 install, "Secondary Distribution Paths" marks npm as shipped.
- Updates `docs/release-checklist.md`: Section 5 npm verification steps.

## Exit Criteria (from #167)

| Criterion | Status |
|---|---|
| `npm-publish-platforms` job, single ubuntu runner, `needs: build`, `id-token: write` | ✅ |
| Downloads all 5 artifacts, re-verifies `.sha256` before staging | ✅ |
| Stages into `npm/platform/<name>/bin/`, bumps version from git tag | ✅ |
| `npm publish --access public --provenance` per platform | ✅ |
| `publish-npm-wrapper` with `needs: [npm-publish-platforms]` | ✅ |
| No `NPM_TOKEN` (OIDC auth only) | ✅ |
| Retry/backoff (3 attempts, 15 s) | ✅ |
| Node ≥ 22 + npm ≥ 11 (upgraded explicitly) | ✅ |
| README npm install option | ✅ |
| `docs/release-checklist.md` npm verification steps | ✅ |

## Security notes

- `github.ref_name` flows through `env: VERSION:` only — never interpolated directly into `run:` commands.
- `node -e` edits receive `PKG_DIR` and `NPM_VERSION` via `process.env.*`, not shell string interpolation.
- No secrets added; authentication is entirely OIDC Trusted Publishing (requires npmjs.com Trusted Publisher config — one-time manual step documented in #167).

## Pre-merge manual prerequisites (one-time, outside this PR)

Per #167: npm account 2FA, claiming the 6 package names with a one-time `npm publish`, and Trusted Publisher config on npmjs.com (Org `takurot`, Repo `dragon-head`, Workflow `release.yml`).

## Test plan

- [ ] Review workflow YAML for correctness (YAML lints clean ✅)
- [ ] Push a pre-release tag (e.g. `v0.2.0-rc.1`) after the npmjs.com Trusted Publisher config is in place to validate the full publish pipeline end-to-end
- [ ] Run `npm view dragon-head-mcp versions` and `npx dragon-head-mcp@X.Y.Z --doctor` after a real release tag