### PR TITLE
[ISSUE-199] Route AUDIT_LOG_STDOUT to stderr, fix stdio JSON-RPC corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ durability = "flush"  # "flush" (default) or "sync"
 | Audit log directory | `AUDIT_LOG_DIR` | `audit.log_dir` |
 | Audit max bytes | `AUDIT_LOG_MAX_BYTES` | `audit.max_bytes` |
 | Audit durability | `AUDIT_DURABILITY` | `audit.durability` |
+| Audit stdout mirroring | `AUDIT_LOG_STDOUT` | none |
+
+`AUDIT_LOG_STDOUT` (if set, any value) mirrors audit events to **stderr**, never
+stdout — `dragon-head-mcp` uses stdout for JSON-RPC framing, so writing there
+would corrupt the protocol stream.
 
 Run `dragon-head-mcp --doctor` to validate the config file. A malformed file, or
 an invalid `prompt_injection.mode` value, makes the "Config file" check fail.

--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -131,6 +131,7 @@ impl AuditLogger {
     /// | `AUDIT_LOG_DIR`       | *(unset)*        | Directory for rolling NDJSON files. If unset, no persistent sink is created. |
     /// | `AUDIT_LOG_MAX_BYTES` | `10485760` (10 MiB) | Rotate log file after this many bytes. `0` = never rotate. |
     /// | `AUDIT_DURABILITY`    | `flush`          | `flush` or `sync`. Use `sync` for crash-safe retention. |
+    /// | `AUDIT_LOG_STDOUT`    | *(unset)*        | If set (any value), also emit events to **stderr** (never stdout, which `dragon-head-mcp` reserves for JSON-RPC framing). |
     ///
     /// When `AUDIT_LOG_DIR` is unset the logger behaves identically to [`AuditLogger::new()`].
     /// Construction errors (bad dir, permission denied) are logged to stderr and fall back to
@@ -141,10 +142,13 @@ impl AuditLogger {
 
     /// Testable variant of [`from_env`] — accepts an env-lookup closure instead of reading
     /// `std::env` directly.  This avoids `set_var`/`remove_var` in tests, which are unsound
-    /// under parallel test runners (project rule #11).
+    /// under parallel test runners (project rule #11). Also covers `AUDIT_LOG_STDOUT`, which
+    /// [`from_env`] previously read via a direct `env::var` call bypassing this closure.
     pub fn from_env_with(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let stdout_enabled = lookup("AUDIT_LOG_STDOUT").is_some();
+
         let Some(dir) = lookup("AUDIT_LOG_DIR").filter(|s| !s.is_empty()) else {
-            return Self::new();
+            return Self::with_sinks_and_stdout(Vec::new(), None, stdout_enabled);
         };
 
         let max_bytes: u64 = lookup("AUDIT_LOG_MAX_BYTES")
@@ -169,29 +173,37 @@ impl AuditLogger {
                 eprintln!(
                     "[AUDIT][ERROR] Failed to create persistent sink at '{dir}': {e}. Falling back to in-memory only."
                 );
-                return Self::new();
+                return Self::with_sinks_and_stdout(Vec::new(), None, stdout_enabled);
             }
         };
 
         let metered = Arc::new(MeteredSink::new(sink));
         let handle = PersistentSinkHandle(Arc::clone(&metered));
         // Arc<MeteredSink<RollingFileSink>>: AuditSink via the blanket impl in audit_sink.rs.
-        Self::with_sinks(vec![Box::new(metered)], Some(handle))
+        Self::with_sinks_and_stdout(vec![Box::new(metered)], Some(handle), stdout_enabled)
     }
 
     /// Create a logger that fans every sanitized event out to `sinks` in
-    /// addition to the in-memory buffer and optional stdout output.
+    /// addition to the in-memory buffer and optional stderr output (see
+    /// `AUDIT_LOG_STDOUT`).
     ///
     /// For external callers that need custom sinks without a persistent-sink metrics handle.
     pub fn with_sinks(
         sinks: Vec<Box<dyn AuditSink>>,
         persistent: Option<PersistentSinkHandle>,
     ) -> Self {
+        Self::with_sinks_and_stdout(sinks, persistent, env::var("AUDIT_LOG_STDOUT").is_ok())
+    }
+
+    fn with_sinks_and_stdout(
+        sinks: Vec<Box<dyn AuditSink>>,
+        persistent: Option<PersistentSinkHandle>,
+        stdout_enabled: bool,
+    ) -> Self {
         const MAX_RECENT_EVENTS: usize = 512;
 
         let (sender, receiver) = unbounded::<AuditMessage>();
         let recent_events = Arc::new(Mutex::new(VecDeque::new()));
-        let stdout_enabled = env::var("AUDIT_LOG_STDOUT").is_ok();
         let recent_events_for_worker = Arc::clone(&recent_events);
 
         thread::spawn(move || {
@@ -235,7 +247,9 @@ impl AuditLogger {
 
                 if stdout_enabled {
                     if let Ok(json) = serde_json::to_string(&sanitized) {
-                        println!("[AUDIT] {}", json);
+                        // Never write to real stdout: dragon-head-mcp uses stdout for
+                        // JSON-RPC framing, so this would corrupt the protocol stream.
+                        eprintln!("[AUDIT] {}", json);
                     }
                 }
             }

--- a/core-runtime/tests/audit_stdout_stream.rs
+++ b/core-runtime/tests/audit_stdout_stream.rs
@@ -1,0 +1,67 @@
+/// Regression test for ISSUE-199: `AUDIT_LOG_STDOUT` must never write to the
+/// real stdout stream, because `dragon-head-mcp` uses stdout for JSON-RPC
+/// framing. Writing audit events there corrupts the protocol stream. The
+/// events must still reach stderr, so the feature keeps working.
+///
+/// The audit worker runs on a background thread, and Rust's default test
+/// harness silently redirects `println!`/`eprintln!` output from threads
+/// spawned during a test into its own in-memory capture buffer — so a plain
+/// in-process assertion cannot observe which real OS stream the bytes land
+/// on. To test the actual fix, this re-executes the compiled test binary as
+/// a child process filtered to just `audit_log_stdout_probe` with
+/// `--nocapture`, so the child's real stdout/stderr file descriptors (which
+/// `Command::output()` pipes independently) reflect exactly what the audit
+/// worker thread wrote.
+use core_runtime::audit::{AuditEvent, AuditLogger};
+use std::process::Command;
+use std::time::Duration;
+
+const CHILD_MARKER_ENV: &str = "DRAGON_HEAD_AUDIT_STDOUT_PROBE_CHILD";
+
+fn tool_call(n: u32) -> AuditEvent {
+    AuditEvent::ToolCall {
+        tool_name: format!("tool_{n}"),
+        args: serde_json::json!({ "n": n }),
+        timestamp: n as u64,
+    }
+}
+
+/// Child-process body: enables AUDIT_LOG_STDOUT purely through the lookup
+/// closure passed to `from_env_with` (never through the real environment) and
+/// logs one event. Only runs when re-exec'd with `CHILD_MARKER_ENV` set.
+#[test]
+fn audit_log_stdout_probe() {
+    if std::env::var(CHILD_MARKER_ENV).is_err() {
+        return; // Not the child invocation — no-op under a normal test run.
+    }
+
+    let logger = AuditLogger::from_env_with(|key| (key == "AUDIT_LOG_STDOUT").then(|| "1".into()));
+    logger.log(tool_call(1));
+    std::thread::sleep(Duration::from_millis(300));
+    drop(logger);
+}
+
+#[test]
+fn audit_log_stdout_env_routes_to_stderr_not_real_stdout() {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(exe)
+        .args(["audit_log_stdout_probe", "--exact", "--nocapture"])
+        .env(CHILD_MARKER_ENV, "1")
+        .output()
+        .expect("failed to spawn probe child process");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stdout.contains("[AUDIT]"),
+        "AUDIT_LOG_STDOUT must never write to real stdout (JSON-RPC framing \
+         channel); captured stdout: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("[AUDIT]") && stderr.contains("tool_1"),
+        "AUDIT_LOG_STDOUT (via the injected lookup closure passed to \
+         from_env_with) must still emit events, just on stderr; captured \
+         stderr: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `AuditLogger`'s worker thread wrote `AUDIT_LOG_STDOUT`-gated events to real stdout via `println!`. `dragon-head-mcp` uses stdout exclusively for JSON-RPC framing, so enabling this flag corrupted the protocol stream mid-session.
- `from_env_with(lookup)` also bypassed its own injected `lookup` closure for this one flag, reading the real process env directly — inconsistent with the rest of the function and untestable without mutating real env vars.
- Fix: thread `stdout_enabled` through `from_env_with`'s `lookup` closure into a new private `with_sinks_and_stdout` helper (the public `with_sinks` keeps its existing signature/behavior, reading the real env once). Emission changed `println!` → `eprintln!`, so events land on stderr instead of stdout.

Closes #199

## Test plan

- [x] New regression test `core-runtime/tests/audit_stdout_stream.rs`: re-execs the compiled test binary as a subprocess (works around Rust's test-harness capture of background-thread stdout/stderr) and asserts real stdout never contains `[AUDIT]` while stderr does, with `AUDIT_LOG_STDOUT` enabled purely via the injected lookup closure (no real env mutation).
- [x] Verified RED against pre-fix code (via `git stash`) and GREEN after the fix, under both `cargo test` and `cargo nextest run`.
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run -p core-runtime -p mcp-server`: 595 passed, 3 skipped, 0 failed (no regressions)
- [x] code-reviewer agent (gstack-review fallback): APPROVE, 0 critical/high/medium findings
- [x] Manual QA (gstack-qa fallback): re-ran the regression test directly — confirms the stdio protocol-safety contract `dragon-head-mcp` depends on