### PR TITLE
fix: add built-in SSN and phone PII redaction

### DIFF
--- a/core-runtime/src/privacy.rs
+++ b/core-runtime/src/privacy.rs
@@ -8,7 +8,7 @@ use crate::sre::state::{FastSemanticState, FullSemanticState, SemanticNode};
 /// A named regex pattern for domain-specific PII detection.
 ///
 /// Domain patterns are registered at startup and applied by `PiiRedactor`
-/// alongside the built-in email and credit-card patterns.
+/// alongside the built-in email, credit-card, SSN, and phone-number patterns.
 pub struct DomainPattern {
     pub name: String,
     regex: Regex,
@@ -60,10 +60,12 @@ impl PiiRedactor {
     // -------------------------------------------------------------------------
 
     /// Redact PII embedded in freeform text (email addresses, card numbers,
-    /// then domain patterns).
+    /// SSNs, phone numbers, then domain patterns).
     pub fn redact_text(&self, text: &str) -> String {
         static CC_RE: OnceLock<Regex> = OnceLock::new();
         static EMAIL_RE: OnceLock<Regex> = OnceLock::new();
+        static SSN_RE: OnceLock<Regex> = OnceLock::new();
+        static PHONE_RE: OnceLock<Regex> = OnceLock::new();
 
         let cc_re = CC_RE
             .get_or_init(|| Regex::new(r"\b\d(?:[ -]?\d){12,18}\b").expect("Invalid CC regex"));
@@ -71,12 +73,20 @@ impl PiiRedactor {
             Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
                 .expect("Invalid email regex")
         });
+        let ssn_re =
+            SSN_RE.get_or_init(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").expect("Invalid SSN regex"));
+        let phone_re = PHONE_RE.get_or_init(|| {
+            Regex::new(r"(?:\+1[ .-]?)?(?:\([2-9]\d{2}\)|[2-9]\d{2})[ .-]\d{3}[ .-]\d{4}\b")
+                .expect("Invalid phone regex")
+        });
 
         let after_cc = cc_re.replace_all(text, "****-****-****-XXXX");
         let after_email = email_re.replace_all(after_cc.as_ref(), "***");
+        let after_ssn = ssn_re.replace_all(after_email.as_ref(), "[SSN]");
+        let after_phone = phone_re.replace_all(after_ssn.as_ref(), "[PHONE]");
 
         // Apply domain-specific patterns sequentially.
-        let mut result = after_email.into_owned();
+        let mut result = after_phone.into_owned();
         for dp in &self.domain_patterns {
             let replaced = dp.regex.replace_all(&result, dp.replacement.as_str());
             if matches!(replaced, std::borrow::Cow::Owned(_)) {
@@ -343,6 +353,21 @@ mod tests {
         assert_eq!(
             r.redact_text("Card 4111-1111-1111-1111 ok"),
             "Card ****-****-****-XXXX ok"
+        );
+    }
+
+    #[test]
+    fn redact_text_masks_ssn() {
+        let r = redactor();
+        assert_eq!(r.redact_text("SSN 123-45-6789"), "SSN [SSN]");
+    }
+
+    #[test]
+    fn redact_text_masks_phone_number() {
+        let r = redactor();
+        assert_eq!(
+            r.redact_text("Call +1 (415) 555-0100 today"),
+            "Call [PHONE] today"
         );
     }
 

--- a/core-runtime/tests/pii_redaction.rs
+++ b/core-runtime/tests/pii_redaction.rs
@@ -2,7 +2,7 @@
 /// or the Audit Sink (Exit Criteria for PR-27 / ISSUE-17).
 use core_runtime::{
     audit::{AuditEvent, AuditLogger},
-    privacy::{DomainPattern, PiiRedactor},
+    privacy::PiiRedactor,
     sre::{AsyncPipeline, AsyncPipelineConfig, LoadProfile, SemanticNode, SemanticState},
 };
 use serde_json::json;
@@ -59,14 +59,22 @@ fn pii_redactor_masks_email_and_cc_in_text() {
 }
 
 #[test]
-fn pii_redactor_domain_pattern_masks_ssn() {
-    // US SSN format (9 digits with dashes) does not match the CC regex (13-19 digits),
-    // so it should be caught exclusively by the domain pattern.
-    let dp = DomainPattern::new("ssn", r"\b\d{3}-\d{2}-\d{4}\b", "[SSN]").unwrap();
-    let r = PiiRedactor::with_domain_patterns(vec![dp]);
+fn pii_redactor_builtin_masks_ssn() {
+    let r = PiiRedactor::new();
     let out = r.redact_text("SSN: 123-45-6789 on file");
     assert!(!out.contains("123-45-6789"), "SSN must be masked");
     assert!(out.contains("[SSN]"));
+}
+
+#[test]
+fn pii_redactor_builtin_masks_phone_number() {
+    let r = PiiRedactor::new();
+    let out = r.redact_text("Phone: (415) 555-0100");
+    assert!(
+        !out.contains("(415) 555-0100"),
+        "phone number must be masked"
+    );
+    assert!(out.contains("[PHONE]"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add built-in SSN and US phone-number redaction to PiiRedactor defaults
- Cover default SSN and phone masking in core-runtime PII integration tests

Closes #212

## Verification
- cargo test -p core-runtime --test pii_redaction
- cargo test -p core-runtime privacy::tests::redact_text_masks_phone_number -- --exact
- cargo fmt --all -- --check
- cargo clippy -p core-runtime -- -D warnings

## Notes
- Left unrelated local core-runtime/tests/fixtures/som/som_visual_baseline.png changes unstaged.