### PR TITLE
[ISSUE-224] Enforce advertised MCP tool schemas

### DIFF
--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 sha2 = "0.10"
 hex = "0.4"
 toml = { workspace = true }
+jsonschema = "0.37"
 
 [[bin]]
 name = "dragon-head-mcp"
@@ -24,7 +25,6 @@ path = "src/main.rs"
 [dev-dependencies]
 escargot = "0.5"
 json-patch = "4.2"
-jsonschema = "0.37"
 tempfile = "3.10"
 tokio = { workspace = true }
 urlencoding = "2.1"

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -29,7 +29,7 @@ use skills_engine::{
 };
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -48,6 +48,12 @@ pub struct ToolDefinition {
     pub input_schema: Value,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("invalid arguments for tool `{tool}`")]
+struct InvalidToolArguments {
+    tool: String,
+}
+
 fn is_known_tool(name: &str) -> bool {
     matches!(
         name,
@@ -60,6 +66,41 @@ fn is_known_tool(name: &str) -> bool {
             | "get_usage_report"
             | "extract"
     )
+}
+
+fn validate_tool_arguments(name: &str, arguments: &Value) -> Result<()> {
+    static VALIDATORS: OnceLock<HashMap<&'static str, jsonschema::Validator>> = OnceLock::new();
+    let validators = VALIDATORS.get_or_init(|| {
+        [
+            ("get_state", get_state_input_schema()),
+            ("act", act_input_schema()),
+            ("verify", verify_input_schema()),
+            ("get_visual", get_visual_input_schema()),
+            ("ask_human", ask_human_input_schema()),
+            ("run_skill", run_skill_input_schema()),
+            ("get_usage_report", get_usage_report_input_schema()),
+            ("extract", extract_input_schema()),
+        ]
+        .into_iter()
+        .map(|(tool, schema)| {
+            let validator = jsonschema::validator_for(&schema)
+                .unwrap_or_else(|error| panic!("invalid input schema for {tool}: {error}"));
+            (tool, validator)
+        })
+        .collect()
+    });
+
+    let Some(validator) = validators.get(name) else {
+        anyhow::bail!("unknown MCP tool: {name}");
+    };
+    if validator.is_valid(arguments) {
+        Ok(())
+    } else {
+        Err(InvalidToolArguments {
+            tool: name.to_string(),
+        }
+        .into())
+    }
 }
 
 pub trait McpBackend {
@@ -174,6 +215,11 @@ impl<B: McpBackend> McpServer<B> {
     }
 
     pub fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value> {
+        if !is_known_tool(name) {
+            anyhow::bail!("unknown MCP tool: {name}");
+        }
+        validate_tool_arguments(name, &arguments)?;
+
         if name == "get_usage_report" {
             return self.get_usage_report_payload();
         }
@@ -290,7 +336,13 @@ impl<B: McpBackend> McpServer<B> {
                                     }]
                                 })
                             })
