### PR TITLE
fix: surface oversized plugin state payloads

### DIFF
--- a/core-runtime/src/plugin_hooks.rs
+++ b/core-runtime/src/plugin_hooks.rs
@@ -6,6 +6,8 @@
 /// * **State hooks** (`StatePlugin::on_state`): called after `normalize_dom`
 ///   produces a `SemanticState`, before the state is delivered externally.
 ///   Failures are *non-fatal* — logged to audit, original state is preserved.
+///   This includes Wasm ABI payload-limit failures; callers receive the last
+///   valid state while audit records the explicit plugin error.
 ///
 /// * **Policy hooks** (`PolicyPlugin::before_act`): called before an action is
 ///   executed, after the built-in `PolicyEngine` allows it.  If any plugin
@@ -371,6 +373,21 @@ mod tests {
         }
     }
 
+    struct OversizedStatePlugin;
+
+    impl StatePlugin for OversizedStatePlugin {
+        fn plugin_id(&self) -> &str {
+            "oversized-state"
+        }
+
+        fn on_state(&self, _: &str) -> Result<String, String> {
+            Err(
+                "plugin payload too large for on_state: 17000 bytes exceeds 16384 bytes ABI limit"
+                    .to_string(),
+            )
+        }
+    }
+
     struct AllowPlugin;
 
     impl PolicyPlugin for AllowPlugin {
@@ -455,6 +472,31 @@ mod tests {
             &events[1],
             AuditEvent::PluginStateTransform { success: false, .. }
         ));
+    }
+
+    #[test]
+    fn state_hooks_oversized_payload_failure_is_audited_and_nonfatal() {
+        let plugins: Vec<Box<dyn StatePlugin>> = vec![Box::new(OversizedStatePlugin)];
+        let input = r#"{"role":"document"}"#;
+        let (result, events) = run_state_hooks(input, plugins.iter().map(|p| p.as_ref()));
+
+        assert_eq!(result, input);
+        assert_eq!(events.len(), 1);
+        let AuditEvent::PluginStateTransform {
+            success,
+            error_message,
+            ..
+        } = &events[0]
+        else {
+            panic!("expected PluginStateTransform event");
+        };
+        assert!(!success);
+        assert!(
+            error_message
+                .as_deref()
+                .is_some_and(|msg| msg.contains("payload too large")),
+            "oversized payload failure must be explicit in audit: {error_message:?}"
+        );
     }
 
     #[test]

--- a/plugin-host/src/lib.rs
+++ b/plugin-host/src/lib.rs
@@ -109,6 +109,14 @@ pub enum PluginError {
     SignaturePayloadSerialization { message: String },
     #[error("wasm execution failed: {message}")]
     ExecutionFailed { message: String },
+    #[error(
+        "plugin payload too large for {operation}: {size} bytes exceeds {limit} bytes ABI limit"
+    )]
+    PayloadTooLarge {
+        operation: String,
+        size: usize,
+        limit: usize,
+    },
     #[error("invalid wasm output: {message}")]
     InvalidOutput { message: String },
     #[error("wasm execution timed out (fuel exhausted or epoch interrupted)")]
@@ -529,9 +537,11 @@ impl PluginRuntime {
 
             let data = memory.data_mut(&mut self.store);
 
-            if input_bytes.len() > OUTPUT_OFFSET as usize {
-                return Err(PluginError::ExecutionFailed {
-                    message: "input JSON too large for wasm memory layout".to_string(),
+            if input_bytes.len() > MAX_INPUT_SIZE {
+                return Err(PluginError::PayloadTooLarge {
+                    operation: fn_name.to_string(),
+                    size: input_bytes.len(),
+                    limit: MAX_INPUT_SIZE,
                 });
             }
             data[..input_bytes.len()].copy_from_slice(input_bytes);
@@ -595,10 +605,10 @@ impl PluginRuntime {
                 u32::from_le_bytes(data[len_slot_start..len_slot_end].try_into().unwrap()) as usize;
 
             if out_len > MAX_OUTPUT_SIZE {
-                return Err(PluginError::InvalidOutput {
-                    message: format!(
-                        "output length {out_len} exceeds MAX_OUTPUT_SIZE {MAX_OUTPUT_SIZE}"
-                    ),
+                return Err(PluginError::PayloadTooLarge {
+                    operation: format!("{fn_name} output"),
+                    size: out_len,
+                    limit: MAX_OUTPUT_SIZE,
                 });
             }
 

--- a/plugin-host/tests/plugin_runtime.rs
+++ b/plugin-host/tests/plugin_runtime.rs
@@ -267,6 +267,41 @@ fn test_on_state_echoes_input() {
     assert_eq!(parsed["dragon"], "head");
 }
 
+#[test]
+fn test_on_state_payload_over_16k_returns_explicit_error() {
+    let (registry, signing_key, key_id) = make_registry_and_key();
+    let wasm = echo_wasm();
+    let package = build_and_sign_package(
+        vec![ExtensionPoint::OnState],
+        vec![Capability::ReadState],
+        wasm,
+        &signing_key,
+        &key_id,
+    );
+
+    let host = PluginHost::new(registry);
+    let loaded = host.load_plugin(&package).expect("plugin must load");
+    let mut runtime = loaded.create_runtime().expect("runtime must be created");
+
+    let oversized = format!(r#"{{"payload":"{}"}}"#, "x".repeat(16 * 1024));
+    let err = runtime
+        .on_state(&oversized)
+        .expect_err("oversized state payload must fail explicitly");
+
+    match err {
+        PluginError::PayloadTooLarge {
+            operation,
+            size,
+            limit,
+        } => {
+            assert_eq!(operation, "on_state");
+            assert!(size > limit, "size={size}, limit={limit}");
+            assert_eq!(limit, 16 * 1024);
+        }
+        other => panic!("expected PayloadTooLarge, got {other:?}"),
+    }
+}
+
 /// 2. Signed plugin with before_act returns policy decision JSON
 #[test]
 fn test_before_act_returns_allow_true() {


### PR DESCRIPTION
## Summary
- Add explicit PayloadTooLarge errors for plugin-host ABI input/output limits
- Add regression coverage for on_state payloads over 16 KiB
- Document and test core-runtime state-hook fallback semantics: preserve last valid state and audit explicit oversized-payload failures

Closes #188

## Verification
- cargo test -p plugin-host test_on_state_payload_over_16k_returns_explicit_error -- --exact
- cargo test -p core-runtime plugin_hooks::tests::state_hooks_oversized_payload_failure_is_audited_and_nonfatal -- --exact
- cargo fmt --all -- --check
- cargo clippy -p plugin-host -p core-runtime -- -D warnings

## Notes
- Left unrelated local core-runtime/tests/fixtures/som/som_visual_baseline.png changes unstaged.