### PR TITLE
[ISSUE-174] perf: shorten stable_key from 64 to 16 hex chars

### DIFF
--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -2323,7 +2323,12 @@ fn find_node_by_id(node: &SemanticNode, target_id: i64) -> Option<&SemanticNode>
 
 fn find_node_by_key<'a>(node: &'a SemanticNode, target_key: &str) -> Option<&'a SemanticNode> {
     if let Some(key) = &node.stable_key {
-        if key == target_key {
+        // Compare using the first STABLE_KEY_SHORT_LEN chars so that a caller
+        // supplying a shortened key (as returned by get_state) matches the full
+        // 64-char SHA-256 stored on SemanticNode.  Both sides are clamped to the
+        // shorter length, so the comparison is always symmetric.
+        let cmp_len = STABLE_KEY_SHORT_LEN.min(key.len()).min(target_key.len());
+        if key[..cmp_len] == target_key[..cmp_len] {
             return Some(node);
         }
     }
@@ -2832,6 +2837,67 @@ mod tests {
     fn is_browser_disconnected_ignores_page_level_errors() {
         let err = anyhow::anyhow!("Could not find node with given id");
         assert!(!is_browser_disconnected(&err));
+    }
+
+    #[test]
+    fn find_node_by_key_matches_full_64_char_key() {
+        let full_key = "a".repeat(64);
+        let node = SemanticNode {
+            stable_key: Some(full_key.clone()),
+            ..Default::default()
+        };
+        assert!(find_node_by_key(&node, &full_key).is_some());
+    }
+
+    #[test]
+    fn find_node_by_key_matches_shortened_16_char_key_against_full_key() {
+        // get_state now returns only the first 16 chars; enforce_policy must still
+        // resolve the node from the SemanticTree which stores full 64-char keys.
+        let full_key = "abcdef1234567890".repeat(4); // 64 chars
+        let short_key: String = full_key.chars().take(STABLE_KEY_SHORT_LEN).collect();
+        let node = SemanticNode {
+            stable_key: Some(full_key.clone()),
+            ..Default::default()
+        };
+        assert!(
+            find_node_by_key(&node, &short_key).is_some(),
+            "shortened key should resolve the node for policy evaluation"
+        );
+    }
+
+    #[test]
+    fn find_node_by_key_does_not_match_wrong_prefix() {
+        let full_key = "abcdef1234567890".repeat(4);
+        let wrong_short = "0000000000000000";
+        let node = SemanticNode {
+            stable_key: Some(full_key.clone()),
+            ..Default::default()
+        };
+        assert!(find_node_by_key(&node, wrong_short).is_none());
+    }
+
+    #[test]
+    fn resolve_policy_target_node_resolves_via_shortened_stable_key() {
+        let full_key = "deadbeefcafe0123".repeat(4);
+        let short_key: String = full_key.chars().take(STABLE_KEY_SHORT_LEN).collect();
+
+        let child = SemanticNode {
+            role: "button".to_string(),
+            stable_key: Some(full_key.clone()),
+            ..Default::default()
+        };
+        let root = SemanticNode {
+            role: "body".to_string(),
+            children: vec![child],
+            ..Default::default()
+        };
+
+        let found = resolve_policy_target_node(&root, None, Some(&short_key));
+        assert!(
+            found.is_some(),
+            "policy target resolution must work with the 16-char short key returned by get_state"
+        );
+        assert_eq!(found.unwrap().role, "button");
     }
 }
 

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -847,19 +847,25 @@ impl PageSession {
     }
 
     /// Resolve a backend node id from the per-session stable_key index.
+    /// The index is keyed by the first `STABLE_KEY_SHORT_LEN` hex chars; callers
+    /// may pass either the full 64-char internal key or the 16-char external key.
     pub fn lookup_backend_node_id_by_stable_key(&self, stable_key: &str) -> Option<i64> {
+        let short: String = stable_key.chars().take(STABLE_KEY_SHORT_LEN).collect();
         self.stable_key_index
             .lock()
             .ok()
-            .and_then(|index| index.get(stable_key).map(|entry| entry.backend_node_id))
+            .and_then(|index| index.get(short.as_str()).map(|entry| entry.backend_node_id))
     }
 
     /// Resolve alias metadata from the per-session stable_key index.
+    /// See [`lookup_backend_node_id_by_stable_key`] for key-length semantics.
     pub fn lookup_alias_by_stable_key(&self, stable_key: &str) -> Option<String> {
-        self.stable_key_index
-            .lock()
-            .ok()
-            .and_then(|index| index.get(stable_key).and_then(|entry| entry.alias.clone()))
+        let short: String = stable_key.chars().take(STABLE_KEY_SHORT_LEN).collect();
+        self.stable_key_index.lock().ok().and_then(|index| {
+            index
+                .get(short.as_str())
+                .and_then(|entry| entry.alias.clone())
+        })
     }
 
     /// Returns a clone of this session's [`AuditLogger`] handle.
@@ -2386,11 +2392,19 @@ fn semantic_path(parent_path: &str, role: &str) -> String {
     format!("{}/{}", parent_path, role.to_lowercase())
 }
 
+/// Number of hex characters exposed in the external (LLM-facing) stable_key.
+/// 16 hex chars = 64 bits of entropy; negligible collision probability at page scale.
+/// Re-exported from `core-runtime` so downstream crates share a single source of truth.
+pub const STABLE_KEY_SHORT_LEN: usize = 16;
+
 fn collect_stable_key_entries(node: &SemanticNode, out: &mut HashMap<String, StableKeyIndexEntry>) {
     if let Some(key) = &node.stable_key {
         if node.backend_node_id > 0 {
+            // Index by the short key so that agents (which receive the 16-char form
+            // from ExternalInteractiveElement) can resolve their key back to a node id.
+            let short_key: String = key.chars().take(STABLE_KEY_SHORT_LEN).collect();
             out.insert(
-                key.clone(),
+                short_key,
                 StableKeyIndexEntry {
                     backend_node_id: node.backend_node_id,
                     alias: node.alias.clone(),

--- a/core-runtime/src/browser.rs
+++ b/core-runtime/src/browser.rs
@@ -2323,13 +2323,17 @@ fn find_node_by_id(node: &SemanticNode, target_id: i64) -> Option<&SemanticNode>
 
 fn find_node_by_key<'a>(node: &'a SemanticNode, target_key: &str) -> Option<&'a SemanticNode> {
     if let Some(key) = &node.stable_key {
-        // Compare using the first STABLE_KEY_SHORT_LEN chars so that a caller
-        // supplying a shortened key (as returned by get_state) matches the full
-        // 64-char SHA-256 stored on SemanticNode.  Both sides are clamped to the
-        // shorter length, so the comparison is always symmetric.
-        let cmp_len = STABLE_KEY_SHORT_LEN.min(key.len()).min(target_key.len());
-        if key[..cmp_len] == target_key[..cmp_len] {
-            return Some(node);
+        // Reject empty keys before any comparison: cmp_len=0 would make every
+        // node match, bypassing policy target resolution.
+        if !target_key.is_empty() && !key.is_empty() {
+            // Compare using the first STABLE_KEY_SHORT_LEN chars so that a caller
+            // supplying a shortened key (as returned by get_state) matches the full
+            // 64-char SHA-256 stored on SemanticNode.  Both sides are clamped to the
+            // shorter length, so the comparison is always symmetric.
+            let cmp_len = STABLE_KEY_SHORT_LEN.min(key.len()).min(target_key.len());
+            if key[..cmp_len] == target_key[..cmp_len] {
+                return Some(node);
+            }
         }
     }
 
@@ -2874,6 +2878,20 @@ mod tests {
             ..Default::default()
         };
         assert!(find_node_by_key(&node, wrong_short).is_none());
+    }
+
+    #[test]
+    fn find_node_by_key_empty_target_key_never_matches() {
+        // An empty target_key would produce cmp_len=0 and ""[..0]==""[..0] which
+        // is always true — guard against that authorization bypass.
+        let node = SemanticNode {
+            stable_key: Some("abcdef1234567890".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            find_node_by_key(&node, "").is_none(),
+            "empty target_key must not match any node"
+        );
     }
 
     #[test]

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub use sre::{
 pub use browser::{
     is_browser_disconnected, ActionLogEntry, BrowserClient, PageSession, SemanticTarget,
     SemanticWaitOptions, SemanticWaitState, SomMark, SomTrigger, VisualCapture,
+    STABLE_KEY_SHORT_LEN,
 };
 pub mod error;
 pub use audit_sink::DurabilityMode;

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -8,6 +8,7 @@ use core_runtime::{
     ActionError, ApprovalScope, BrowserClient, DeltaPolicy, PageSession, PolicyRule,
     PromptInjectionMode, PromptInjectionSanitizer, PromptInjectionSanitizerConfig, SemanticState,
     SemanticTarget, SemanticWaitState, SessionError, StateUpdate, VerifyError,
+    STABLE_KEY_SHORT_LEN,
 };
 use plugin_host::{ExtractionRule, SchemaRegistry};
 use serde::{Deserialize, Serialize};
@@ -1464,11 +1465,13 @@ impl CoreRuntimeBackend {
         speculative: bool,
     ) -> Result<ExternalInteractiveElement> {
         let id = node.backend_node_id;
-        let stable_key = node
-            .stable_key
-            .clone()
-            .filter(|key| !key.trim().is_empty())
-            .unwrap_or_else(|| fallback_stable_key(&node));
+        let stable_key = shorten_key(
+            &node
+                .stable_key
+                .clone()
+                .filter(|key| !key.trim().is_empty())
+                .unwrap_or_else(|| fallback_stable_key(&node)),
+        );
         let alias = node
             .alias
             .clone()
@@ -1776,7 +1779,7 @@ impl McpBackend for CoreRuntimeBackend {
                 .map(|mark| {
                     json!({
                         "id": mark.id,
-                        "stable_key": mark.stable_key,
+                        "stable_key": mark.stable_key.as_deref().map(shorten_key),
                         "bbox": mark.bbox
                     })
                 })
@@ -2339,6 +2342,12 @@ fn infer_policy_flags(node: &SemanticNode) -> Vec<String> {
     flags
 }
 
+/// Truncate a full SHA-256 hex key to the external short form.
+/// If the input is already shorter than `STABLE_KEY_SHORT_LEN`, it is returned as-is.
+fn shorten_key(key: &str) -> String {
+    key.chars().take(STABLE_KEY_SHORT_LEN).collect()
+}
+
 fn fallback_stable_key(node: &SemanticNode) -> String {
     let mut hasher = Sha256::new();
     hasher.update(node.role.as_bytes());
@@ -2346,7 +2355,7 @@ fn fallback_stable_key(node: &SemanticNode) -> String {
     hasher.update(node.label.clone().unwrap_or_default().as_bytes());
     hasher.update(b":");
     hasher.update(node.backend_node_id.to_string().as_bytes());
-    hex::encode(hasher.finalize())
+    shorten_key(&hex::encode(hasher.finalize()))
 }
 
 fn fallback_alias(node: &SemanticNode, stable_key: &str) -> String {
@@ -2619,6 +2628,37 @@ mod tests {
             },
             LoadProfile::Interactive,
         )
+    }
+
+    #[test]
+    fn shorten_key_truncates_64_char_sha256_to_16() {
+        let full = "a".repeat(64);
+        assert_eq!(shorten_key(&full), "a".repeat(16));
+    }
+
+    #[test]
+    fn shorten_key_leaves_short_strings_unchanged() {
+        assert_eq!(shorten_key("abc"), "abc");
+    }
+
+    #[test]
+    fn fallback_stable_key_returns_16_hex_chars() {
+        let node = SemanticNode {
+            role: "button".to_string(),
+            label: Some("Submit".to_string()),
+            backend_node_id: 42,
+            ..make_node(42, vec![])
+        };
+        let key = fallback_stable_key(&node);
+        assert_eq!(
+            key.len(),
+            16,
+            "fallback_stable_key must return 16-char key, got {key:?}"
+        );
+        assert!(
+            key.chars().all(|c| c.is_ascii_hexdigit()),
+            "fallback_stable_key must be hex, got {key:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #174

## Summary

- `ExternalInteractiveElement.stable_key` truncated from 64 to 16 hex chars (64 bits)
- SoM marks (`get_visual`) likewise truncated for consistency
- `stable_key_index` in `PageSession` keyed by 16-char short form; `lookup_backend_node_id_by_stable_key` normalises both 16-char (agent) and 64-char (internal) inputs to 16 chars before lookup
- `STABLE_KEY_SHORT_LEN = 16` exported from `core-runtime` and imported by `mcp-server` — mismatch is now a compile error, not a silent runtime failure
- Internal `SemanticNode.stable_key` and audit logs retain the full 64-char SHA-256

## Expected token impact

| Fixture | Before | After (est.) | Δ |
|---|---|---|---|
| spa-like.html (290 elements) | 22,993 tok | ~19,500 tok | −3,480 tok (~15%) |
| simple.html | 3,465 tok | ~3,100 tok | −365 tok (~11%) |

## Exit Criteria (ISSUE-174)

- [x] `stable_key` in `ExternalSemanticState` truncated to 16 hex chars
- [x] Internal representation and audit log retain full 64-char key
- [x] Self-healing (`DOMSignatureCache`) uses full key internally; lookup normalises to short form
- [x] New unit tests: `shorten_key_truncates_64_char_sha256_to_16`, `shorten_key_leaves_short_strings_unchanged`, `fallback_stable_key_returns_16_hex_chars`
- [x] All existing tests pass (`cargo test --workspace`)

## Review & QA

- Code review (internal): 0 CRITICAL, 1 HIGH (constant duplication) — fixed by exporting `STABLE_KEY_SHORT_LEN` from `core-runtime`
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --all`: clean
- `cargo test --workspace`: all pass