### PR TITLE
[ISSUE-225] Enforce verify-before-act across skill branches

### DIFF
--- a/skills-engine/src/lib.rs
+++ b/skills-engine/src/lib.rs
@@ -469,9 +469,72 @@ pub fn validate_skill_definition(skill: &SkillDefinition) -> Result<(), SkillEng
         }
     }
 
-    for idx in 0..skill.steps.len() {
-        if let SkillStep::Act(act) = &skill.steps[idx]
-            && (idx == 0 || !matches!(skill.steps[idx - 1], SkillStep::Verify(_)))
+    validate_act_predecessors(skill, &index)?;
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TransitionOutcome {
+    Success,
+    Failure,
+    Retry,
+}
+
+fn validate_act_predecessors(
+    skill: &SkillDefinition,
+    index: &HashMap<String, usize>,
+) -> Result<(), SkillEngineError> {
+    let mut has_incoming_edge = vec![false; skill.steps.len()];
+
+    validate_act_transition(skill, None, TransitionOutcome::Success, 0)?;
+    has_incoming_edge[0] = true;
+
+    for (source_idx, step) in skill.steps.iter().enumerate() {
+        let control = step.control();
+
+        if control.max_retries > 0 {
+            validate_act_transition(
+                skill,
+                Some(source_idx),
+                TransitionOutcome::Retry,
+                source_idx,
+            )?;
+            has_incoming_edge[source_idx] = true;
+        }
+
+        if !matches!(step, SkillStep::Handoff(_)) {
+            let success_target = control
+                .on_success
+                .as_ref()
+                .map(|target| index[target])
+                .or_else(|| (source_idx + 1 < skill.steps.len()).then_some(source_idx + 1));
+            if let Some(target_idx) = success_target {
+                validate_act_transition(
+                    skill,
+                    Some(source_idx),
+                    TransitionOutcome::Success,
+                    target_idx,
+                )?;
+                has_incoming_edge[target_idx] = true;
+            }
+        }
+
+        if let Some(target) = control.on_failure.as_ref() {
+            let target_idx = index[target];
+            validate_act_transition(
+                skill,
+                Some(source_idx),
+                TransitionOutcome::Failure,
+                target_idx,
+            )?;
+            has_incoming_edge[target_idx] = true;
+        }
+    }
+
+    for (idx, step) in skill.steps.iter().enumerate() {
+        if let SkillStep::Act(act) = step
+            && !has_incoming_edge[idx]
         {
             return Err(SkillEngineError::ActStepMissingVerifyPredecessor {
                 step_id: act.id.clone(),
@@ -480,6 +543,33 @@ pub fn validate_skill_definition(skill: &SkillDefinition) -> Result<(), SkillEng
     }
 
     Ok(())
+}
+
+fn validate_act_transition(
+    skill: &SkillDefinition,
+    source_idx: Option<usize>,
+    outcome: TransitionOutcome,
+    target_idx: usize,
+) -> Result<(), SkillEngineError> {
+    let SkillStep::Act(act) = &skill.steps[target_idx] else {
+        return Ok(());
+    };
+
+    let authorized = source_idx
+        .filter(|_| outcome == TransitionOutcome::Success)
+        .and_then(|idx| match &skill.steps[idx] {
+            SkillStep::Verify(verify) => Some(verify.target == act.target),
+            _ => None,
+        })
+        .unwrap_or(false);
+
+    if authorized {
+        Ok(())
+    } else {
+        Err(SkillEngineError::ActStepMissingVerifyPredecessor {
+            step_id: act.id.clone(),
+        })
+    }
 }
 
 pub fn skill_definition_schema() -> Value {

--- a/skills-engine/tests/skill_conformance.rs
+++ b/skills-engine/tests/skill_conformance.rs
@@ -249,3 +249,227 @@ fn test_act_requires_immediate_verify_predecessor() {
         SkillEngineError::ActStepMissingVerifyPredecessor { .. }
     ));
 }
+
+fn verify_step(id: &str, target: &str, control: StepControl) -> SkillStep {
+    SkillStep::Verify(VerifyStep {
+        id: Some(id.to_string()),
+        target: target.to_string(),
+        expected: "visible".to_string(),
+        control,
+    })
+}
+
+fn act_step(id: &str, target: &str, control: StepControl) -> SkillStep {
+    SkillStep::Act(ActStep {
+        id: Some(id.to_string()),
+        action: "click".to_string(),
+        target: target.to_string(),
+        value: None,
+        control,
+    })
+}
+
+fn locate_step(id: &str, control: StepControl) -> SkillStep {
+    SkillStep::Locate(LocateStep {
+        id: Some(id.to_string()),
+        query: "target".to_string(),
+        control,
+    })
+}
+
+fn assert_invalid_act_flow(steps: Vec<SkillStep>) {
+    let skill = SkillDefinition {
+        schema_version: 1,
+        name: "invalid-act-flow".to_string(),
+        steps,
+    };
+    let mut runtime = MockRuntime::default();
+
+    let error = SkillEngine::new().run(&skill, &mut runtime).unwrap_err();
+    assert!(matches!(
+        error,
+        SkillEngineError::ActStepMissingVerifyPredecessor { .. }
+    ));
+}
+
+#[test]
+fn test_branch_cannot_skip_verify_before_act() {
+    assert_invalid_act_flow(vec![
+        locate_step(
+            "start",
+            StepControl {
+                on_success: Some("do_act".to_string()),
+                ..StepControl::default()
+            },
+        ),
+        verify_step("check", "target", StepControl::default()),
+        act_step("do_act", "target", StepControl::default()),
+    ]);
+}
+
+#[test]
+fn test_verify_failure_cannot_authorize_act() {
+    assert_invalid_act_flow(vec![
+        verify_step(
+            "check",
+            "target",
+            StepControl {
+                on_failure: Some("do_act".to_string()),
+                ..StepControl::default()
+            },
+        ),
+        act_step("do_act", "target", StepControl::default()),
+    ]);
+}
+
+#[test]
+fn test_verify_must_match_act_target() {
+    assert_invalid_act_flow(vec![
+        verify_step("check", "first-target", StepControl::default()),
+        act_step("do_act", "second-target", StepControl::default()),
+    ]);
+}
+
+#[test]
+fn test_act_cannot_retry_without_reverification() {
+    assert_invalid_act_flow(vec![
+        verify_step("check", "target", StepControl::default()),
+        act_step(
+            "do_act",
+            "target",
+            StepControl {
+                max_retries: 1,
+                ..StepControl::default()
+            },
+        ),
+    ]);
+}
+
+#[test]
+fn test_act_cannot_loop_without_reverification() {
+    assert_invalid_act_flow(vec![
+        verify_step("check", "target", StepControl::default()),
+        act_step(
+            "do_act",
+            "target",
+            StepControl {
+                on_success: Some("do_act".to_string()),
+                ..StepControl::default()
+            },
+        ),
+    ]);
+}
+
+#[test]
+fn test_unsafe_backward_edge_into_act_is_rejected() {
+    assert_invalid_act_flow(vec![
+        verify_step("check", "target", StepControl::default()),
+        act_step("do_act", "target", StepControl::default()),
+        locate_step(
+            "loop",
+            StepControl {
+                on_success: Some("do_act".to_string()),
+                ..StepControl::default()
+            },
+        ),
+    ]);
+}
+
+#[test]
+fn test_branched_verify_can_authorize_matching_act() -> Result<(), SkillEngineError> {
+    let skill = SkillDefinition {
+        schema_version: 1,
+        name: "safe-verify-branch".to_string(),
+        steps: vec![
+            verify_step(
+                "check",
+                "target",
+                StepControl {
+                    on_success: Some("do_act".to_string()),
+                    ..StepControl::default()
+                },
+            ),
+            SkillStep::Handoff(HandoffStep {
+                id: Some("skipped".to_string()),
+                reason: "not reached".to_string(),
+                assignee: None,
+                control: StepControl::default(),
+            }),
+            act_step("do_act", "target", StepControl::default()),
+        ],
+    };
+    let mut runtime = MockRuntime::default();
+
+    let report = SkillEngine::new().run(&skill, &mut runtime)?;
+    let operations: Vec<&str> = report
+        .trace
+        .iter()
+        .map(|entry| entry.operation.as_str())
+        .collect();
+    assert_eq!(
+        operations,
+        vec!["verify", "policy_check", "act", "post_check"]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_safe_cycle_reverifies_before_each_act() -> Result<(), SkillEngineError> {
+    let skill = SkillDefinition {
+        schema_version: 1,
+        name: "safe-reverify-cycle".to_string(),
+        steps: vec![
+            verify_step(
+                "check",
+                "target",
+                StepControl {
+                    on_success: Some("do_act".to_string()),
+                    on_failure: Some("done".to_string()),
+                    ..StepControl::default()
+                },
+            ),
+            SkillStep::Handoff(HandoffStep {
+                id: Some("done".to_string()),
+                reason: "cycle complete".to_string(),
+                assignee: None,
+                control: StepControl::default(),
+            }),
+            act_step(
+                "do_act",
+                "target",
+                StepControl {
+                    on_success: Some("check".to_string()),
+                    ..StepControl::default()
+                },
+            ),
+        ],
+    };
+    let mut runtime = MockRuntime::default().with_script(
+        "verify",
+        vec![
+            OperationOutcome::Success,
+            OperationOutcome::Failure {
+                reason: "done".to_string(),
+            },
+        ],
+    );
+
+    let report = SkillEngine::new().run(&skill, &mut runtime)?;
+    let operations: Vec<&str> = report
+        .trace
+        .iter()
+        .map(|entry| entry.operation.as_str())
+        .collect();
+    assert_eq!(
+        operations,
+        vec![
+            "verify",
+            "policy_check",
+            "act",
+            "post_check",
+            "verify",
+            "handoff"
+        ]
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes #225

## Summary
- validate actual success, failure, fallthrough, entry, and retry control-flow edges into `act`
- require a successful `verify` for the same target on every incoming `act` edge
- reject bypass branches, failure authorization, retries, and self-loops while preserving safe re-verification cycles

## Exit criteria
- [x] Branches cannot skip verify before act
- [x] Act self-loops and retries cannot repeat without re-verification
- [x] Sequential and branched verify-to-act flows remain supported
- [x] on_success, on_failure, backward edges, target mismatch, and safe cycles are covered
- [x] Runtime trace tests demonstrate re-verification before repeated acts

## Validation
- `cargo test -p skills-engine` (17 passed)
- `cargo test --workspace` (passed)
- `cargo fmt --all -- --check` (passed)
- `cargo clippy --workspace -- -D warnings` (passed)
- gstack review: no unresolved findings
- gstack qa-only: contract and negative-path coverage passed; no browser-facing surface changed

## Notes
- `docs/PLAN.md` is already DONE for SKILL-01; no checklist state changed.
