### PR TITLE
[ISSUE-186] Fail skill verify step for stable_key and malformed targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ resume.txt
 docs/ceo-plans/**
 temp/
 __pycache__/
+.venv/
+.tokensave/
+bench/results/

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -1734,8 +1734,30 @@ impl SkillRuntime for PageSkillRuntime<'_> {
                 },
             };
         }
-
-        OperationOutcome::Success
+        if let Some(key) = parse_target_stable_key(&target) {
+            // Refresh the SRE cache before lookup so we don't read stale state.
+            if let Err(err) = self.page.capture_semantic_state(LoadProfile::Interactive) {
+                return OperationOutcome::Failure {
+                    reason: err.to_string(),
+                };
+            }
+            let Some(id) = self.page.lookup_backend_node_id_by_stable_key(&key) else {
+                return OperationOutcome::Failure {
+                    reason: format!("element stable_key:{key} not found"),
+                };
+            };
+            return match self.page.verify_text(id, Some(&key), &expected) {
+                Ok(()) => OperationOutcome::Success,
+                Err(err) => OperationOutcome::Failure {
+                    reason: err.to_string(),
+                },
+            };
+        }
+        OperationOutcome::Failure {
+            reason: format!(
+                "unrecognised verify target {target:?}; expected id:<N> or stable_key:<key>"
+            ),
+        }
     }
 
     fn act(
@@ -3337,6 +3359,90 @@ mod tests {
         assert!(
             md.contains("security_flags=possible_prompt_injection,data_exfil_risk"),
             "multiple flags must be comma-joined in markdown: {md}"
+        );
+    }
+
+    // --- PageSkillRuntime::verify (ISSUE-186) ---
+
+    fn verify_step(target: &str, expected: &str) -> VerifyStep {
+        VerifyStep {
+            id: None,
+            target: target.to_string(),
+            expected: expected.to_string(),
+            control: Default::default(),
+        }
+    }
+
+    #[test]
+    fn skill_verify_fails_for_missing_stable_key_target() {
+        if test_bench_support::should_skip_browser_tests() {
+            eprintln!("SKIP: Chrome not available");
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        page.navigate("data:text/html,<html><body>hello</body></html>")
+            .expect("navigate");
+
+        let params = json!({});
+        let mut runtime = PageSkillRuntime::new(&page, &params);
+        let mut ctx = skills_engine::SkillExecutionContext::default();
+        let outcome = runtime.verify(&verify_step("stable_key:not-present", "hello"), &mut ctx);
+        assert!(
+            matches!(outcome, OperationOutcome::Failure { .. }),
+            "verify against a missing stable_key must fail, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn skill_verify_fails_for_malformed_target_syntax() {
+        if test_bench_support::should_skip_browser_tests() {
+            eprintln!("SKIP: Chrome not available");
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        page.navigate("data:text/html,<html><body>hello</body></html>")
+            .expect("navigate");
+
+        let params = json!({});
+        let mut runtime = PageSkillRuntime::new(&page, &params);
+        let mut ctx = skills_engine::SkillExecutionContext::default();
+        let outcome = runtime.verify(&verify_step("body", "hello"), &mut ctx);
+        assert!(
+            matches!(outcome, OperationOutcome::Failure { .. }),
+            "verify with unsupported target syntax must fail, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn skill_verify_passes_for_matching_stable_key_target() {
+        if test_bench_support::should_skip_browser_tests() {
+            eprintln!("SKIP: Chrome not available");
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        page.navigate("data:text/html,<html><body><button>Click me</button></body></html>")
+            .expect("navigate");
+        let state = page
+            .capture_semantic_state(LoadProfile::Interactive)
+            .expect("capture semantic state");
+        let stable_key = state
+            .root()
+            .children
+            .iter()
+            .find_map(|n| n.stable_key.clone())
+            .expect("button should have a stable_key");
+
+        let params = json!({});
+        let mut runtime = PageSkillRuntime::new(&page, &params);
+        let mut ctx = skills_engine::SkillExecutionContext::default();
+        let target = format!("stable_key:{stable_key}");
+        let outcome = runtime.verify(&verify_step(&target, "Click me"), &mut ctx);
+        assert!(
+            matches!(outcome, OperationOutcome::Success),
+            "verify against matching stable_key should succeed, got {outcome:?}"
         );
     }
 }

--- a/npm/dragon-head-mcp/package.json
+++ b/npm/dragon-head-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragon-head-mcp",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "AI-native headless browser runtime MCP server (npm distribution wrapper)",
   "license": "MIT",
   "repository": {
@@ -21,10 +21,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "dragon-head-mcp-darwin-arm64": "0.2.0",
-    "dragon-head-mcp-darwin-x64": "0.2.0",
-    "dragon-head-mcp-linux-x64": "0.2.0",
-    "dragon-head-mcp-linux-arm64": "0.2.0",
-    "dragon-head-mcp-win32-x64": "0.2.0"
+    "dragon-head-mcp-darwin-arm64": "0.1.0",
+    "dragon-head-mcp-darwin-x64": "0.1.0",
+    "dragon-head-mcp-linux-x64": "0.1.0",
+    "dragon-head-mcp-linux-arm64": "0.1.0",
+    "dragon-head-mcp-win32-x64": "0.1.0"
   }
 }

--- a/npm/dragon-head-mcp/package.json
+++ b/npm/dragon-head-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragon-head-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI-native headless browser runtime MCP server (npm distribution wrapper)",
   "license": "MIT",
   "repository": {
@@ -21,10 +21,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "dragon-head-mcp-darwin-arm64": "0.1.0",
-    "dragon-head-mcp-darwin-x64": "0.1.0",
-    "dragon-head-mcp-linux-x64": "0.1.0",
-    "dragon-head-mcp-linux-arm64": "0.1.0",
-    "dragon-head-mcp-win32-x64": "0.1.0"
+    "dragon-head-mcp-darwin-arm64": "0.2.0",
+    "dragon-head-mcp-darwin-x64": "0.2.0",
+    "dragon-head-mcp-linux-x64": "0.2.0",
+    "dragon-head-mcp-linux-arm64": "0.2.0",
+    "dragon-head-mcp-win32-x64": "0.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- `PageSkillRuntime::verify` only performed a real DOM check for `id:<N>` targets; `stable_key:<key>` and any other unrecognised target syntax silently returned `OperationOutcome::Success`, letting a skill proceed past an unverified `verify` step (Closes #186).
- Mirrors `locate`'s existing `stable_key` resolution path: refresh the SRE cache, resolve the stable key to a backend node id, then call `verify_text`. Unsupported target syntax now returns an explicit `OperationOutcome::Failure` with an actionable reason, matching `locate`'s behavior for unrecognised queries.

## Changes
- `mcp-server/src/lib.rs`: `PageSkillRuntime::verify` handles `stable_key:<key>` targets and fails explicitly for unsupported syntax instead of returning `Success`.
- Added 3 regression tests (browser-dependent, gated by `test_bench_support::should_skip_browser_tests()`), exercising the exact `PageSkillRuntime::verify` code path directly:
  - `skill_verify_fails_for_missing_stable_key_target`
  - `skill_verify_fails_for_malformed_target_syntax`
  - `skill_verify_passes_for_matching_stable_key_target`

## Test plan
- [x] `cargo test -p mcp-server --lib skill_verify` — 3/3 new tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p mcp-server --all-targets -- -D warnings` — clean
- [x] `CHROME_INSTALLED=true cargo nextest run --workspace --profile ci` — 696/696 pass
- [x] Code review (via `/code-review` skill): no CRITICAL/HIGH issues found — change is scoped, mirrors existing `locate` error-handling pattern, no security concerns
- [x] QA: backend-only change with no browser-facing UI surface; real-Chrome coverage is provided directly by the new unit tests, which exercise the exact `PageSkillRuntime::verify` path end-to-end against a live `PageSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)