-                            .map_err(|err| (-32000, err.to_string()))
+                            .map_err(|err| {
+                                if err.downcast_ref::<InvalidToolArguments>().is_some() {
+                                    (-32602, err.to_string())
+                                } else {
+                                    (-32000, err.to_string())
+                                }
+                            })
                     }
                     Some(unknown) => Err((-32601, format!("unknown tool: {unknown}"))),
                     None => Err((
@@ -331,7 +383,8 @@ impl<B: McpBackend> McpServer<B> {
     fn check_plan_gate(&self, name: &str, arguments: &Value) -> Option<Value> {
         match name {
             "get_state" => {
-                let args = parse_get_state_arguments(arguments);
+                let args = parse_get_state_arguments(arguments)
+                    .expect("tool arguments were validated before plan gating");
                 if args.delivery == StateDelivery::Delta {
                     return self
                         .ensure_plan_feature(PlanFeature::SemanticDelta)
@@ -398,7 +451,8 @@ impl<B: McpBackend> McpServer<B> {
     ) {
         match name {
             "get_state" => {
-                let args = parse_get_state_arguments(arguments);
+                let args = parse_get_state_arguments(arguments)
+                    .expect("tool arguments were validated before usage metering");
                 match args.delivery {
                     StateDelivery::Delta => {
                         self.usage_meters.state_generations.delta += 1;
@@ -471,6 +525,7 @@ enum StateDelivery {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct GetStateArguments {
     #[serde(default)]
     format: StateFormat,
@@ -491,6 +546,7 @@ impl Default for GetStateArguments {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ActArguments {
     #[serde(default)]
     target_id: Option<i64>,
@@ -527,6 +583,7 @@ fn action_signature_for_act(args: &ActArguments) -> ActionSignature {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct VerifyArguments {
     target_id: i64,
     #[serde(default)]
@@ -535,11 +592,13 @@ struct VerifyArguments {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct VerifyExpected {
     text: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct GetVisualArguments {
     #[serde(default = "default_visual_mode")]
     mode: String,
@@ -556,6 +615,7 @@ fn default_viewport() -> String {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AskHumanArguments {
     reason: String,
     #[serde(default)]
@@ -563,6 +623,7 @@ struct AskHumanArguments {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RunSkillArguments {
     skill_name: String,
     #[serde(default = "default_skill_params")]
@@ -573,8 +634,8 @@ fn default_skill_params() -> Value {
     json!({})
 }
 
-fn parse_get_state_arguments(arguments: &Value) -> GetStateArguments {
-    serde_json::from_value(arguments.clone()).unwrap_or_default()
+fn parse_get_state_arguments(arguments: &Value) -> Result<GetStateArguments> {
+    serde_json::from_value(arguments.clone()).context("invalid get_state arguments")
 }
 
 /// Outcome of [`resolve_speculative_state`] — distinguishes a verified
@@ -1161,7 +1222,7 @@ impl CoreRuntimeBackend {
 
 impl McpBackend for CoreRuntimeBackend {
     fn get_state(&mut self, arguments: Value) -> Result<Value> {
-        let args = parse_get_state_arguments(&arguments);
+        let args = parse_get_state_arguments(&arguments)?;
 
         match args.delivery {
             StateDelivery::Full => {
@@ -2139,7 +2200,11 @@ fn act_input_schema() -> Value {
         "additionalProperties": false,
         "required": ["action"],
         "properties": {
-            "target_id": { "type": "integer" },
+            "target_id": {
+                "type": "integer",
+                "minimum": i64::MIN,
+                "maximum": i64::MAX
+            },
             "target_stable_key": { "type": "string" },
             "action": {
                 "type": "string",
@@ -2156,7 +2221,11 @@ fn verify_input_schema() -> Value {
         "additionalProperties": false,
         "required": ["target_id", "expected"],
         "properties": {
-            "target_id": { "type": "integer" },
+            "target_id": {
+                "type": "integer",
+                "minimum": i64::MIN,
+                "maximum": i64::MAX
+            },
             "target_stable_key": { "type": "string" },
             "expected": {
                 "type": "object",
@@ -2220,6 +2289,54 @@ fn get_usage_report_input_schema() -> Value {
 }
 
 fn extract_input_schema() -> Value {
+    let inline_rule_schema = json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["selector"],
+                "properties": {
+                    "selector": { "type": "string", "minLength": 1 },
+                    "attribute": { "type": "string", "minLength": 1 }
+                }
+            },
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["selector", "fields"],
+                "properties": {
+                    "selector": { "type": "string", "minLength": 1 },
+                    "fields": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": { "type": "string", "minLength": 1 }
+                    }
+                }
+            },
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["items"],
+                "properties": {
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["selector", "fields"],
+                        "properties": {
+                            "selector": { "type": "string", "minLength": 1 },
+                            "fields": {
+                                "type": "object",
+                                "minProperties": 1,
+                                "additionalProperties": { "type": "string", "minLength": 1 }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "description": "Inline Deep Lens DSL rule"
+    });
+
     json!({
         "type": "object",
         "additionalProperties": false,
@@ -2237,10 +2354,7 @@ fn extract_input_schema() -> Value {
             {
                 "required": ["inline"],
                 "properties": {
-                    "inline": {
-                        "type": "object",
-                        "description": "Inline Deep Lens DSL rule"
-                    }
+                    "inline": inline_rule_schema.clone()
                 }
             }
         ],
@@ -2250,10 +2364,7 @@ fn extract_input_schema() -> Value {
                 "minLength": 1,
                 "description": "Name of a pre-registered SchemaRegistry rule"
             },
-            "inline": {
-                "type": "object",
-                "description": "Inline Deep Lens DSL rule (used when rule_name is not provided)"
-            }
+            "inline": inline_rule_schema
         }
     })
 }

--- a/mcp-server/tests/mcp_client_contract.rs
+++ b/mcp-server/tests/mcp_client_contract.rs
@@ -156,16 +156,19 @@ fn test_mcp_contract_exposes_required_tools() {
 fn test_mcp_contract_all_tools_are_callable() {
     let mut server = McpServer::new(MockBackend);
 
-    for name in [
-        "get_state",
-        "act",
-        "verify",
-        "get_visual",
-        "ask_human",
-        "run_skill",
+    for (name, arguments) in [
+        ("get_state", json!({})),
+        ("act", json!({"action": "click"})),
+        (
+            "verify",
+            json!({"target_id": 1, "expected": {"text": "ready"}}),
+        ),
+        ("get_visual", json!({})),
+        ("ask_human", json!({"reason": "approval required"})),
+        ("run_skill", json!({"skill_name": "checkout"})),
     ] {
         let result = server
-            .call_tool(name, json!({}))
+            .call_tool(name, arguments)
             .unwrap_or_else(|_| panic!("tool call failed for {name}"));
         assert_eq!(result["ok"], json!(true));
         assert_eq!(result["tool"], json!(name));

--- a/mcp-server/tests/mcp_protocol_compliance.rs
+++ b/mcp-server/tests/mcp_protocol_compliance.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use mcp_server::{McpBackend, McpServer};
+use mcp_server::{McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
 
 #[derive(Default)]
@@ -228,4 +228,171 @@ fn test_tool_call_missing_name_returns_32602() {
         .expect("response");
     let response: Value = serde_json::from_str(&response_raw).expect("response json");
     assert_eq!(response["error"]["code"], json!(-32602));
+}
+
+#[derive(Default)]
+struct CountingBackend {
+    calls: usize,
+}
+
+impl McpBackend for CountingBackend {
+    fn get_state(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"metadata": {}, "interactive_elements": []}))
+    }
+    fn act(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"status": "ok"}))
+    }
+    fn verify(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"matched": true}))
+    }
+    fn get_visual(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"mode": "som", "image_sha256": "abc"}))
+    }
+    fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"approved": true}))
+    }
+    fn run_skill(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"status": "completed"}))
+    }
+    fn extract(&mut self, _arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(json!({"result": null}))
+    }
+}
+
+fn call_tool_jsonrpc<B: McpBackend>(
+    server: &mut McpServer<B>,
+    name: &str,
+    arguments: Value,
+) -> Value {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 99,
+        "method": "tools/call",
+        "params": { "name": name, "arguments": arguments }
+    });
+    serde_json::from_str(
+        &server
+            .handle_jsonrpc(&request.to_string())
+            .expect("tools/call response"),
+    )
+    .expect("response json")
+}
+
+#[test]
+fn every_tool_rejects_unknown_fields_without_side_effects() {
+    let cases = [
+        ("get_state", json!({"unexpected": true})),
+        ("act", json!({"action": "click", "unexpected": true})),
+        (
+            "verify",
+            json!({"target_id": 1, "expected": {"text": "ok"}, "unexpected": true}),
+        ),
+        ("get_visual", json!({"unexpected": true})),
+        (
+            "ask_human",
+            json!({"reason": "approve", "unexpected": true}),
+        ),
+        (
+            "run_skill",
+            json!({"skill_name": "checkout", "unexpected": true}),
+        ),
+        ("get_usage_report", json!({"unexpected": true})),
+        ("extract", json!({"rule_name": "price", "unexpected": true})),
+    ];
+
+    for (name, arguments) in cases {
+        let mut server = McpServer::new(CountingBackend::default());
+        let before = server.call_tool("get_usage_report", json!({})).unwrap();
+        let response = call_tool_jsonrpc(&mut server, name, arguments);
+        let after = server.call_tool("get_usage_report", json!({})).unwrap();
+
+        assert_eq!(response["error"]["code"], -32602, "tool: {name}");
+        assert!(response.get("result").is_none(), "tool: {name}");
+        assert_eq!(server.backend_mut().calls, 0, "tool: {name}");
+        assert_eq!(before, after, "usage changed for tool: {name}");
+    }
+}
+
+#[test]
+fn malformed_enums_types_and_nested_fields_return_invalid_params() {
+    let cases = [
+        ("get_state", json!({"format": "xml"})),
+        ("get_state", json!({"delivery": "detla"})),
+        ("get_state", json!({"force_refresh": "true"})),
+        ("get_state", json!([])),
+        ("get_visual", json!({"mode": "annotated"})),
+        ("get_visual", json!({"viewport": "visible"})),
+        ("get_visual", json!({"mode": false})),
+        (
+            "act",
+            json!({"action": "click", "target_id": 9_223_372_036_854_775_808_u64}),
+        ),
+        (
+            "verify",
+            json!({
+                "target_id": 9_223_372_036_854_775_808_u64,
+                "expected": {"text": "ok"}
+            }),
+        ),
+        (
+            "verify",
+            json!({"target_id": 1, "expected": {"text": "ok", "unexpected": true}}),
+        ),
+        ("verify", json!({"target_id": 1, "expected": {"text": ""}})),
+        ("ask_human", json!({"reason": ""})),
+        ("run_skill", json!({"skill_name": "checkout", "params": []})),
+        ("run_skill", json!({"skill_name": ""})),
+        ("extract", json!({"rule_name": "price", "inline": {}})),
+        ("extract", json!({"inline": []})),
+        ("extract", json!({"inline": {}})),
+        (
+            "extract",
+            json!({"inline": {"selector": ".item", "fields": {}}}),
+        ),
+        (
+            "extract",
+            json!({"inline": {"items": {"selector": ".item", "fields": {"price": 1}}}}),
+        ),
+        ("extract", json!({"rule_name": ""})),
+        ("extract", json!({})),
+    ];
+
+    for (name, arguments) in cases {
+        let mut server = McpServer::new(CountingBackend::default());
+        let response = call_tool_jsonrpc(&mut server, name, arguments);
+        assert_eq!(response["error"]["code"], -32602, "tool: {name}");
+        assert_eq!(server.backend_mut().calls, 0, "tool: {name}");
+    }
+}
+
+#[test]
+fn invalid_visual_mode_is_rejected_before_plan_gate() {
+    let mut server = McpServer::new_with_plan(CountingBackend::default(), PlanTier::Developer);
+    let response = call_tool_jsonrpc(&mut server, "get_visual", json!({"mode": "invalid"}));
+
+    assert_eq!(response["error"]["code"], -32602);
+    assert_eq!(server.backend_mut().calls, 0);
+}
+
+#[test]
+fn omitted_optional_fields_keep_current_defaults() {
+    let mut server = McpServer::new(CountingBackend::default());
+
+    let state = call_tool_jsonrpc(&mut server, "get_state", json!({}));
+    let visual = call_tool_jsonrpc(&mut server, "get_visual", json!({}));
+
+    assert!(state.get("result").is_some());
+    assert!(visual.get("result").is_some());
+    assert_eq!(server.backend_mut().calls, 2);
+    let report = server.call_tool("get_usage_report", json!({})).unwrap();
+    assert_eq!(report["state_generations"]["full"], 1);
+    assert_eq!(report["state_generations"]["delta"], 0);
+    assert_eq!(report["visual_captures"], 1);
 }


### PR DESCRIPTION
Closes #224

## Summary
- validate every tools/call argument against the same schemas returned by tools/list
- reject malformed arguments as JSON-RPC -32602 before plan gates, backend calls, or metering
- keep omitted optional-field defaults while enforcing strict DTOs, i64 bounds, and inline extraction DSL shapes

## Acceptance criteria
- invalid enums, types, and unknown fields return -32602
- invalid requests have zero backend and usage-meter side effects
- optional defaults remain unchanged
- all eight tool schemas are shared by listing and runtime validation

## Verification
- cargo test -p mcp-server: 184 passed, 2 ignored
- cargo test --workspace: 744 passed, 8 ignored
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt --all -- --check: clean

## Review and QA
- pre-landing API/security and test-strategy reviews: no unresolved P1/P2
- backend/schema QA: all eight minimal-valid and unknown-field cases, malformed enums/types, nested fields, i64 overflow, inline DSL variants, plan-gate order, metering, and defaults verified
- review fixes: added i64 schema bounds and exact Deep Lens inline rule schemas with negative tests