### PR TITLE
[ISSUE-197] Sign executable Domain Pack content

### DIFF
--- a/marketplace/src/lib.rs
+++ b/marketplace/src/lib.rs
@@ -1,8 +1,8 @@
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
-use plugin_host::PluginPackage;
+use plugin_host::{PluginPackage, SignatureBlock};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use skills_engine::SkillDefinition;
+use skills_engine::{SkillDefinition, SkillStep, StepControl};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MarketplaceMetadata {
@@ -47,8 +47,273 @@ pub enum MarketplaceError {
     InvalidPublicKey,
     #[error("signature encoding error")]
     InvalidSignatureEncoding,
+    #[error("unsupported domain pack signature version: {0}")]
+    UnsupportedSignatureVersion(String),
     #[error("incompatible version: {0}")]
     IncompatibleVersion(String),
+    #[error("failed to serialize domain pack signature payload: {0}")]
+    SignaturePayloadSerialization(String),
+}
+
+const DOMAIN_PACK_SIGNATURE_DOMAIN: &str = "dragon-head.marketplace.domain-pack-signature";
+const DOMAIN_PACK_SIGNATURE_VERSION: u32 = 1;
+const DOMAIN_PACK_SIGNATURE_PREFIX: &str = "v1:";
+
+#[derive(Serialize)]
+struct SignedMarketplaceMetadata<'a> {
+    pack_id: &'a str,
+    author: &'a str,
+    version: &'a str,
+    compatible_version: &'a str,
+    dependencies: &'a [String],
+}
+
+#[derive(Serialize)]
+struct SignedPlugin<'a> {
+    manifest: SignedPluginManifestV1<'a>,
+    wasm_hash_algorithm: &'static str,
+    wasm_sha256: String,
+}
+
+#[derive(Serialize)]
+struct SignedPluginManifestV1<'a> {
+    plugin_id: &'a str,
+    version: &'a str,
+    entry_points: Vec<&'static str>,
+    capabilities: Vec<&'static str>,
+    signature: Option<SignedPluginSignatureV1<'a>>,
+    sbom: SignedSbomDocumentV1<'a>,
+}
+
+#[derive(Serialize)]
+struct SignedPluginSignatureV1<'a> {
+    key_id: &'a str,
+    signature_hex: &'a str,
+}
+
+#[derive(Serialize)]
+struct SignedSbomDocumentV1<'a> {
+    format: &'a str,
+    components: Vec<SignedSbomComponentV1<'a>>,
+}
+
+#[derive(Serialize)]
+struct SignedSbomComponentV1<'a> {
+    name: &'a str,
+    version: &'a str,
+    license: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct SignedSkillDefinitionV1<'a> {
+    schema_version: u32,
+    name: &'a str,
+    steps: Vec<SignedSkillStepV1<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SignedSkillStepV1<'a> {
+    Locate {
+        id: Option<&'a str>,
+        query: &'a str,
+        control: SignedStepControlV1<'a>,
+    },
+    Verify {
+        id: Option<&'a str>,
+        target: &'a str,
+        expected: &'a str,
+        control: SignedStepControlV1<'a>,
+    },
+    Act {
+        id: Option<&'a str>,
+        action: &'a str,
+        target: &'a str,
+        value: Option<&'a str>,
+        control: SignedStepControlV1<'a>,
+    },
+    Wait {
+        id: Option<&'a str>,
+        condition: &'a str,
+        timeout_ms: u64,
+        control: SignedStepControlV1<'a>,
+    },
+    Extract {
+        id: Option<&'a str>,
+        key: &'a str,
+        selector: &'a str,
+        control: SignedStepControlV1<'a>,
+    },
+    Handoff {
+        id: Option<&'a str>,
+        reason: &'a str,
+        assignee: Option<&'a str>,
+        control: SignedStepControlV1<'a>,
+    },
+}
+
+#[derive(Serialize)]
+struct SignedStepControlV1<'a> {
+    max_retries: u32,
+    on_success: Option<&'a str>,
+    on_failure: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct DomainPackSignaturePayload<'a> {
+    domain: &'static str,
+    version: u32,
+    metadata: SignedMarketplaceMetadata<'a>,
+    plugin: Option<SignedPlugin<'a>>,
+    skills: Vec<SignedSkillDefinitionV1<'a>>,
+}
+
+fn signed_plugin_signature(signature: &SignatureBlock) -> SignedPluginSignatureV1<'_> {
+    SignedPluginSignatureV1 {
+        key_id: &signature.key_id,
+        signature_hex: &signature.signature_hex,
+    }
+}
+
+fn signed_extension_point_v1(extension_point: &plugin_host::ExtensionPoint) -> &'static str {
+    match extension_point {
+        plugin_host::ExtensionPoint::OnState => "on_state",
+        plugin_host::ExtensionPoint::BeforeAct => "before_act",
+        plugin_host::ExtensionPoint::Connector => "connector",
+    }
+}
+
+fn signed_capability_v1(capability: &plugin_host::Capability) -> &'static str {
+    match capability {
+        plugin_host::Capability::ReadState => "read_state",
+        plugin_host::Capability::NetworkOut => "network_out",
+        plugin_host::Capability::VaultAccess => "vault_access",
+    }
+}
+
+fn signed_step_control(control: &StepControl) -> SignedStepControlV1<'_> {
+    SignedStepControlV1 {
+        max_retries: control.max_retries,
+        on_success: control.on_success.as_deref(),
+        on_failure: control.on_failure.as_deref(),
+    }
+}
+
+fn signed_skill_step(step: &SkillStep) -> SignedSkillStepV1<'_> {
+    match step {
+        SkillStep::Locate(step) => SignedSkillStepV1::Locate {
+            id: step.id.as_deref(),
+            query: &step.query,
+            control: signed_step_control(&step.control),
+        },
+        SkillStep::Verify(step) => SignedSkillStepV1::Verify {
+            id: step.id.as_deref(),
+            target: &step.target,
+            expected: &step.expected,
+            control: signed_step_control(&step.control),
+        },
+        SkillStep::Act(step) => SignedSkillStepV1::Act {
+            id: step.id.as_deref(),
+            action: &step.action,
+            target: &step.target,
+            value: step.value.as_deref(),
+            control: signed_step_control(&step.control),
+        },
+        SkillStep::Wait(step) => SignedSkillStepV1::Wait {
+            id: step.id.as_deref(),
+            condition: &step.condition,
+            timeout_ms: step.timeout_ms,
+            control: signed_step_control(&step.control),
+        },
+        SkillStep::Extract(step) => SignedSkillStepV1::Extract {
+            id: step.id.as_deref(),
+            key: &step.key,
+            selector: &step.selector,
+            control: signed_step_control(&step.control),
+        },
+        SkillStep::Handoff(step) => SignedSkillStepV1::Handoff {
+            id: step.id.as_deref(),
+            reason: &step.reason,
+            assignee: step.assignee.as_deref(),
+            control: signed_step_control(&step.control),
+        },
+    }
+}
+
+fn signed_skill(skill: &SkillDefinition) -> SignedSkillDefinitionV1<'_> {
+    SignedSkillDefinitionV1 {
+        schema_version: skill.schema_version,
+        name: &skill.name,
+        steps: skill.steps.iter().map(signed_skill_step).collect(),
+    }
+}
+
+/// Returns the exact versioned bytes that authors must sign for a domain pack.
+///
+/// The fixed struct field order and serde JSON encoding are part of the v1
+/// signature protocol. Collection order is significant. The marketplace
+/// signature itself is intentionally excluded to avoid a recursive payload;
+/// every other execution- or compatibility-relevant field is included.
+pub fn domain_pack_signature_payload(pack: &DomainPack) -> Result<Vec<u8>, MarketplaceError> {
+    let payload = DomainPackSignaturePayload {
+        domain: DOMAIN_PACK_SIGNATURE_DOMAIN,
+        version: DOMAIN_PACK_SIGNATURE_VERSION,
+        metadata: SignedMarketplaceMetadata {
+            pack_id: &pack.metadata.pack_id,
+            author: &pack.metadata.author,
+            version: &pack.metadata.version,
+            compatible_version: &pack.metadata.compatible_version,
+            dependencies: &pack.metadata.dependencies,
+        },
+        plugin: pack.plugin.as_ref().map(|plugin| {
+            let manifest = &plugin.manifest;
+            SignedPlugin {
+                manifest: SignedPluginManifestV1 {
+                    plugin_id: &manifest.plugin_id,
+                    version: &manifest.version,
+                    entry_points: manifest
+                        .entry_points
+                        .iter()
+                        .map(signed_extension_point_v1)
+                        .collect(),
+                    capabilities: manifest
+                        .capabilities
+                        .iter()
+                        .map(signed_capability_v1)
+                        .collect(),
+                    signature: manifest.signature.as_ref().map(signed_plugin_signature),
+                    sbom: SignedSbomDocumentV1 {
+                        format: &manifest.sbom.format,
+                        components: manifest
+                            .sbom
+                            .components
+                            .iter()
+                            .map(|component| SignedSbomComponentV1 {
+                                name: &component.name,
+                                version: &component.version,
+                                license: component.license.as_deref(),
+                            })
+                            .collect(),
+                    },
+                },
+                wasm_hash_algorithm: "sha256",
+                wasm_sha256: hex::encode(Sha256::digest(&plugin.wasm_module)),
+            }
+        }),
+        skills: pack.skills.iter().map(signed_skill).collect(),
+    };
+
+    serde_json::to_vec(&payload)
+        .map_err(|error| MarketplaceError::SignaturePayloadSerialization(error.to_string()))
+}
+
+/// Encodes an Ed25519 signature with the payload-version discriminator required
+/// by [`verify_domain_pack`]. Legacy unversioned signatures are rejected.
+pub fn encode_domain_pack_signature(signature: &Signature) -> String {
+    format!(
+        "{DOMAIN_PACK_SIGNATURE_PREFIX}{}",
+        hex::encode(signature.to_bytes())
+    )
 }
 
 pub fn verify_domain_pack(
@@ -69,19 +334,22 @@ pub fn verify_domain_pack(
     let verifying_key =
         VerifyingKey::from_bytes(&pubkey_bytes).map_err(|_| MarketplaceError::InvalidPublicKey)?;
 
+    let signature_hex = sig_hex
+        .strip_prefix(DOMAIN_PACK_SIGNATURE_PREFIX)
+        .ok_or_else(|| {
+            MarketplaceError::UnsupportedSignatureVersion(
+                sig_hex
+                    .split_once(':')
+                    .map_or("legacy", |(version, _)| version)
+                    .to_string(),
+            )
+        })?;
     let signature_bytes =
-        hex::decode(sig_hex).map_err(|_| MarketplaceError::InvalidSignatureEncoding)?;
+        hex::decode(signature_hex).map_err(|_| MarketplaceError::InvalidSignatureEncoding)?;
     let parsed_signature = Signature::from_slice(&signature_bytes)
         .map_err(|_| MarketplaceError::InvalidSignatureEncoding)?;
 
-    // Hash payload for signature: pack_id, author, version
-    let mut hasher = Sha256::new();
-    hasher.update(pack.metadata.pack_id.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(pack.metadata.author.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(pack.metadata.version.as_bytes());
-    let payload = hasher.finalize();
+    let payload = domain_pack_signature_payload(pack)?;
 
     verifying_key
         .verify(&payload, &parsed_signature)

--- a/marketplace/tests/comprehensive_evaluation.rs
+++ b/marketplace/tests/comprehensive_evaluation.rs
@@ -1,10 +1,10 @@
 use ed25519_dalek::{Signer, SigningKey};
 use marketplace::{
-    DomainPack, MarketplaceMetadata, UsageEvent, calculate_revenue_share, verify_domain_pack,
+    DomainPack, MarketplaceMetadata, UsageEvent, calculate_revenue_share,
+    domain_pack_signature_payload, encode_domain_pack_signature, verify_domain_pack,
 };
 use rand_core::OsRng;
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
@@ -41,41 +41,30 @@ fn scenario_domain_pack_signature_verification() -> anyhow::Result<Value> {
     let pubkey_bytes = signing_key.verifying_key().to_bytes();
     let pubkey_hex = hex::encode(pubkey_bytes);
 
-    let pack_id = "com.example.testpack";
-    let author = "Test Author";
-    let version = "1.0.0";
-
-    let mut hasher = Sha256::new();
-    hasher.update(pack_id.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(author.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(version.as_bytes());
-    let payload = hasher.finalize();
-
-    let signature = signing_key.sign(&payload);
-    let signature_hex = hex::encode(signature.to_bytes());
-
     let metadata = MarketplaceMetadata {
-        pack_id: pack_id.to_string(),
-        author: author.to_string(),
-        version: version.to_string(),
+        pack_id: "com.example.testpack".to_string(),
+        author: "Test Author".to_string(),
+        version: "1.0.0".to_string(),
         compatible_version: "2.1".to_string(),
         dependencies: vec![],
-        signature: Some(signature_hex),
+        signature: None,
     };
 
-    let pack = DomainPack {
+    let mut pack = DomainPack {
         metadata,
         plugin: None,
         skills: vec![],
     };
+    let payload = domain_pack_signature_payload(&pack)?;
+    pack.metadata.signature = Some(encode_domain_pack_signature(&signing_key.sign(&payload)));
 
     assert!(verify_domain_pack(&pack, &pubkey_hex).is_ok());
     assert!(verify_domain_pack(&pack, &"00".repeat(32)).is_err());
+    pack.metadata.compatible_version = "tampered".to_string();
+    assert!(verify_domain_pack(&pack, &pubkey_hex).is_err());
 
     Ok(json!({
-        "pack_id": pack_id,
+        "pack_id": pack.metadata.pack_id,
         "verified": true,
     }))
 }

--- a/marketplace/tests/marketplace_tests.rs
+++ b/marketplace/tests/marketplace_tests.rs
@@ -1,52 +1,219 @@
 use ed25519_dalek::{Signer, SigningKey};
 use marketplace::{
-    DomainPack, MarketplaceMetadata, UsageEvent, calculate_revenue_share, verify_domain_pack,
+    DomainPack, MarketplaceMetadata, UsageEvent, calculate_revenue_share,
+    domain_pack_signature_payload, encode_domain_pack_signature, verify_domain_pack,
 };
-use rand_core::OsRng;
+use plugin_host::{
+    Capability, ExtensionPoint, PluginManifest, PluginPackage, SbomComponent, SbomDocument,
+    SignatureBlock,
+};
 use sha2::{Digest, Sha256};
+use skills_engine::{LocateStep, SkillDefinition, SkillStep, StepControl};
+
+fn sample_pack() -> DomainPack {
+    DomainPack {
+        metadata: MarketplaceMetadata {
+            pack_id: "com.example.testpack".to_string(),
+            author: "Test Author".to_string(),
+            version: "1.0.0".to_string(),
+            compatible_version: "2.1".to_string(),
+            dependencies: vec!["alpha@1".to_string(), "beta@2".to_string()],
+            signature: None,
+        },
+        plugin: Some(PluginPackage {
+            manifest: PluginManifest {
+                plugin_id: "com.example.plugin".to_string(),
+                version: "1.0.0".to_string(),
+                entry_points: vec![ExtensionPoint::OnState],
+                capabilities: vec![Capability::ReadState],
+                signature: None,
+                sbom: SbomDocument {
+                    format: "cyclonedx".to_string(),
+                    components: vec![SbomComponent {
+                        name: "sample".to_string(),
+                        version: "1.0.0".to_string(),
+                        license: Some("MIT".to_string()),
+                    }],
+                },
+            },
+            wasm_module: b"\0asm\x01\0\0\0".to_vec(),
+        }),
+        skills: vec![SkillDefinition {
+            schema_version: 1,
+            name: "find_checkout".to_string(),
+            steps: vec![SkillStep::Locate(LocateStep {
+                id: Some("find".to_string()),
+                query: "checkout".to_string(),
+                control: StepControl {
+                    max_retries: 2,
+                    on_success: None,
+                    on_failure: Some("handoff".to_string()),
+                },
+            })],
+        }],
+    }
+}
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[7_u8; 32])
+}
+
+fn sign_pack(pack: &mut DomainPack) {
+    pack.metadata.signature = None;
+    let payload = domain_pack_signature_payload(pack).unwrap();
+    pack.metadata.signature = Some(encode_domain_pack_signature(&signing_key().sign(&payload)));
+}
+
+fn assert_tamper_rejected(mut pack: DomainPack, mutate: impl FnOnce(&mut DomainPack)) {
+    sign_pack(&mut pack);
+    mutate(&mut pack);
+    let pubkey = hex::encode(signing_key().verifying_key().to_bytes());
+    assert!(verify_domain_pack(&pack, &pubkey).is_err());
+}
 
 #[test]
-fn test_signature_verification() {
-    let mut csprng = OsRng;
-    let signing_key = SigningKey::generate(&mut csprng);
-    let pubkey_bytes = signing_key.verifying_key().to_bytes();
-    let pubkey_hex = hex::encode(pubkey_bytes);
-
-    let pack_id = "com.example.testpack";
-    let author = "Test Author";
-    let version = "1.0.0";
-
-    let mut hasher = Sha256::new();
-    hasher.update(pack_id.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(author.as_bytes());
-    hasher.update(b"\0");
-    hasher.update(version.as_bytes());
-    let payload = hasher.finalize();
-
-    let signature = signing_key.sign(&payload);
-    let signature_hex = hex::encode(signature.to_bytes());
-
-    let metadata = MarketplaceMetadata {
-        pack_id: pack_id.to_string(),
-        author: author.to_string(),
-        version: version.to_string(),
-        compatible_version: "2.1".to_string(),
-        dependencies: vec![],
-        signature: Some(signature_hex),
-    };
-
-    let pack = DomainPack {
-        metadata,
-        plugin: None,
-        skills: vec![],
-    };
-
+fn signed_domain_pack_verifies() {
+    let mut pack = sample_pack();
+    sign_pack(&mut pack);
+    let pubkey_hex = hex::encode(signing_key().verifying_key().to_bytes());
     assert!(verify_domain_pack(&pack, &pubkey_hex).is_ok());
 
-    // Test with invalid public key
     let invalid_pubkey = "00".repeat(32);
     assert!(verify_domain_pack(&pack, &invalid_pubkey).is_err());
+}
+
+#[test]
+fn legacy_and_unknown_signature_versions_are_rejected_without_fallback() {
+    let mut pack = sample_pack();
+    let payload = domain_pack_signature_payload(&pack).unwrap();
+    let signature_hex = hex::encode(signing_key().sign(&payload).to_bytes());
+    let pubkey_hex = hex::encode(signing_key().verifying_key().to_bytes());
+
+    pack.metadata.signature = Some(signature_hex.clone());
+    assert!(matches!(
+        verify_domain_pack(&pack, &pubkey_hex),
+        Err(marketplace::MarketplaceError::UnsupportedSignatureVersion(version)) if version == "legacy"
+    ));
+
+    pack.metadata.signature = Some(format!("v2:{signature_hex}"));
+    assert!(matches!(
+        verify_domain_pack(&pack, &pubkey_hex),
+        Err(marketplace::MarketplaceError::UnsupportedSignatureVersion(version)) if version == "v2"
+    ));
+}
+
+#[test]
+fn plugin_wasm_and_manifest_tampering_is_rejected() {
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin.as_mut().unwrap().wasm_module[1] ^= 1;
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin
+            .as_mut()
+            .unwrap()
+            .manifest
+            .capabilities
+            .push(Capability::NetworkOut);
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin.as_mut().unwrap().manifest.sbom.format = "tampered".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin.as_mut().unwrap().manifest.entry_points[0] = ExtensionPoint::BeforeAct;
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin.as_mut().unwrap().manifest.signature = Some(SignatureBlock {
+            key_id: "plugin-key".to_string(),
+            signature_hex: "deadbeef".to_string(),
+        });
+    });
+}
+
+#[test]
+fn nested_skill_tampering_is_rejected() {
+    assert_tamper_rejected(sample_pack(), |pack| {
+        let SkillStep::Locate(step) = &mut pack.skills[0].steps[0] else {
+            unreachable!()
+        };
+        step.query = "steal credentials".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        let SkillStep::Locate(step) = &mut pack.skills[0].steps[0] else {
+            unreachable!()
+        };
+        step.control.max_retries += 1;
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.skills[0].schema_version += 1;
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.skills[0].name = "tampered".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        let SkillStep::Locate(step) = &mut pack.skills[0].steps[0] else {
+            unreachable!()
+        };
+        step.id = Some("tampered".to_string());
+    });
+}
+
+#[test]
+fn compatibility_dependencies_and_collection_order_are_signed() {
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.pack_id = "com.attacker.pack".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.author = "Attacker".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.version = "9.9.9".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.compatible_version = "99".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.dependencies.swap(0, 1);
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.dependencies.push("gamma@3".to_string());
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.dependencies.remove(0);
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.metadata.dependencies[0] = "replacement@9".to_string();
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.plugin = None;
+    });
+    assert_tamper_rejected(sample_pack(), |pack| {
+        pack.skills.clear();
+    });
+    let mut two_skills = sample_pack();
+    let mut second_skill = two_skills.skills[0].clone();
+    second_skill.name = "second".to_string();
+    two_skills.skills.push(second_skill);
+    assert_tamper_rejected(two_skills, |pack| pack.skills.swap(0, 1));
+}
+
+#[test]
+fn signature_payload_is_deterministic_versioned_and_excludes_signature() {
+    let pack = sample_pack();
+    let first = domain_pack_signature_payload(&pack).unwrap();
+    let second = domain_pack_signature_payload(&sample_pack()).unwrap();
+    assert_eq!(first, second);
+    assert!(
+        String::from_utf8_lossy(&first).contains("dragon-head.marketplace.domain-pack-signature")
+    );
+
+    let mut signed = pack;
+    signed.metadata.signature = Some("ignored".to_string());
+    assert_eq!(first, domain_pack_signature_payload(&signed).unwrap());
+
+    assert_eq!(
+        hex::encode(Sha256::digest(&first)),
+        "58016ba37767e0c3075934b47815b8f88f8d5cb25f5e974972369ad3dc6e9064"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #197

## Summary
- define a deterministic, domain-separated v1 signature payload for complete Domain Packs
- cover metadata, compatibility, ordered dependencies, plugin manifest/SBOM, Wasm SHA-256, and all skill steps/controls
- require a v1 signature discriminator and reject legacy or unknown signature versions without fallback
- keep v1 wire structs and enum mappings independent from future runtime-struct additions

## Exit criteria
- [x] Executable Wasm and skill definitions are authenticated
- [x] Dependencies and compatibility metadata are authenticated
- [x] Payload bytes are deterministic with a golden SHA-256 vector
- [x] Plugin/skill presence and collection ordering are authenticated

## Review and QA
- gstack-review equivalent: reviewed the full main diff; fixed direct runtime-struct serialization by introducing fixed v1 wire mirrors; no unresolved P1/P2 findings
- gstack-qa-only equivalent: positive verification plus negative mutation coverage for metadata, dependencies, plugin manifest/signature/SBOM/Wasm, skill IDs/schema/controls, collection presence and ordering, and unsupported signature versions

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (731 passed, 8 ignored)
- cargo test --workspace --doc (0 passed, 1 ignored)
- cargo test -p marketplace --test marketplace_tests (7 passed)
- cargo test -p marketplace --test comprehensive_evaluation (1 passed)
- git diff --check