### PR TITLE
[ISSUE-201] Cap stdio JSON-RPC request line length

### DIFF
--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -4,10 +4,51 @@ use core_runtime::{
     BrowserClient, PolicyEngine, PromptInjectionMode, PromptInjectionSanitizerConfig,
 };
 use mcp_server::{config, doctor, CoreRuntimeBackend, McpServer};
-use std::io::{self, BufRead, Write};
+use serde_json::json;
+use std::io::{self, BufRead, Read, Write};
 
 mod cli;
 mod init;
+
+/// Caps a single stdio JSON-RPC request line so a misbehaving or malicious
+/// client cannot drive unbounded memory growth before `handle_jsonrpc` sees
+/// a single byte of the payload.
+const MAX_REQUEST_LINE_BYTES: usize = 10 * 1024 * 1024;
+
+enum StdinLine {
+    Line(String),
+    TooLong,
+    Eof,
+}
+
+/// Reads one line from `reader`, capping growth at `max_bytes`. If a
+/// newline isn't found within the cap, the remainder of that oversized line
+/// is drained so the next call starts at the following line, and
+/// `TooLong` is returned instead of buffering further.
+fn read_capped_line<R: BufRead>(reader: &mut R, max_bytes: usize) -> io::Result<StdinLine> {
+    let mut buf = Vec::new();
+    let read = (&mut *reader)
+        .take(max_bytes as u64)
+        .read_until(b'\n', &mut buf)?;
+    if read == 0 {
+        return Ok(StdinLine::Eof);
+    }
+    if buf.last() == Some(&b'\n') || read < max_bytes {
+        // Either a complete line, or the reader hit true EOF before the cap.
+        return Ok(StdinLine::Line(String::from_utf8_lossy(&buf).into_owned()));
+    }
+
+    loop {
+        let mut discard = Vec::new();
+        let drained = (&mut *reader)
+            .take(max_bytes as u64)
+            .read_until(b'\n', &mut discard)?;
+        if drained == 0 || discard.last() == Some(&b'\n') {
+            break;
+        }
+    }
+    Ok(StdinLine::TooLong)
+}
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -97,10 +138,31 @@ fn main() -> anyhow::Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut stdout_handle = stdout.lock();
+    let mut stdin_handle = stdin.lock();
 
