### PR TITLE
[ISSUE-176] Add MVP operations runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dragon Head: Neural-Browser Runtime
 
-**Last updated:** 2026-06-27
+**Last updated:** 2026-06-28
 
 Dragon Head is an AI-native headless browser runtime for LLM and VLM agents.
 It exposes a browser session as a structured **Semantic State** and provides an
@@ -408,6 +408,17 @@ Run formatting and lint checks:
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 ```
+
+## Operations and Runbooks
+
+- [Operations Guide](docs/operations.md) — day-to-day startup, Chrome
+  configuration, log locations, Session Vault key handling, and upgrade steps.
+- [Known Constraints](docs/known-constraints.md) — documented limitations for
+  first-call token overhead, load profiles, prompt-injection detection, Wasm
+  plugin signatures, and Chrome compatibility.
+- [Incident Response Runbook](docs/incident-response.md) — response procedures
+  for Chrome crash recovery, audit log failures, HITL timeouts, and browser
+  restart rate limits.
 
 ## Security: Prompt Injection Sanitization
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -25,7 +25,7 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 - [x] 必須CIチェック（`lint`, `test`, `smoke-e2e`, `cdp-smoke`, `policy-regression`, `policy-schema-lint`, `sre-regression`, `sre-semantic-delta`, `som-regression`, `mcp-protocol-compliance`, `mcp-api-schema-diff`, `mcp-schema-compatibility`）が安定してグリーンである。
 - [x] `SEC-01` / `SEC-02` / `AUD-01` の Exit Criteria（`PR-09`〜`PR-11`）がすべて満たされている。
 - [x] `PR-14` の Exit Criteria（MCPツール群の一貫利用）が満たされ、外部契約テストがCI必須化されている。
-- [ ] 利用手順・既知制約・障害時手順が `docs/` に明示され、運用可能な状態になっている。
+- [x] 利用手順・既知制約・障害時手順が `docs/` に明示され、運用可能な状態になっている。
 
 ## 2. フェーズダッシュボード
 
@@ -41,7 +41,7 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 | 7 | Marketplace | PR-17 | 1/1 | DONE |
 | 8 | Robustness & Verification | PR-18 | 1/1 | DONE |
 | 9 | Comprehensive Evaluation Bench | PR-19 | 1/1 | DONE |
-| 10 | Cathedral Edition (Commercialization) | PR-20〜29 | 9/10 | IN_PROGRESS |
+| 10 | Cathedral Edition (Commercialization) | PR-20〜29 | 10/10 | DONE |
 
 ## 3. PRバックログ（進捗チェック付き）
 

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,0 +1,108 @@
+# Incident Response Runbook
+
+**Last updated:** 2026-06-28
+
+Use this runbook when a production or evaluation workflow using
+`dragon-head-mcp` fails in a way that affects safety, auditability, or
+availability.
+
+## Chrome crash or disconnect
+
+Relevant behavior: PR-30 added typed Chrome crash/disconnect recovery. When an
+MCP tool call encounters a disconnected browser process, `mcp-server` attempts
+to relaunch Chrome through `CoreRuntimeBackend::handle_browser_disconnect`.
+
+Expected effects:
+
+- the current call returns a structured JSON-RPC error indicating that the
+  browser restarted or that restart failed;
+- `get_usage_report` increments `browser_restarts` after a successful restart;
+- `AuditEvent::BrowserRestart` is written to the audit logger;
+- in-page navigation state, cookies outside the Session Vault, DOM node IDs,
+  state cache, and speculative snapshots are reset;
+- policy rules are reapplied to the new page.
+
+Response steps:
+
+1. Check the MCP client error. If it reports `BrowserRestarted`, retry the
+   workflow from a safe checkpoint rather than blindly replaying the last
+   mutation.
+2. Call `get_usage_report` and record `browser_restarts`.
+3. Check stderr and persistent audit logs for `BrowserRestart` details.
+4. Re-establish required page state: navigate to the target URL, reload session
+   credentials from the vault if used, and call `get_state` with a suitable
+   load profile.
+5. If restarts repeat, stop the MCP client and inspect Chrome availability with
+   `dragon-head-mcp --doctor`.
+
+## Audit log write failure handling
+
+Persistent audit logs are created only when `AUDIT_LOG_DIR` or
+`audit.log_dir` is configured. If the rolling file sink cannot be created, the
+server emits an `[AUDIT][ERROR]` line to stderr and falls back to in-memory
+audit retention.
+
+Response steps:
+
+1. Treat persistent audit loss as a compliance-impacting incident for workflows
+   that require durable action records.
+2. Stop high-risk automation until the sink is restored.
+3. Check directory existence, permissions, free disk space, and mount health for
+   `AUDIT_LOG_DIR`.
+4. Fix the path or permissions and restart the MCP client.
+5. Run a low-risk `get_state` / `act` flow and confirm a new
+   `audit_<unix_ms>_<sequence>.ndjson` file receives events.
+6. If `AUDIT_DURABILITY=sync` causes unacceptable latency, switch to `flush`
+   only after documenting the durability tradeoff for that deployment.
+
+For `WebhookSink` SIEM delivery, failed HTTP delivery is best-effort and logs
+`[AUDIT][ERROR]` to stderr after retries. Restore SIEM availability and compare
+local rolling files with the SIEM ingestion window to identify gaps.
+
+## HITL escalation timeout handling
+
+HITL approvals can enter a pending state when policy requires human approval or
+when an action cannot be safely disambiguated. The MCP tool surface exposes
+`ask_human`, and the Slack/Teams reference bridge can poll and route approvals.
+
+Response steps:
+
+1. Inspect the failed or pending tool response for `requires_human_approval` or
+   `ask_human_required`.
+2. Confirm the approver channel or bridge is running. For Slack, check the
+   `hitl-bridge` process, its `SLACK_*` environment variables, and its audit
+   log path.
+3. If the bridge is unavailable, pause the workflow. Do not auto-approve by
+   replaying the mutation outside policy.
+4. If the approval is stale, reject or abandon the pending request and restart
+   from a fresh `get_state` so the human sees current page state.
+5. After resolution, verify that one decision was recorded in the bridge audit
+   log for the approval request.
+
+## Browser restart rate limit
+
+`mcp-server` limits browser restarts to 3 attempts within 60 seconds. The
+counter includes failed relaunch attempts so crash loops cannot spin forever.
+
+When the limit is hit, the backend returns an error similar to:
+
+```text
+browser restart rate limit exceeded (3 restarts within 60s); the Chrome process may be crash-looping
+```
+
+Response steps:
+
+1. Stop the MCP client to break the crash loop.
+2. Run `dragon-head-mcp --doctor` outside the client.
+3. Check whether Chrome was updated, removed, quarantined, or blocked by host
+   policy.
+4. Check system resources: memory pressure, process limits, disk space, and
+   sandbox restrictions.
+5. Restart the MCP client only after `--doctor` passes.
+6. If the issue returns on a specific page, reproduce with a narrow browser
+   integration test or a minimal URL and file a bug with stderr, audit events,
+   Chrome version, OS, and reproduction steps.
+
+Do not raise the restart limit as a first response. The limit is a safety
+guardrail that prevents repeated browser relaunches from hiding an underlying
+host or page-specific crash.

--- a/docs/known-constraints.md
+++ b/docs/known-constraints.md
@@ -1,0 +1,92 @@
+# Known Constraints
+
+**Last updated:** 2026-06-28
+
+This document lists current operational limitations that users should account
+for when deciding whether Dragon Head is the right browser runtime for a
+workflow.
+
+## First-call token overhead
+
+Dragon Head's first `get_state` payload can be larger than a hand-written
+Playwright custom extract because each semantic element carries metadata such
+as `stable_key`, `alias`, `backend_node_id`, and attributes used for reliable
+follow-up actions.
+
+The current benchmark report shows that Dragon Head's primary token advantage
+is expected in multi-step workflows, where the first full state is followed by
+small RFC 6902 delta payloads.
+
+Benchmark link: [`docs/bench-playwright-comparison.md`](bench-playwright-comparison.md).
+
+Use Dragon Head when selector stability, policy enforcement, HITL, audit, or
+delta delivery matter. For one-off extraction from a simple page, a minimal
+Playwright custom extract can be smaller.
+
+## Pages requiring `LoadProfile::Interactive`
+
+Some pages require `LoadProfile::Interactive` or a forced refresh to produce a
+usable semantic state:
+
+- heavy SPAs that populate controls after client-side hydration;
+- login-gated flows that render meaningful controls only after authentication;
+- pages whose controls are disabled until asynchronous validation completes;
+- pages where hidden or virtualized controls become available only after user
+  interaction.
+
+Lighter profiles are better for cost and latency, but they can under-report
+interactive controls on these page classes. Use `verify` before risky actions
+and prefer `Interactive` for workflows where missing a control is worse than a
+larger state payload.
+
+## Prompt injection detection is phrase-list based
+
+Prompt injection detection is a defense-in-depth signal, not a complete
+defense. The sanitizer scans labels, aliases, and attributes for built-in
+known-risk phrases plus optional `prompt_injection.additional_phrases` literals
+from `config.toml`.
+
+Detection normalizes a copy of the scanned text for HTML entities, NFKC,
+zero-width/control characters, and common confusables. It does not provide
+custom regular expressions, ML classification, or a guarantee that all indirect
+prompt injections will be found.
+
+Operational guidance:
+
+- Keep `prompt_injection.mode = "report_only"` unless a workflow has been
+  tested with redacted page text.
+- Treat `security_flags` as a risk signal for the agent and surrounding policy,
+  not as proof that the page is safe.
+- Add workflow-specific literals to `prompt_injection.additional_phrases` when
+  a deployment repeatedly sees domain-specific attack strings.
+
+## Wasm plugin signatures
+
+Wasm plugins are expected to pass manifest validation, capability declaration,
+SBOM checks, and signature verification before execution. This is intentional:
+plugins run at a trust boundary that can observe state or influence actions.
+
+Unsigned or incorrectly signed plugins should be rejected rather than bypassed
+in production. During development, use test fixtures or a development signing
+key and keep that key out of production trust roots.
+
+## Chrome/Chromium compatibility
+
+Dragon Head launches Chrome/Chromium through CDP via the `headless_chrome`
+crate. Compatibility depends on both the installed browser and the protocol
+surface exercised by a workflow.
+
+Supported operating assumptions:
+
+- Use a current stable Chrome or Chromium build where possible.
+- Run `dragon-head-mcp --doctor` on every host before configuring an MCP
+  client.
+- Set `CHROME_PATH` when a host has multiple browser builds or a non-standard
+  install location.
+- Browser-dependent tests are skipped unless Chrome is available and
+  `CHROME_INSTALLED=true` is set for the test run.
+
+Known risk: a browser update can change CDP behavior or timing. If a workflow
+starts failing after a Chrome update, rerun `--doctor`, reproduce with a narrow
+`cargo test -p core-runtime --test <test_name>` when possible, and pin or
+rollback the browser while investigating.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,186 @@
+# Operations Guide
+
+**Last updated:** 2026-06-28
+
+This guide covers day-to-day operation of the `dragon-head-mcp` stdio MCP
+server after installation. For installation commands and MCP client snippets,
+start with the root `README.md`.
+
+## Starting and stopping the MCP server
+
+`dragon-head-mcp` is a stdio server. In normal operation it is started and
+stopped by the MCP client, not by a long-running service manager.
+
+Start it from an MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "dragon-head": {
+      "command": "dragon-head-mcp",
+      "env": {
+        "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      }
+    }
+  }
+}
+```
+
+Before enabling the client entry, validate the local runtime:
+
+```bash
+dragon-head-mcp --doctor
+dragon-head-mcp --init codex
+```
+
+Stop the server by closing or reloading the MCP client session. If a client
+leaves a process behind, terminate the `dragon-head-mcp` process and restart
+the client. Running `dragon-head-mcp` directly in a terminal without stdin is a
+smoke test only; it exits when stdin closes.
+
+## Chrome path configuration and detection failures
+
+Chrome/Chromium is launched through the `headless_chrome` crate. Detection uses
+the default platform locations unless overridden.
+
+Configuration precedence:
+
+1. `CHROME_PATH` environment variable.
+2. `chrome_path` in `$XDG_CONFIG_HOME/dragon-head/config.toml`, falling back to
+   `$HOME/.config/dragon-head/config.toml`.
+3. Built-in Chrome/Chromium detection.
+
+Validate detection with:
+
+```bash
+dragon-head-mcp --doctor
+```
+
+Common failures:
+
+| Symptom | Check |
+| --- | --- |
+| `--doctor` cannot find Chrome | Install Chrome/Chromium or set `CHROME_PATH` to the executable path. |
+| GUI MCP client works in terminal but not in the app | Use an absolute `command` path or the `npx` form; GUI apps often do not inherit shell `PATH`. |
+| Wrong browser build starts | Set `CHROME_PATH` explicitly in the MCP client `env` block or `config.toml`. |
+| Config parse failure | Run `dragon-head-mcp --doctor`; malformed `config.toml`, invalid `prompt_injection.mode`, and invalid audit durability are fatal. |
+
+## Log locations
+
+There are two log surfaces: process diagnostics and audit events.
+
+### MCP stderr
+
+`dragon-head-mcp` prints startup, configuration, and warning messages to
+stderr. The location depends on the parent MCP client:
+
+- Terminal smoke run: visible in the terminal.
+- GUI MCP clients: captured by the client process or its app logs.
+- Service wrappers: captured by the wrapper's configured stderr sink.
+
+Expected startup lines include:
+
+```text
+dragon-head-mcp: starting...
+dragon-head-mcp: ready, listening on stdio
+```
+
+Security and audit misconfiguration warnings also go to stderr, for example
+non-default prompt-injection mode warnings or audit sink creation failures.
+
+### Audit log files
+
+Persistent audit logging is off unless an audit log directory is configured.
+Enable rolling NDJSON audit files with either environment variables or
+`config.toml`:
+
+```bash
+export AUDIT_LOG_DIR=/var/log/dragon-head
+export AUDIT_LOG_MAX_BYTES=10485760
+export AUDIT_DURABILITY=flush
+```
+
+```toml
+[audit]
+log_dir = "/var/log/dragon-head"
+max_bytes = 10485760
+durability = "flush"
+```
+
+Files are created as:
+
+```text
+audit_<unix_ms>_<sequence>.ndjson
+```
+
+`AUDIT_LOG_MAX_BYTES` controls rotation. `AUDIT_DURABILITY=flush` flushes the
+process buffer after each event; `sync` also calls `sync_data()` for stronger
+crash durability at lower throughput.
+
+If the audit directory cannot be created or opened, the server logs an
+`[AUDIT][ERROR]` message to stderr and falls back to in-memory audit retention
+so the MCP server can continue running.
+
+The Slack/Teams reference bridge has a separate audit trail controlled by its
+`--audit-log` argument; see [`hitl-slack-bridge.md`](hitl-slack-bridge.md).
+
+## Session Vault key management procedure
+
+`SessionVault` stores session cookies and token data through the
+`core-runtime::session_vault` trait. The default `BrowserClient` uses
+`LocalSessionVault` with a randomly generated in-process `SoftwareKms` key.
+That default is suitable for one running MCP process, but it is not a durable
+cross-process credential store.
+
+Operational rules:
+
+1. Treat vault data as secret material. Do not write decrypted session payloads
+   to logs, fixtures, PR comments, or screenshots.
+2. Use `save_to_vault(session_id)` only for sessions that are allowed to be
+   reused by the current MCP process.
+3. Use unique, purpose-specific session IDs. Avoid embedding user secrets in
+   the session ID.
+4. For integrations that need durable storage, provide an explicit
+   `SessionVault` implementation and a KMS-backed `KmsAdapter`; do not rely on
+   the default in-memory vault.
+5. Rotate keys by calling `rotate_key(new_key, new_key_id)` on the vault
+   implementation. Verify that existing sessions still load before retiring
+   the previous key material.
+6. After suspected key exposure, stop the MCP client, revoke the affected
+   website sessions upstream, rotate vault keys, and restart the client.
+
+Chrome crash recovery preserves the vault handle across relaunches, but the new
+page starts with a fresh browser session. Reload required credentials from the
+vault explicitly when the workflow depends on authenticated state after a
+restart.
+
+## Upgrading dragon-head-mcp safely
+
+1. Read the release notes and check for MCP protocol, config, policy, audit, or
+   prompt-injection mode changes.
+2. Run the current binary's health checks and record the output:
+
+   ```bash
+   dragon-head-mcp --version
+   dragon-head-mcp --doctor
+   ```
+
+3. Install the new binary through the same channel used for the old one:
+   npm, GitHub release asset, install script, or source build.
+4. Verify checksum files for downloaded release assets before replacing the
+   binary.
+5. Run the new binary checks:
+
+   ```bash
+   dragon-head-mcp --version
+   dragon-head-mcp --doctor
+   dragon-head-mcp --init codex
+   ```
+
+6. Restart the MCP client so it launches the new binary.
+7. Confirm the client can call `get_state` on a known safe page and that stderr
+   contains no new configuration or audit warnings.
+8. Keep the previous binary available until the first real workflow completes.
+
+If the new version changes `config.toml` or policy rule semantics, update the
+file first and run `--doctor` before restarting the MCP client.

