### PR TITLE
[ISSUE-187] Emit TOOL_CALL audit event for run_skill

### DIFF
--- a/core-runtime/src/browser/mod.rs
+++ b/core-runtime/src/browser/mod.rs
@@ -992,6 +992,23 @@ impl PageSession {
         Ok(())
     }
 
+    /// Record a top-level `TOOL_CALL` audit event for a `run_skill` request.
+    ///
+    /// Mirrors the `act`/`verify_text` tool-call logging so every `run_skill`
+    /// request is captured in the audit trail per Spec §AUD-01, even when the
+    /// skill's steps never reach an `act` call or the skill fails outright
+    /// (ISSUE-187).
+    pub fn log_skill_tool_call(&self, skill_name: &str, params: &serde_json::Value) {
+        self.audit_logger.log(AuditEvent::ToolCall {
+            tool_name: "run_skill".to_string(),
+            args: serde_json::json!({
+                "skill_name": skill_name,
+                "params": params
+            }),
+            timestamp: epoch_millis_u64(),
+        });
+    }
+
     /// Verify element text against an expected value.
     /// On mismatch, triggers a SoM capture to help disambiguate recovery.
     ///

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -1475,6 +1475,9 @@ impl McpBackend for CoreRuntimeBackend {
         let args: RunSkillArguments =
             serde_json::from_value(arguments).context("invalid run_skill arguments")?;
 
+        self.page
+            .log_skill_tool_call(&args.skill_name, &args.params);
+
         let Some(skill) = self.skills.get(&args.skill_name).cloned() else {
             return Ok(json!({
                 "status": "not_found",

--- a/mcp-server/tests/mcp_run_skill_audit.rs
+++ b/mcp-server/tests/mcp_run_skill_audit.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+
+use core_runtime::audit::AuditEvent;
+use core_runtime::BrowserClient;
+use mcp_server::{CoreRuntimeBackend, McpServer};
+use serde_json::json;
+
+/// ISSUE-187: `run_skill` must emit a top-level `TOOL_CALL` audit event for the
+/// skill request itself, mirroring `act`/`verify_text`, even when the skill's
+/// steps never reach an `act` call.
+#[test]
+fn run_skill_emits_top_level_tool_call_audit_event() -> Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.navigate("data:text/html,<html><body>hello</body></html>")?;
+
+    let mut backend = CoreRuntimeBackend::new(page);
+    backend.register_skill_json(&json!({
+        "schema_version": 1,
+        "name": "locate_only",
+        "steps": [
+            {
+                "type": "locate",
+                "query": "id:999999"
+            }
+        ]
+    }))?;
+
+    let mut server = McpServer::new(backend);
+    server.backend_mut().page().clear_audit_events();
+
+    // The locate step targets a nonexistent id, so the skill fails, but the
+    // top-level run_skill request must still be recorded.
+    server.call_tool("run_skill", json!({"skill_name": "locate_only"}))?;
+
+    let events = server.backend_mut().page().audit_events();
+    let found = events.iter().any(|event| {
+        matches!(
+            event,
+            AuditEvent::ToolCall { tool_name, .. } if tool_name == "run_skill"
+        )
+    });
+    assert!(
+        found,
+        "expected a TOOL_CALL(run_skill) audit event, got: {events:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- `run_skill` previously recorded no top-level `TOOL_CALL` audit event for the skill request itself — only step-level side effects (e.g. `act` steps) produced audit entries. This violated `AUD-01` (`docs/SPEC.md`), which specifies `TOOL_CALL` covers Act/Verify/**Skill** requests.
- Adds `PageSession::log_skill_tool_call` (mirrors the existing `act`/`verify_text` pattern) and calls it from `CoreRuntimeBackend::run_skill` before skill lookup, so both the `not_found` case and skill-failure case are captured.
- `params` are sanitized the same way as other tool-call args via `AuditLogger::log`'s existing `redact_json_tool_args` call — no new PII/secret exposure.

Closes #187

## Exit Criteria (from issue acceptance criteria)

- [x] Regression test invokes `run_skill` and asserts a `TOOL_CALL` audit event is recorded for the skill request (including when the skill fails before reaching an `act` step).
- [x] Skill parameters sanitized consistently with other tool-call arguments (inherited from existing `AuditLogger::log` sanitization).
- [x] Existing per-step action/HITL usage metering behavior preserved (metering tests unaffected).

## Test plan

- [x] `cargo test -p mcp-server --test mcp_run_skill_audit` (new regression test, browser-dependent)
- [x] `cargo test -p mcp-server -p core-runtime -p skills-engine` — full suite green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p mcp-server -p core-runtime -p skills-engine --all-targets -- -D warnings`

## Review / QA

- `code-review` skill: no CRITICAL/HIGH/MEDIUM findings — minimal diff, reuses existing audit pattern, inherits sanitization.
- QA (report-only, backend-only change, no browser-facing UI): contract test exercises the real `CoreRuntimeBackend`/`McpServer` path including the negative case (skill fails); confirmed redaction consistency; all CI-relevant gates pass locally.