### PR TITLE
docs: align agent docs with current tool contract

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,7 +22,7 @@ The project uses `just` as a command runner for common development tasks.
 | Command | Description |
 | :--- | :--- |
 | `just check` | Runs `cargo check` across the entire workspace. |
-| `just build` | Builds the project (standard `cargo build` is used). |
+| `cargo build` | Builds the workspace. There is no `just build` recipe in the current `Justfile`. |
 | `just fmt` | Formats all code using `cargo fmt`. |
 | `just lint` | Runs `clippy` with strict warnings enabled (`-D warnings`). |
 | `just test` | Executes all unit and integration tests. |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/takurot/dragon-head/actions/workflows/ci.yml/badge.svg)](https://github.com/takurot/dragon-head/actions/workflows/ci.yml)
 [![Nightly E2E](https://github.com/takurot/dragon-head/actions/workflows/e2e.yml/badge.svg)](https://github.com/takurot/dragon-head/actions/workflows/e2e.yml)
 
-**Last updated:** 2026-06-28
+**Last updated:** 2026-07-06
 
 Dragon Head is an AI-native headless browser runtime for LLM and VLM agents.
 It exposes a browser session as a structured **Semantic State** and provides an
@@ -353,7 +353,8 @@ specific Chromium build.
 
 ## Available MCP Tools
 
-`dragon-head-mcp` currently exposes these tools:
+`dragon-head-mcp` currently exposes 8 tools. The source of truth is
+`McpServer::tools()` in `mcp-server/src/lib.rs`:
 
 | Tool | Purpose |
 | --- | --- |
@@ -363,8 +364,8 @@ specific Chromium build.
 | `get_visual` | Capture visual context with optional marks. |
 | `ask_human` | Resolve a pending human-in-the-loop request. |
 | `run_skill` | Execute a declarative skill workflow. |
-| `extract` | Run Deep Lens extraction with prompt-injection `security_flags`. |
 | `get_usage_report` | Retrieve usage meters and plan tier summary. |
+| `extract` | Run Deep Lens extraction with prompt-injection `security_flags`. |
 
 ## Developer Examples
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -1,130 +1,109 @@
 # AI_CONTEXT.md
 
-> Read this file first. It is a map, not a manual — use it to decide which other
-> file to open next, instead of exploring the whole repo.
+**Last updated:** 2026-07-06
 
-## What this project is
+Read this first. It is a map for deciding which files to open next; it is not a
+full manual.
 
-Dragon Head is an AI-native **headless browser runtime** for LLM/VLM agents. It
-wraps a Chrome/CDP session and exposes it to an agent as a compact, structured
-**Semantic State** (an accessibility-tree-like JSON, not raw HTML/DOM) via a
-stdio **MCP server** binary, `dragon-head-mcp`. The agent inspects pages, acts
-on elements, verifies outcomes, requests human approval, and runs declarative
-skills — all through 7 MCP tools.
+## What This Project Is
 
-## Primary users
+Dragon Head is an AI-native headless browser runtime for LLM/VLM agents. It
+wraps a Chrome/Chromium CDP session and exposes compact, structured
+**Semantic State** through the `dragon-head-mcp` stdio MCP server. Agents use
+the MCP tools to inspect pages, act on stable targets, verify outcomes, request
+human approval, run declarative skills, extract structured data, and inspect
+usage meters.
 
-- AI coding/browsing agents (Claude, GPT, etc.) connected via an MCP client
-  (Claude Desktop, Claude Code, Codex, or any MCP-compatible client).
-- Developers embedding `core-runtime` directly as a Rust library (no MCP).
+The current MCP tool contract has 8 tools, defined in `McpServer::tools()` in
+`mcp-server/src/lib.rs`:
 
-## Primary use cases
+- `get_state`
+- `act`
+- `verify`
+- `get_visual`
+- `ask_human`
+- `run_skill`
+- `get_usage_report`
+- `extract`
 
-- Web automation/testing driven by an LLM (navigate, click, fill forms, verify
-  text) without feeding raw HTML/screenshots into the model.
-- Human-in-the-loop (HITL) gated actions (e.g. financial transactions) via
-  policy rules + Slack/Teams approval (`hitl-bridge`).
-- Declarative, reusable browser workflows ("skills") instead of ad-hoc agent
-  exploration on every run.
+## Primary Users
 
-## Tech stack
+- AI coding or browsing agents connected through MCP clients such as Claude
+  Desktop, Claude Code, Codex, or any MCP-compatible client.
+- Rust developers embedding `core-runtime` directly without the MCP layer.
 
-- **Language**: Rust (stable, see `rust-toolchain.toml`), workspace of 8 crates.
-- **Browser control**: `headless_chrome` (CDP), Chrome/Chromium required at
-  runtime (not vendored).
-- **Protocol**: MCP (JSON-RPC over stdio).
-- **Plugins**: WebAssembly via `wasmtime` (`plugin-host`).
-- **Testing**: `cargo nextest`, integration tests under `tests/` per crate.
-- **CI**: GitHub Actions (`.github/workflows/ci.yml`, `e2e.yml`, `release.yml`).
+## Tech Stack
 
-## Key commands
+- **Language:** Rust stable, pinned by `rust-toolchain.toml`.
+- **Workspace:** 8 crates listed in the root `Cargo.toml`.
+- **Browser control:** `headless_chrome` over CDP; Chrome/Chromium is required
+  at runtime and is not vendored.
+- **Protocol:** MCP JSON-RPC over stdio.
+- **Plugins:** WebAssembly via `wasmtime` in `plugin-host`.
+- **Testing:** `cargo nextest`, crate-local integration tests, and
+  browser-dependent tests that skip unless Chrome is available.
+- **CI:** GitHub Actions in `.github/workflows/ci.yml`, `e2e.yml`, and
+  `release.yml`.
+
+## Common Commands
 
 ```bash
-just check              # cargo check --workspace
-just test               # cargo nextest run --workspace
-just test-ci             # nextest --profile ci (what CI runs)
-just lint                # cargo clippy --workspace -- -D warnings
-just fmt                 # cargo fmt --all
-just test-all            # test + lint + fmt
+just check
+just test
+just test-ci
+just lint
+just fmt
+just test-all
 cargo run -p mcp-server --bin dragon-head-mcp -- --doctor
 ```
-See `DEVELOPMENT_GUIDE.md` for the full list.
 
-## Key directories
+There is no `just build` recipe in the current `Justfile`; use `cargo build`.
+
+## Key Directories
 
 | Path | What it is |
 |---|---|
 | `core-runtime/` | Chrome/CDP session, Semantic State, policy, audit, privacy, plugins, speculative state |
-| `mcp-server/` | The `dragon-head-mcp` stdio binary and tool dispatch — **start here for tool behavior** |
-| `skills-engine/` | Declarative skill (workflow) definitions and execution |
-| `plugin-host/` | Wasm plugin manifest validation + sandboxed execution |
+| `mcp-server/` | `dragon-head-mcp` binary, MCP tool dispatch, config, doctor/init commands |
+| `skills-engine/` | Declarative browser workflow definitions and execution |
+| `plugin-host/` | Wasm plugin manifest validation and sandboxed execution |
 | `marketplace/` | Plugin/domain-pack metadata and revenue-share primitives |
-| `hitl-bridge/` | Slack/Teams human-approval bridge for `ask_human` |
-| `bench/`, `nfr-baseline/` | Performance benchmarking and regression baselines |
-| `docs/` | Spec, plan, and this onboarding doc set |
-| `examples/` | Runnable, Chrome-free examples (`cargo run --example quickstart`) |
+| `hitl-bridge/` | Slack/Teams human approval bridge for `ask_human` flows |
+| `bench/`, `nfr-baseline/` | Performance benchmarks and regression baselines |
+| `docs/` | Spec, architecture, operational docs, and agent guidance |
+| `examples/` | Chrome-free examples and MCP request/response fixtures |
 
-## Files to read before changing anything
+## Files To Read First
 
-1. `AI_CONTEXT.md` (this file)
-2. `ARCHITECTURE.md` — component responsibilities and data flow
-3. `FILE_GUIDE.md` — where to find/change a specific thing
-4. `CLAUDE.md` (project root) — authoritative crate table + commands, kept up
-   to date by convention
-5. `docs/SPEC.md` — functional spec, referenced by code comments (e.g. `SEC-03`)
-6. `docs/PLAN.md` — PR-by-PR status; check before assuming a feature is "not
-   built yet"
+1. `docs/AI_CONTEXT.md`
+2. `docs/ARCHITECTURE.md`
+3. `docs/FILE_GUIDE.md`
+4. `GEMINI.md`
+5. Local `AGENTS.md` / `CLAUDE.md`, if present. These are ignored by
+   `.gitignore`, so treat them as operator-specific guidance, not repository
+   source-of-truth documentation.
+6. `docs/SPEC.md`, when behavior or public contract is relevant.
+7. `docs/PLAN.md`, for historical PR/phase status only. Verify current code
+   before assuming a feature is present or absent.
 
-## Design principles to respect
+## Design Principles
 
-- **`SemanticState` is the contract.** Agents never see raw DOM/HTML. Any
-  change to `sre/` must keep `stable_key` identity stable across re-renders
-  (tests: `core-runtime/tests/stable_key_*`, `sre_determinism.rs`).
-- **Audit before execution, policy before mutation.** In `act`, the audit log
-  entry is written *before* policy enforcement, and policy enforcement runs
-  *before* any CDP mutation. Don't reorder this (see `core-runtime/src/browser.rs`
-  around `enforce_policy`).
-- **Capture state before propagating errors.** Don't let `?` silently drop
-  accumulated metering/audit/speculative state — see CLAUDE.md §12.
-- **No `std::env::set_var`/`remove_var` in tests** — inject env values as
-  function parameters instead (CLAUDE.md §11).
-- **Immutability by default** — return new values, don't mutate in place
-  (workspace-wide Rust convention).
+- Preserve the `SemanticState` contract. Agents should not need raw DOM/HTML,
+  and `stable_key` identity must remain stable across re-renders.
+- Preserve audit-before-policy-before-mutation ordering in `act`.
+- Keep per-session state inside `PageSession`; avoid hidden global caches.
+- Capture metering, audit, and speculative state before propagating errors.
+- Do not mutate process-wide environment variables in parallel tests; pass
+  values through explicit parameters.
 
-## Frequently changed areas
+## High Blast-Radius Areas
 
-- `mcp-server/src/lib.rs` — tool dispatch, usage metering, speculative wiring
-  (this file is large; expect most "new tool behavior" work to land here).
-- `core-runtime/src/sre/` — semantic capture/normalization tuning.
-- `core-runtime/src/policy.rs` — new policy rule shapes / Guardian Angel
-  thresholds.
-- `docs/PLAN.md` — updated every PR to track phase status.
+- `core-runtime/src/sre/stable_key.rs`
+- `core-runtime/src/browser.rs`
+- `core-runtime/src/speculative/`
+- `core-runtime/src/prompt_injection.rs`
+- `.config/nextest.toml`
+- `nfr-baseline/*.json`
 
-## High blast-radius areas (change with care, check tests first)
-
-- `core-runtime/src/sre/stable_key.rs` — identity hashing; a change here
-  silently breaks every agent's ability to re-target elements across page
-  re-renders.
-- `core-runtime/src/browser.rs` — `enforce_policy`/audit ordering in `act()`
-  and crash/disconnect recovery (`relaunch`, `is_browser_disconnected`).
-- `core-runtime/src/speculative/` — feeds `get_state`'s fast path; a bug here
-  causes agents to silently see stale state (`StateDelta::Mismatch` is the
-  safety net — don't remove it).
-- `core-runtime/src/prompt_injection.rs` — security-relevant; changes affect
-  `security_flags` and `Redact` mode page-text mutation.
-- `.config/nextest.toml` — CI's `[profile.ci]` does **not** inherit from
-  `[profile.default]`; every field must be repeated (CLAUDE.md §7).
-- `nfr-baseline/*.json` — only update via `scripts/update_nfr_baseline.sh`,
-  never hand-edit.
-
-## Checklist before starting work
-
-- [ ] Read `AI_CONTEXT.md`, `ARCHITECTURE.md`, and the relevant section of
-      `FILE_GUIDE.md` for the area you're touching.
-- [ ] Check `docs/PLAN.md` for existing status/PR history on this feature.
-- [ ] Identify the exact test files that exercise this code path
-      (`FILE_GUIDE.md` lists test directories per crate).
-- [ ] If touching `sre/`, `policy.rs`, or `browser.rs`'s `act`/`enforce_policy`
-      path, re-read the relevant "High blast-radius" note above.
-- [ ] Run `just check` and the targeted test file locally before considering
-      the change done; run `just test-all` before a PR.
+Update documentation that names MCP tools, Semantic State schema, or developer
+commands whenever the corresponding implementation changes.

--- a/docs/AI_TASK_GUIDE.md
+++ b/docs/AI_TASK_GUIDE.md
@@ -1,116 +1,61 @@
 # AI_TASK_GUIDE.md
 
-AIコーディングエージェントがこのリポジトリで作業する際のガイド。トークン
-消費を抑えるため、まず最小限のファイルセットだけを読み、タスク種別ごとに
-必要な範囲だけ追加で探索すること。
+AIコーディングエージェントがこのリポジトリで作業する際のガイド。
+最初に読む範囲を絞り、必要になった時点で追加の実装・テスト・仕様を開く。
 
-## 最初に読むファイル(最小セット)
+## 最初に読むファイル
 
-1. `docs/AI_CONTEXT.md` — リポジトリの地図
-2. `docs/ARCHITECTURE.md` — コンポーネント責務とデータフロー
-3. `docs/FILE_GUIDE.md` — 「この機能を変えるならこのファイル」の対応表
-4. `CLAUDE.md`(リポジトリルート) — 正本のクレート表とコマンド一覧、
-   Rust固有の落とし穴(§1〜§14)
-5. 対象機能に関係する実装ファイル(`FILE_GUIDE.md` の「機能別に見るべき
-   場所」で特定する)
-6. 対象機能に関係するテストファイル(同上)
+1. `docs/AI_CONTEXT.md` — リポジトリの地図。
+2. `docs/ARCHITECTURE.md` — コンポーネント責務と主要データフロー。
+3. `docs/FILE_GUIDE.md` — 機能別に見るべき実装・テストの対応表。
+4. `GEMINI.md` — 追跡済みのエージェント向け概要とコマンド一覧。
+5. ローカルの `AGENTS.md` / `CLAUDE.md` が存在する場合のみ読む。これらは
+   `.gitignore` 対象なので、リポジトリ正本ではなく作業者固有の補助指示として扱う。
+6. 対象機能に関係する実装ファイル。
+7. 対象機能に関係するテストファイル。
 
-`docs/SPEC.md` と `docs/PLAN.md` は必要になったときだけ参照する
-(全文を毎回読む必要はない — `PLAN.md` はPRステータスの確認に使う)。
+`docs/SPEC.md` と `docs/PLAN.md` は必要になったときだけ参照する。
+`PLAN.md` は履歴・計画の確認用であり、現在の実装状態はコードで再確認する。
 
 ## タスク別ガイド
 
 ### バグ修正
-1. 再現条件を確認する(可能ならテストで再現させる)。
+
+1. 再現条件を確認し、可能なら失敗するテストを先に作る。
 2. `FILE_GUIDE.md` で関連する実装ファイルとテストファイルを特定する。
-3. 同じファイル内に「兄弟パス」(同じ出力型を生成する他の関数/分岐)が
-   ないか `grep` で確認する — CLAUDE.md のBugfix Discipline参照。
-4. 最小範囲で修正する。`?` でエラーを伝播する箇所では、計測/監査用の
-   状態がエラー伝播の前にキャプチャされているか確認する(CLAUDE.md §12)。
-5. 修正対象のコードパスを直接アサートする回帰テストを追加する(集約した
-   呼び出し元ではなく、直接の出力に対して)。
-6. `just check` → 対象テスト → `just test-all` で確認。
+3. 同じ出力型を作る兄弟パスがないか `rg` で確認する。
+4. 修正した関数・分岐を直接通るテストを追加する。
+5. fallible な処理でメーター、audit、speculative state などを蓄積する場合は、
+   エラー伝播の前に状態を保存しているか確認する。
+6. `just check`、対象テスト、必要なら `just test-all` を実行する。
 
-### 新機能追加
-1. `FILE_GUIDE.md`/`ARCHITECTURE.md` で既存の類似機能(似たツール、似た
-   ポリシー拡張など)を探す。
-2. 既存パターンに合わせる(例: 新しいMCPツールなら既存ツールの定義・
-   ディスパッチ・契約テストの3点セットをコピーして変更)。
-3. 影響範囲を確認する: MCPツール契約(`mcp-server/tests/mcp_*`)、Semantic
-   Stateスキーマ(`core-runtime/tests/sre_*`, `stable_key_*`)、ポリシー
-   スキーマ(`policy_schema_lint.rs`)、スキル/プラグインのスキーマ互換性
-   テスト。
-4. `docs/PLAN.md` に対応するPR/ISSUEがあれば状態を確認・更新する。
-5. テストを追加し、`docs/testing.md` のテストピラミッド方針に従う。
+### 新規 MCP ツールまたはツール契約変更
 
-### 設計変更・リファクタリング
-1. `docs/ARCHITECTURE.md` の「Easy to break」セクションを必ず確認する。
-2. 変更前後でテストが通ることを確認する(振る舞いを変えない場合)。
-3. 監査ログ順序(audit→policy→execution)や `stable_key` 生成方式など、
-   暗黙の契約を変えないこと。変える場合はユーザーに明示し、影響範囲
-   (互換性テスト一覧)を提示する。
+1. `mcp-server/src/lib.rs` の既存 tool 定義、dispatch、input schema を確認する。
+2. `mcp-server/tests/mcp_*` の契約テストを更新する。
+3. `README.md` の Available MCP Tools、`docs/ARCHITECTURE.md`、
+   `docs/AI_CONTEXT.md` を更新する。
+4. Semantic State 構造を変える場合は `core-runtime/tests/sre_*` と
+   `examples/` の fixture も確認する。
 
-## テスト追加・更新の方針
+### Policy / HITL / Guardian Angel 変更
 
-- バグ修正のテストは修正対象のコードパスを直接アサートする(集約した
-  呼び出し元経由のテストは弱い — CLAUDE.md「Test the Exact Path」)。
-- ブラウザ依存テストは `test_bench_support::should_skip_browser_tests()`
-  でスキップ可能にする。
-- 環境変数を読むテストでは `std::env::set_var`/`remove_var` を使わない。
-  関数を「envオプション引数を受け取る版」に分離し、テストはその引数に
-  直接値を渡す(CLAUDE.md §11)。
-- カバレッジ目標は80%(ユーザー個人ルール)。CIのカバレッジゲートは70%
-  (`.github/workflows/ci.yml` の `coverage` ジョブ)。
+1. `core-runtime/src/policy.rs` と関連テストを読む。
+2. JSON schema と MCP tool contract に影響があるか確認する。
+3. HITL の挙動が変わる場合は `hitl-bridge/` と `docs/operations.md` を確認する。
 
-## 既存設計を壊さないための注意
+### ドキュメント更新
 
-- `core-runtime` は他のワークスペースクレートに依存しない(基盤クレート)。
-  この依存方向を逆転させる変更をしない。
-- `act` 内の「監査ログ→ポリシー評価→実行」の順序を変えない。
-- `SpeculativeEngine` のミスは必ず通常キャプチャにフォールバックする
-  仕組み(`StateDelta::Mismatch`)を維持する — キャッシュヒットを無条件に
-  信頼するコードを書かない。
-- `nfr-baseline/*.json` は直接編集しない(`scripts/update_nfr_baseline.sh`
-  経由)。
-- `.config/nextest.toml` の `[profile.ci]` は `[profile.default]` を
-  継承しないため、両方に必要なフィールドを明示的に複製する。
+1. 対象文書が参照している実装ファイルを開く。
+2. 追跡されていない `AGENTS.md` / `CLAUDE.md` を正本として参照しない。
+3. MCP tool 数、コマンド名、環境変数、crate 構成はコード・`Justfile`・
+   `Cargo.toml` から確認する。
+4. `python3 scripts/check_mvp_docs.py` を実行する。
 
-## やってはいけないこと
+## 注意領域
 
-- 推測で `config.toml` の新フィールドを追加する(実際に
-  `mcp-server/src/config.rs` の `FileConfig` 構造を確認してから)。
-- `Cargo.lock` を手動編集する。
-- `target/` 配下のファイルを参照・編集する(ビルド出力)。
-- バイナリ/スナップショットフィクスチャ(`*.png`, `golden/*.json` 等)を
-  意図した視覚差分更新以外の理由で変更する。
-- CI/CD設定(`.github/workflows/*.yml`)を、`deny.toml` やnextestプロファイル
-  との整合性を確認せずに変更する。
-- 無関係なコードの整形・リファクタリング(ユーザーの依頼範囲外の変更)。
-
-## 推測で変更してはいけない箇所
-
-- `core-runtime/src/sre/stable_key.rs` のハッシュ/識別ロジック
-  — 既存エージェント統合の要素識別が壊れる。
-- `core-runtime/src/policy.rs` のenum/構造体のシリアライズ形式
-  — `PolicyRule`/`PolicyDecision` のJSONスキーマはツール契約に含まれる。
-- `deny.toml` のRUSTSEC例外リスト — 根拠なく削除/追加しない。
-- 監査イベントのスキーマ(`audit_schema.rs` がテストする形式)。
-
-## 大きな変更をする前に確認すべきこと
-
-- `docs/PLAN.md` で同等の作業が既に計画/完了していないか。
-- 変更対象のクレートに対応する `tests/` ディレクトリの一覧
-  (`FILE_GUIDE.md` 参照)で、影響を受けるテストファイルを把握しているか。
-- MCPツールのスキーマや`SemanticState`の構造を変える場合、
-  `examples/mcp_examples/*.json` や `README.md` の表も更新が必要か。
-- ユーザー個人ルール(`~/.claude/rules/`)の「Surgical Changes」原則
-  ——変更は依頼内容に直接トレースできる範囲に留める。
-
-## トークン削減のため、まず読むべき最小ファイルセット
-
-| タスク種別 | 最小限読むファイル |
-|---|---|
-| バグ修正(範囲が明確) | `AI_CONTEXT.md` + 対象実装ファイル1〜2つ + 対応テスト |
-| 新規MCPツール | `AI_CONTEXT.md` + `ARCHITECTURE.md`(データフロー節) + `mcp-server/src/lib.rs` + 既存ツールの契約テスト1例 |
-| ポリシー/Guardian Angel変更 | `AI_CONTEXT.md` + `DOMAIN_MODEL.md`(該当エンティティ) + `core-runtime/src/policy.rs` + `policy_engine.rs`/`policy_enforcement.rs` |
-| ドキュメント更新のみ | 対象ドキュメントと、その記述が参照する実装ファイルのみ(全文探索しない) |
+- `std::env::set_var` / `remove_var` を並列テストで使わない。
+- `nfr-baseline/*.json` は `scripts/update_nfr_baseline.sh` 経由で更新する。
+- `.config/nextest.toml` の `[profile.ci]` は `[profile.default]` を継承しない。
+- `Cargo.lock` は手編集しない。
+- LFS 管理のバイナリ fixture は、ドキュメント変更 PR に混ぜない。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ flowchart TD
 
 | Component | Responsibility |
 |---|---|
-| `mcp-server` | stdio JSON-RPC server; tool contract (7 tools); config loading; `--doctor`/`--init`; usage metering and plan-tier gating |
+| `mcp-server` | stdio JSON-RPC server; tool contract (8 tools: `get_state`, `act`, `verify`, `get_visual`, `ask_human`, `run_skill`, `get_usage_report`, `extract`); config loading; `--doctor`/`--init`; usage metering and plan-tier gating |
 | `core-runtime::browser` | Owns the Chrome process and per-tab `PageSession`; executes actions; crash/disconnect detection and relaunch |
 | `core-runtime::sre` | DOM → `SemanticState`/`SemanticNode` capture and normalization; `stable_key` identity; delta computation |
 | `core-runtime::policy` | `PolicyEngine` — rule-based action gating (Allow/Block/RequireHumanApproval) and Guardian Angel outcome projection |

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -62,7 +62,7 @@ CHROME_INSTALLED=true cargo test -p core-runtime --test semantic_wait
 
 nextestのプロファイルは `.config/nextest.toml` に `default`/`ci` の2種類。
 **`ci` プロファイルは `default` を継承しないため全フィールドを repeat する
-必要がある**(CLAUDE.md §7)。
+必要がある**。
 
 ## lint / format / typecheck
 
@@ -138,8 +138,9 @@ release.ymlの全ジョブ詳細は未確認)。
 - `cargo fmt`(デフォルト設定)+ `cargo clippy -D warnings` を必須。
 - ライブラリ層は `thiserror`、アプリ層は `anyhow` でエラー型を扱う
   (ユーザー個人ルール `~/.claude/rules/rust/coding-style.md` 準拠)。
-- 詳細はリポジトリの `CLAUDE.md` 末尾(§1〜§14)に蓄積されたRust固有の
-  落とし穴ガイドを参照。
+- Rust固有の落とし穴は、追跡済みドキュメントでは `docs/AI_CONTEXT.md` と
+  `docs/AI_TASK_GUIDE.md` の高リスク領域メモを正本として参照する。ローカルの
+  `CLAUDE.md` が存在する場合は補助指示として扱う。
 
 ## ブランチ・コミット方針
 

--- a/docs/FILE_GUIDE.md
+++ b/docs/FILE_GUIDE.md
@@ -149,5 +149,5 @@
 | `core-runtime/target/nfr-dashboard*.md` | ベンチ出力 | 無視 |
 | `rust-toolchain.toml` | 設定(`channel = "stable"`) | 変更時はCI全体に影響、慎重に |
 | `deny.toml` | 設定(cargo-deny advisories) | 例外追加時は根拠を明記 |
-| `.config/nextest.toml` | 設定(`default`/`ci`プロファイル) | プロファイル非継承に注意(CLAUDE.md §7) |
+| `.config/nextest.toml` | 設定(`default`/`ci`プロファイル) | プロファイル非継承に注意。`ci` は `default` を継承しない |
 | `nfr-baseline/*.json` | ベースラインデータ | スクリプト経由のみ更新 |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,12 +1,15 @@
 # Neural-Browser Runtime 実装計画（進捗管理版）
 
 - 対象仕様: [SPEC.md](./SPEC.md) v2.1（2026-02-10）
-- 最終更新日: 2026-05-19
+- 最終更新日: 2026-07-06
 - プラン状態: In Progress
 
 ## 1. 進捗管理ルール
 
 - `Status` は `NOT_STARTED` / `IN_PROGRESS` / `BLOCKED` / `DONE` を使用する。
+- このファイルは実装計画と完了済みPRの履歴であり、現在のコードベースの正本は
+  `Cargo.toml`、各 crate の実装、`mcp-server/src/lib.rs` の MCP tool contract、
+  および `README.md` / `docs/ARCHITECTURE.md` の利用者向け説明で確認する。
 - 各PRは `実装` / `テスト` / `CI` の3カテゴリでチェックボックス管理する。
 - PRを `DONE` に変更できる条件:
   - 実装タスク完了


### PR DESCRIPTION
## Summary
- Update README and architecture docs to reflect the current 8-tool MCP contract, including extract.
- Clarify that AGENTS.md and CLAUDE.md are local ignored guidance, while tracked docs/GEMINI.md are the repository source of truth.
- Refresh agent guidance docs and correct the tracked command guidance around cargo build vs Justfile recipes.

## Verification
- python3 scripts/check_mvp_docs.py
- just --summary
- README MCP tool table matches mcp-server/src/lib.rs tools() check
- cargo test -p mcp-server extract_tool_is_listed_in_tools