--- a/scripts/check_mvp_docs.py
+++ b/scripts/check_mvp_docs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify MVP operational documentation required by Issue #176."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_DOCS = {
+    "docs/operations.md": [
+        "Starting and stopping",
+        "Chrome path",
+        "Log locations",
+        "Session Vault",
+        "Upgrading",
+    ],
+    "docs/known-constraints.md": [
+        "First-call token overhead",
+        "LoadProfile::Interactive",
+        "Prompt injection",
+        "Wasm plugin signatures",
+        "Chrome/Chromium compatibility",
+    ],
+    "docs/incident-response.md": [
+        "Chrome crash or disconnect",
+        "Audit log write failure",
+        "HITL escalation timeout",
+        "Browser restart rate limit",
+    ],
+}
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_required_docs_exist_and_cover_required_topics() -> None:
+    for path, topics in REQUIRED_DOCS.items():
+        doc_path = ROOT / path
+        assert doc_path.exists(), f"missing required document: {path}"
+        body = doc_path.read_text(encoding="utf-8")
+        for topic in topics:
+            assert topic in body, f"{path} does not cover required topic: {topic}"
+
+
+def test_readme_links_all_required_docs() -> None:
+    readme = read("README.md")
+    for path in REQUIRED_DOCS:
+        assert f"]({path})" in readme, f"README.md does not link {path}"
+
+
+def test_plan_marks_mvp_operational_docs_complete() -> None:
+    plan = read("docs/PLAN.md")
+    expected = (
+        "- [x] 利用手順・既知制約・障害時手順が `docs/` に明示され、"
+        "運用可能な状態になっている。"
+    )
+    assert expected in plan, "docs/PLAN.md does not mark the MVP docs condition complete"
+
+
+if __name__ == "__main__":
+    test_required_docs_exist_and_cover_required_topics()
+    test_readme_links_all_required_docs()
+    test_plan_marks_mvp_operational_docs_complete()


### PR DESCRIPTION
## Summary
- Adds `docs/operations.md`, `docs/known-constraints.md`, and `docs/incident-response.md` for the final MVP operational-docs condition.
- Links the new runbooks from `README.md` and marks the MVP docs condition / Phase 10 dashboard complete in `docs/PLAN.md`.
- Adds `scripts/check_mvp_docs.py` to mechanically verify the Issue #176 documentation contract.

Closes #176

## Acceptance Criteria
- [x] All three required documents exist under `docs/`
- [x] Each document is linked from `README.md`
- [x] MVP completion condition in `docs/PLAN.md` is checked off

## Verification
- `python3 scripts/check_mvp_docs.py`
- Markdown link check for README + new runbooks
- `git diff --cached --check` before commit
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`

## Review / QA
- gstack-review equivalent: cached diff scoped to Issue #176 docs/script only; no unresolved P1/P2 findings.
- gstack-qa-only equivalent: docs contract, README links, and workspace gates verified; no browser-facing target for this docs-only change.

## Notes
- The worktree still has an unstaged LFS fixture normalization diff (`core-runtime/tests/fixtures/som/som_visual_baseline.png`) caused by checkout/LFS pointer handling. It is intentionally excluded from this PR.