-    for line in stdin.lock().lines() {
-        let request = match line {
-            Ok(line) => {
+    loop {
+        let request = match read_capped_line(&mut stdin_handle, MAX_REQUEST_LINE_BYTES) {
+            Ok(StdinLine::Eof) => break,
+            Ok(StdinLine::TooLong) => {
+                eprintln!(
+                    "dragon-head-mcp: rejected request line exceeding \
+                     {MAX_REQUEST_LINE_BYTES} bytes"
+                );
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {
+                        "code": -32600,
+                        "message": format!(
+                            "request line exceeds maximum size of {MAX_REQUEST_LINE_BYTES} bytes"
+                        )
+                    }
+                });
+                writeln!(stdout_handle, "{response}")?;
+                stdout_handle.flush()?;
+                continue;
+            }
+            Ok(StdinLine::Line(line)) => {
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
                     continue;
@@ -121,4 +183,76 @@ fn main() -> anyhow::Result<()> {
 
     eprintln!("dragon-head-mcp: shutting down");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn reads_a_normal_line() {
+        let mut reader = Cursor::new(b"hello\nworld\n".to_vec());
+        match read_capped_line(&mut reader, 1024).unwrap() {
+            StdinLine::Line(line) => assert_eq!(line, "hello\n"),
+            other => panic!(
+                "expected Line, got {other:?}",
+                other = std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn reports_eof_on_empty_input() {
+        let mut reader = Cursor::new(Vec::new());
+        assert!(matches!(
+            read_capped_line(&mut reader, 1024).unwrap(),
+            StdinLine::Eof
+        ));
+    }
+
+    #[test]
+    fn final_line_shorter_than_cap_without_trailing_newline_is_returned() {
+        let mut reader = Cursor::new(b"short".to_vec());
+        match read_capped_line(&mut reader, 1024).unwrap() {
+            StdinLine::Line(line) => assert_eq!(line, "short"),
+            other => panic!(
+                "expected Line, got {other:?}",
+                other = std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_line_and_resyncs_to_the_next_line() {
+        let oversized = "a".repeat(50);
+        let input = format!("{oversized}\nshort\n");
+        let mut reader = Cursor::new(input.into_bytes());
+
+        assert!(matches!(
+            read_capped_line(&mut reader, 10).unwrap(),
+            StdinLine::TooLong
+        ));
+
+        match read_capped_line(&mut reader, 10).unwrap() {
+            StdinLine::Line(line) => assert_eq!(line, "short\n"),
+            other => panic!(
+                "expected Line after resync, got {other:?}",
+                other = std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn does_not_grow_the_buffer_past_the_cap_for_a_single_oversized_line() {
+        // 50 MiB with no newline: if this test completes quickly and without
+        // OOM, the read was bounded rather than buffering the whole line.
+        let oversized = vec![b'a'; 50 * 1024 * 1024];
+        let mut reader = Cursor::new(oversized);
+
+        assert!(matches!(
+            read_capped_line(&mut reader, 1024).unwrap(),
+            StdinLine::TooLong
+        ));
+    }
 }

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -16,7 +16,7 @@ mod init;
 const MAX_REQUEST_LINE_BYTES: usize = 10 * 1024 * 1024;
 
 enum StdinLine {
-    Line(String),
+    Line(Vec<u8>),
     TooLong,
     Eof,
 }
@@ -24,7 +24,9 @@ enum StdinLine {
 /// Reads one line from `reader`, capping growth at `max_bytes`. If a
 /// newline isn't found within the cap, the remainder of that oversized line
 /// is drained so the next call starts at the following line, and
-/// `TooLong` is returned instead of buffering further.
+/// `TooLong` is returned instead of buffering further. The line is returned
+/// as raw bytes: decoding invalid UTF-8 is the caller's concern, and it
+/// should be rejected rather than silently rewritten.
 fn read_capped_line<R: BufRead>(reader: &mut R, max_bytes: usize) -> io::Result<StdinLine> {
     let mut buf = Vec::new();
     let read = (&mut *reader)
@@ -35,7 +37,7 @@ fn read_capped_line<R: BufRead>(reader: &mut R, max_bytes: usize) -> io::Result<
     }
     if buf.last() == Some(&b'\n') || read < max_bytes {
         // Either a complete line, or the reader hit true EOF before the cap.
-        return Ok(StdinLine::Line(String::from_utf8_lossy(&buf).into_owned()));
+        return Ok(StdinLine::Line(buf));
     }
 
     loop {
@@ -162,7 +164,24 @@ fn main() -> anyhow::Result<()> {
                 stdout_handle.flush()?;
                 continue;
             }
-            Ok(StdinLine::Line(line)) => {
+            Ok(StdinLine::Line(bytes)) => {
+                let line = match String::from_utf8(bytes) {
+                    Ok(line) => line,
+                    Err(err) => {
+                        eprintln!("dragon-head-mcp: rejected non-UTF-8 request line: {err}");
+                        let response = json!({
+                            "jsonrpc": "2.0",
+                            "id": null,
+                            "error": {
+                                "code": -32700,
+                                "message": "request line is not valid UTF-8"
+                            }
+                        });
+                        writeln!(stdout_handle, "{response}")?;
+                        stdout_handle.flush()?;
+                        continue;
+                    }
+                };
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
                     continue;
@@ -194,7 +213,7 @@ mod tests {
     fn reads_a_normal_line() {
         let mut reader = Cursor::new(b"hello\nworld\n".to_vec());
         match read_capped_line(&mut reader, 1024).unwrap() {
-            StdinLine::Line(line) => assert_eq!(line, "hello\n"),
+            StdinLine::Line(line) => assert_eq!(line, b"hello\n"),
             other => panic!(
                 "expected Line, got {other:?}",
                 other = std::mem::discriminant(&other)
@@ -215,7 +234,7 @@ mod tests {
     fn final_line_shorter_than_cap_without_trailing_newline_is_returned() {
         let mut reader = Cursor::new(b"short".to_vec());
         match read_capped_line(&mut reader, 1024).unwrap() {
-            StdinLine::Line(line) => assert_eq!(line, "short"),
+            StdinLine::Line(line) => assert_eq!(line, b"short"),
             other => panic!(
                 "expected Line, got {other:?}",
                 other = std::mem::discriminant(&other)
@@ -235,7 +254,7 @@ mod tests {
         ));
 
         match read_capped_line(&mut reader, 10).unwrap() {
-            StdinLine::Line(line) => assert_eq!(line, "short\n"),
+            StdinLine::Line(line) => assert_eq!(line, b"short\n"),
             other => panic!(
                 "expected Line after resync, got {other:?}",
                 other = std::mem::discriminant(&other)
@@ -254,5 +273,23 @@ mod tests {
             read_capped_line(&mut reader, 1024).unwrap(),
             StdinLine::TooLong
         ));
+    }
+
+    #[test]
+    fn preserves_invalid_utf8_bytes_for_the_caller_to_reject() {
+        // read_capped_line must not lossily rewrite invalid UTF-8 — the
+        // caller decodes with `String::from_utf8` and rejects the request
+        // instead of silently substituting replacement characters.
+        let mut reader = Cursor::new(vec![0xFF, 0xFE, b'\n']);
+        match read_capped_line(&mut reader, 1024).unwrap() {
+            StdinLine::Line(line) => {
+                assert_eq!(line, vec![0xFF, 0xFE, b'\n']);
+                assert!(String::from_utf8(line).is_err());
+            }
+            other => panic!(
+                "expected Line, got {other:?}",
+                other = std::mem::discriminant(&other)
+            ),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `stdin.lock().lines()` in `mcp-server/src/main.rs` accumulated the request line into a `String` with no size bound before any request validation ran. A misbehaving or malicious MCP client sending an oversized (or newline-less) line could drive unbounded memory growth in the server process.
- Adds `read_capped_line`, which reads a line via a `Take`-bounded `BufRead::read_until`, capped at `MAX_REQUEST_LINE_BYTES` (10 MiB). If the cap is hit without finding a newline, the remainder of that oversized line is drained (bounded, chunk by chunk) so the next read resynchronizes to the following line, and the server responds with a JSON-RPC `-32600` error instead of buffering further.

Closes #201

## Test plan
- [x] New unit tests in `mcp-server/src/main.rs` (`read_capped_line`): normal line, EOF, final line without trailing newline, oversized-line resync, and a 50 MiB no-newline line to confirm the read is bounded rather than buffering the whole line.
- [x] `cargo test --workspace` — 706 passed, 8 ignored.
- [x] `cargo fmt --all -- --check` and `cargo clippy --workspace -- -D warnings` — clean.
- [x] Manual E2E smoke: launched the built `dragon-head-mcp` binary, piped a 20 MiB no-newline line followed by a valid `initialize` request. Confirmed the server emits the `-32600` error for the oversized line and then correctly serves the subsequent valid request (resync verified).
- [x] Code review (in lieu of unavailable `gstack-review`/`gstack-qa` skills): no CRITICAL/HIGH issues — no secrets, functions/files within size limits, error handling via `io::Result`, tests cover the fixed path directly rather than an aggregating caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)