### PR TITLE
[ISSUE-223] Make HITL approval resolution retries resumable

### DIFF
--- a/core-runtime/src/browser/mod.rs
+++ b/core-runtime/src/browser/mod.rs
@@ -927,12 +927,12 @@ impl PageSession {
 
     /// Approve the latest pending policy request.
     pub fn approve_pending_policy_action(&self) -> Result<()> {
-        let mut guard = self
+        let guard = self
             .policy_approvals
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock policy approval state"))?;
 
-        let Some(request) = guard.pending.take() else {
+        let Some(request) = guard.pending.clone() else {
             anyhow::bail!("No pending policy approval request");
         };
 
@@ -952,6 +952,10 @@ impl PageSession {
             .policy_approvals
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock policy approval state"))?;
+        if guard.pending.as_ref() != Some(&request) {
+            anyhow::bail!("Pending policy approval request changed before commit");
+        }
+        guard.pending = None;
         guard.granted.push(GrantedPolicyApproval {
             request,
             granted_navigation_epoch,

--- a/docs/hitl-slack-bridge.md
+++ b/docs/hitl-slack-bridge.md
@@ -20,9 +20,9 @@ PageSession (ask_human pending) ──poll──▶ Bridge ──notify──▶
                                              │              reviewer clicks Approve/Reject
                                              │                        │
                                              ▼                        ▼
-                                  SessionLockRegistry ◀── POST /slack/interactions
+                                  ResolutionRegistry ◀── POST /slack/interactions
                                              │
-                              (winner) ──▶ gateway.approve()/reject() ──▶ audit trail ──▶ chat update
+                    (owner / exact retry) ──▶ gateway.approve()/reject() ──▶ audit trail ──▶ chat update
 ```
 
 1. **Polling** (`Bridge::poll_once`, `bridge.rs`): on a fixed interval (default 1s),
@@ -36,10 +36,11 @@ PageSession (ask_human pending) ──poll──▶ Bridge ──notify──▶
    (≤5 minutes, matching Slack's documented recommendation). Verification fails
    closed — malformed, unsigned, stale, or mis-signed requests are rejected (`401`)
    before any gateway/lock/audit state is touched.
-3. **Resolution** (`Bridge::resolve`): enforces a strict order — **claim the
-   session-level lock → mutate the gateway (approve/reject) → write the audit
-   record → update the chat message**. A lock loss never leaves a partial mutation;
-   a lock win is always durably recorded before the chat message changes.
+3. **Resolution** (`Bridge::resolve`): enforces resumable phases — **claim the
+   request → mutate the gateway (approve/reject) → write the audit record → update
+   the chat message**. The first reviewer and decision own the request. If a phase
+   fails, only that exact reviewer/decision pair may retry, starting at the first
+   incomplete phase; competing decisions never repeat an earlier side effect.
 
 ## Message format
 
@@ -68,21 +69,22 @@ Once resolved, the original message is replaced (`chat.update`) with a static
 
 ## Session-lock / "first decision wins" semantics
 
-`SessionLockRegistry` (`lock.rs`) is a `Mutex<HashMap<Uuid, Claim>>`. `try_claim`
-atomically checks-and-sets: the first caller for a given request ID wins
-(`ClaimOutcome::Won`) and proceeds to mutate the gateway, write the audit record, and
-update chat; every subsequent caller for the same ID loses (`ClaimOutcome::LostTo {
-decided_by, decision }`) and is told who already resolved it and what they decided —
-no gateway, audit, or notifier mutation happens on the losing path. This is what
+`Bridge` keeps a per-request `ResolutionProgress` behind a mutex. Creating the entry
+atomically claims the request for one `(decided_by, decision)` pair. A competing pair
+is told who already resolved it and cannot touch the gateway, audit trail, or chat.
+The owning pair may retry an incomplete `gateway_applied`, `audited`, or
+`chat_updated` phase; completed phases are skipped. The registry is capped at 1,024
+entries. Completed history is evicted oldest-first, while a registry full of
+unrepaired failures rejects new claims instead of growing without bound. This is what
 `tests/bridge_flow.rs::concurrent_resolutions_of_the_same_request_apply_exactly_once`
-verifies: four reviewers race to resolve the same request and exactly one mutation,
-one audit record, and one chat update occur.
+and the fail-once phase tests in `bridge.rs` verify.
 
 ## Audit trail format
 
 `BridgeAuditTrail` (`audit.rs`) is an append-only NDJSON log — one immutable JSON
-record per line, opened in append mode and `fsync`'d on every write so a crash never
-leaves a torn or missing entry:
+record per line, opened in append mode and `fsync`'d before a write reports success.
+An identical retry for an existing request ID is idempotent; conflicting decision
+data for the same ID is rejected:
 
 ```json
 {"id":"5b1b...","decision":"approved","decided_by":"alice","decided_at_ms":1717740000000,"outcome_projection":{"projected_amount":900.5,"risk_level":"high"}}
@@ -143,10 +145,11 @@ curl -s -o /dev/null -w '%{http_code}\n' \
   http://localhost:8787/slack/interactions
 ```
 
-A `200` indicates the bridge claimed the lock, mutated the gateway, wrote an audit
-record, and updated the chat message; a `409` indicates the lock was already claimed
-by another reviewer; a `401`/`400` indicates signature verification or payload
-parsing failed (check the bridge's `tracing` logs for the rejection reason).
+A `200` indicates all resolution phases completed. A `409` indicates either that a
+different reviewer/decision owns the request or that the owning decision hit a
+retryable gateway, audit, or chat-update failure; a `401`/`400` indicates signature
+verification or payload parsing failed (check the bridge's `tracing` logs for the
+rejection reason).
 
 ## Evaluation-bench exemption
 

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use core_runtime::OutcomeProjection;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -16,6 +17,8 @@ use std::sync::Mutex;
 use uuid::Uuid;
 
 use crate::lock::Decision;
+
+const MAX_RECENT_AUDIT_RECORDS: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -49,14 +52,29 @@ pub struct AuditRecord {
 /// `fsync`s before returning, so a crash never leaves a torn or missing entry.
 pub struct BridgeAuditTrail {
     path: PathBuf,
-    write_lock: Mutex<()>,
+    state: Mutex<AuditState>,
+}
+
+#[derive(Default)]
+struct AuditState {
+    initialized: bool,
+    recent_records: VecDeque<AuditRecord>,
+}
+
+impl AuditState {
+    fn remember(&mut self, record: AuditRecord) {
+        self.recent_records.push_back(record);
+        while self.recent_records.len() > MAX_RECENT_AUDIT_RECORDS {
+            self.recent_records.pop_front();
+        }
+    }
 }
 
 impl BridgeAuditTrail {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
             path: path.into(),
-            write_lock: Mutex::new(()),
+            state: Mutex::new(AuditState::default()),
         }
     }
 
@@ -70,7 +88,7 @@ impl BridgeAuditTrail {
     pub fn record(&self, record: &AuditRecord) -> Result<()> {
         let line = serde_json::to_string(record).context("failed to serialize audit record")?;
 
-        let _guard = self.write_lock.lock().expect("audit trail mutex poisoned");
+        let mut state = self.state.lock().expect("audit trail mutex poisoned");
         let mut file = OpenOptions::new()
             .create(true)
             .read(true)
@@ -78,26 +96,40 @@ impl BridgeAuditTrail {
             .open(&self.path)
             .with_context(|| format!("failed to open audit trail at {}", self.path.display()))?;
 
-        for existing_line in BufReader::new(&file).lines() {
-            let existing_line = existing_line.context("failed to inspect audit trail")?;
-            if existing_line.trim().is_empty() {
-                continue;
-            }
-            let existing: AuditRecord = serde_json::from_str(&existing_line)
-                .context("failed to parse existing audit record")?;
-            if existing.id == record.id {
-                if existing != *record {
-                    anyhow::bail!(
-                        "audit record {} conflicts with an existing decision",
-                        record.id
-                    );
+        if !state.initialized {
+            for existing_line in BufReader::new(&file).lines() {
+                let existing_line = existing_line.context("failed to inspect audit trail")?;
+                if existing_line.trim().is_empty() {
+                    continue;
                 }
-                file.sync_all().context("failed to fsync audit trail")?;
-                return Ok(());
+                match serde_json::from_str::<AuditRecord>(&existing_line) {
+                    Ok(existing) => state.remember(existing),
+                    Err(error) => tracing::warn!(
+                        %error,
+                        "ignoring malformed historical HITL audit record"
+                    ),
+                }
             }
+            state.initialized = true;
+        }
+
+        if let Some(existing) = state
+            .recent_records
+            .iter()
+            .find(|existing| existing.id == record.id)
+        {
+            if existing != record {
+                anyhow::bail!(
+                    "audit record {} conflicts with an existing decision",
+                    record.id
+                );
+            }
+            file.sync_all().context("failed to fsync audit trail")?;
+            return Ok(());
         }
 
         writeln!(file, "{line}").context("failed to write audit record")?;
+        state.remember(record.clone());
         file.sync_all().context("failed to fsync audit trail")?;
         Ok(())
     }
@@ -107,7 +139,7 @@ impl BridgeAuditTrail {
     /// Intended for tests and operator inspection — the bridge itself is
     /// write-only.
     pub fn read_all(&self) -> Result<Vec<AuditRecord>> {
-        let _guard = self.write_lock.lock().expect("audit trail mutex poisoned");
+        let _guard = self.state.lock().expect("audit trail mutex poisoned");
         let contents = match std::fs::read_to_string(&self.path) {
             Ok(contents) => contents,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -192,6 +224,49 @@ mod tests {
         trail.record(&record).expect("idempotent retry");
 
         assert_eq!(trail.read_all().expect("read audit trail"), vec![record]);
+    }
+
+    #[test]
+    fn malformed_history_does_not_block_new_audit_records() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("audit.ndjson");
+        std::fs::write(&path, "{truncated\n").expect("write malformed history");
+        let trail = BridgeAuditTrail::new(&path);
+        let record = sample_record(Uuid::new_v4(), AuditDecision::Approved);
+
+        trail
+            .record(&record)
+            .expect("malformed history must not block a new decision");
+
+        let contents = std::fs::read_to_string(path).expect("read audit trail");
+        assert_eq!(contents.lines().count(), 2);
+        assert_eq!(
+            serde_json::from_str::<AuditRecord>(contents.lines().nth(1).expect("new record"))
+                .expect("valid appended record"),
+            record
+        );
+    }
+
+    #[test]
+    fn in_memory_audit_index_is_bounded() {
+        let dir = tempdir().expect("tempdir");
+        let trail = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+
+        for _ in 0..=MAX_RECENT_AUDIT_RECORDS {
+            trail
+                .record(&sample_record(Uuid::new_v4(), AuditDecision::Approved))
+                .expect("record");
+        }
+
+        assert_eq!(
+            trail
+                .state
+                .lock()
+                .expect("audit trail mutex")
+                .recent_records
+                .len(),
+            MAX_RECENT_AUDIT_RECORDS
+        );
     }
 
     #[test]

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -58,6 +58,7 @@ pub struct BridgeAuditTrail {
 #[derive(Default)]
 struct AuditState {
     initialized: bool,
+    persistent_index: bool,
     recent_records: VecDeque<AuditRecord>,
 }
 
@@ -103,7 +104,16 @@ impl BridgeAuditTrail {
                 );
             }
         }
-        std::fs::create_dir_all(self.index_dir()).context("failed to create audit index")?;
+        state.persistent_index = match std::fs::create_dir_all(self.index_dir()) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "persistent HITL audit index unavailable; using on-disk scan fallback"
+                );
+                false
+            }
+        };
         let file = match std::fs::File::open(&self.path) {
             Ok(file) => file,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -119,12 +129,17 @@ impl BridgeAuditTrail {
             }
             match serde_json::from_str::<AuditRecord>(&existing_line) {
                 Ok(existing) => {
-                    std::fs::write(
-                        self.index_path(existing.id),
-                        serde_json::to_vec(&existing)
-                            .context("failed to serialize audit index record")?,
-                    )
-                    .context("failed to rebuild audit index")?;
+                    if state.persistent_index {
+                        let bytes = serde_json::to_vec(&existing)
+                            .context("failed to serialize audit index record")?;
+                        if let Err(error) = std::fs::write(self.index_path(existing.id), bytes) {
+                            tracing::warn!(
+                                %error,
+                                "persistent HITL audit index became unavailable; using scan fallback"
+                            );
+                            state.persistent_index = false;
+                        }
+                    }
                     state.remember(existing);
                 }
                 Err(error) => tracing::warn!(
@@ -141,6 +156,23 @@ impl BridgeAuditTrail {
     pub fn prepare(&self) -> Result<()> {
         let mut state = self.state.lock().expect("audit trail mutex poisoned");
         self.prepare_locked(&mut state)
+    }
+
+    fn find_record_in_history(&self, id: Uuid) -> Result<Option<AuditRecord>> {
+        let file = match std::fs::File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error).context("failed to search audit trail"),
+        };
+        for line in BufReader::new(file).lines() {
+            let line = line.context("failed to search audit trail")?;
+            if let Ok(record) = serde_json::from_str::<AuditRecord>(&line) {
+                if record.id == id {
+                    return Ok(Some(record));
+                }
+            }
+        }
+        Ok(None)
     }
 
     /// Append `record` as a single NDJSON line, fsync'd before returning.
@@ -162,7 +194,7 @@ impl BridgeAuditTrail {
             .iter()
             .find(|existing| existing.id == record.id)
             .cloned();
-        let indexed = if cached.is_none() {
+        let indexed = if cached.is_none() && state.persistent_index {
             match std::fs::read(self.index_path(record.id)) {
                 Ok(bytes) => Some(
                     serde_json::from_slice::<AuditRecord>(&bytes)
@@ -174,7 +206,12 @@ impl BridgeAuditTrail {
         } else {
             None
         };
-        if let Some(existing) = cached.as_ref().or(indexed.as_ref()) {
+        let scanned = if cached.is_none() && indexed.is_none() && !state.persistent_index {
+            self.find_record_in_history(record.id)?
+        } else {
+            None
+        };
+        if let Some(existing) = cached.as_ref().or(indexed.as_ref()).or(scanned.as_ref()) {
             if existing != record {
                 anyhow::bail!(
                     "audit record {} conflicts with an existing decision",
@@ -188,11 +225,17 @@ impl BridgeAuditTrail {
         writeln!(file, "{line}").context("failed to write audit record")?;
         state.remember(record.clone());
         file.sync_all().context("failed to fsync audit trail")?;
-        std::fs::write(
-            self.index_path(record.id),
-            serde_json::to_vec(record).context("failed to serialize audit index record")?,
-        )
-        .context("failed to persist audit index record")?;
+        if state.persistent_index {
+            let bytes =
+                serde_json::to_vec(record).context("failed to serialize audit index record")?;
+            if let Err(error) = std::fs::write(self.index_path(record.id), bytes) {
+                tracing::warn!(
+                    %error,
+                    "persistent HITL audit index became unavailable; using scan fallback"
+                );
+                state.persistent_index = false;
+            }
+        }
         Ok(())
     }
 

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use core_runtime::OutcomeProjection;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
@@ -88,7 +89,13 @@ impl BridgeAuditTrail {
     }
 
     fn index_path(&self, id: Uuid) -> PathBuf {
-        self.index_dir().join(format!("{id}.json"))
+        self.index_dir().join(format!("{id}.sha256"))
+    }
+
+    fn record_digest(record: &AuditRecord) -> Result<String> {
+        let bytes =
+            serde_json::to_vec(record).context("failed to serialize audit record digest")?;
+        Ok(hex::encode(Sha256::digest(bytes)))
     }
 
     fn prepare_locked(&self, state: &mut AuditState) -> Result<()> {
@@ -130,8 +137,7 @@ impl BridgeAuditTrail {
             match serde_json::from_str::<AuditRecord>(&existing_line) {
                 Ok(existing) => {
                     if state.persistent_index {
-                        let bytes = serde_json::to_vec(&existing)
-                            .context("failed to serialize audit index record")?;
+                        let bytes = Self::record_digest(&existing)?;
                         if let Err(error) = std::fs::write(self.index_path(existing.id), bytes) {
                             tracing::warn!(
                                 %error,
@@ -194,25 +200,34 @@ impl BridgeAuditTrail {
             .iter()
             .find(|existing| existing.id == record.id)
             .cloned();
-        let indexed = if cached.is_none() && state.persistent_index {
+        let indexed_digest = if cached.is_none() && state.persistent_index {
             match std::fs::read(self.index_path(record.id)) {
-                Ok(bytes) => Some(
-                    serde_json::from_slice::<AuditRecord>(&bytes)
-                        .context("failed to parse audit index record")?,
-                ),
+                Ok(bytes) => {
+                    Some(String::from_utf8(bytes).context("failed to parse audit index digest")?)
+                }
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
                 Err(error) => return Err(error).context("failed to read audit index record"),
             }
         } else {
             None
         };
-        let scanned = if cached.is_none() && indexed.is_none() && !state.persistent_index {
+        let scanned = if cached.is_none() && indexed_digest.is_none() && !state.persistent_index {
             self.find_record_in_history(record.id)?
         } else {
             None
         };
-        if let Some(existing) = cached.as_ref().or(indexed.as_ref()).or(scanned.as_ref()) {
+        if let Some(existing) = cached.as_ref().or(scanned.as_ref()) {
             if existing != record {
+                anyhow::bail!(
+                    "audit record {} conflicts with an existing decision",
+                    record.id
+                );
+            }
+            file.sync_all().context("failed to fsync audit trail")?;
+            return Ok(());
+        }
+        if let Some(existing_digest) = indexed_digest {
+            if existing_digest != Self::record_digest(record)? {
                 anyhow::bail!(
                     "audit record {} conflicts with an existing decision",
                     record.id
@@ -226,8 +241,7 @@ impl BridgeAuditTrail {
         state.remember(record.clone());
         file.sync_all().context("failed to fsync audit trail")?;
         if state.persistent_index {
-            let bytes =
-                serde_json::to_vec(record).context("failed to serialize audit index record")?;
+            let bytes = Self::record_digest(record)?;
             if let Err(error) = std::fs::write(self.index_path(record.id), bytes) {
                 tracing::warn!(
                     %error,

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -82,6 +82,67 @@ impl BridgeAuditTrail {
         &self.path
     }
 
+    fn index_dir(&self) -> PathBuf {
+        PathBuf::from(format!("{}.index", self.path.to_string_lossy()))
+    }
+
+    fn index_path(&self, id: Uuid) -> PathBuf {
+        self.index_dir().join(format!("{id}.json"))
+    }
+
+    fn prepare_locked(&self, state: &mut AuditState) -> Result<()> {
+        if state.initialized {
+            return Ok(());
+        }
+
+        if let Some(parent) = self.path.parent() {
+            if !parent.as_os_str().is_empty() && !parent.is_dir() {
+                anyhow::bail!(
+                    "audit trail parent directory does not exist: {}",
+                    parent.display()
+                );
+            }
+        }
+        std::fs::create_dir_all(self.index_dir()).context("failed to create audit index")?;
+        let file = match std::fs::File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                state.initialized = true;
+                return Ok(());
+            }
+            Err(error) => return Err(error).context("failed to open audit trail for indexing"),
+        };
+        for existing_line in BufReader::new(file).lines() {
+            let existing_line = existing_line.context("failed to inspect audit trail")?;
+            if existing_line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<AuditRecord>(&existing_line) {
+                Ok(existing) => {
+                    std::fs::write(
+                        self.index_path(existing.id),
+                        serde_json::to_vec(&existing)
+                            .context("failed to serialize audit index record")?,
+                    )
+                    .context("failed to rebuild audit index")?;
+                    state.remember(existing);
+                }
+                Err(error) => tracing::warn!(
+                    %error,
+                    "ignoring malformed historical HITL audit record"
+                ),
+            }
+        }
+        state.initialized = true;
+        Ok(())
+    }
+
+    /// Prepares the persistent request-ID index before gateway mutation.
+    pub fn prepare(&self) -> Result<()> {
+        let mut state = self.state.lock().expect("audit trail mutex poisoned");
+        self.prepare_locked(&mut state)
+    }
+
     /// Append `record` as a single NDJSON line, fsync'd before returning.
     /// Replaying the same request ID with an identical record is idempotent;
     /// reusing an ID for different decision data is rejected.
@@ -89,35 +150,31 @@ impl BridgeAuditTrail {
         let line = serde_json::to_string(record).context("failed to serialize audit record")?;
 
         let mut state = self.state.lock().expect("audit trail mutex poisoned");
+        self.prepare_locked(&mut state)?;
         let mut file = OpenOptions::new()
             .create(true)
-            .read(true)
             .append(true)
             .open(&self.path)
             .with_context(|| format!("failed to open audit trail at {}", self.path.display()))?;
 
-        if !state.initialized {
-            for existing_line in BufReader::new(&file).lines() {
-                let existing_line = existing_line.context("failed to inspect audit trail")?;
-                if existing_line.trim().is_empty() {
-                    continue;
-                }
-                match serde_json::from_str::<AuditRecord>(&existing_line) {
-                    Ok(existing) => state.remember(existing),
-                    Err(error) => tracing::warn!(
-                        %error,
-                        "ignoring malformed historical HITL audit record"
-                    ),
-                }
-            }
-            state.initialized = true;
-        }
-
-        if let Some(existing) = state
+        let cached = state
             .recent_records
             .iter()
             .find(|existing| existing.id == record.id)
-        {
+            .cloned();
+        let indexed = if cached.is_none() {
+            match std::fs::read(self.index_path(record.id)) {
+                Ok(bytes) => Some(
+                    serde_json::from_slice::<AuditRecord>(&bytes)
+                        .context("failed to parse audit index record")?,
+                ),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => return Err(error).context("failed to read audit index record"),
+            }
+        } else {
+            None
+        };
+        if let Some(existing) = cached.as_ref().or(indexed.as_ref()) {
             if existing != record {
                 anyhow::bail!(
                     "audit record {} conflicts with an existing decision",
@@ -131,6 +188,11 @@ impl BridgeAuditTrail {
         writeln!(file, "{line}").context("failed to write audit record")?;
         state.remember(record.clone());
         file.sync_all().context("failed to fsync audit trail")?;
+        std::fs::write(
+            self.index_path(record.id),
+            serde_json::to_vec(record).context("failed to serialize audit index record")?,
+        )
+        .context("failed to persist audit index record")?;
         Ok(())
     }
 
@@ -266,6 +328,36 @@ mod tests {
                 .recent_records
                 .len(),
             MAX_RECENT_AUDIT_RECORDS
+        );
+    }
+
+    #[test]
+    fn persistent_index_deduplicates_records_older_than_the_memory_window() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("audit.ndjson");
+        let first = sample_record(Uuid::new_v4(), AuditDecision::Approved);
+        let mut records = vec![first.clone()];
+        records.extend(
+            (0..MAX_RECENT_AUDIT_RECORDS)
+                .map(|_| sample_record(Uuid::new_v4(), AuditDecision::Approved)),
+        );
+        let contents = records
+            .iter()
+            .map(|record| serde_json::to_string(record).expect("serialize record"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        std::fs::write(&path, contents).expect("seed long audit trail");
+        let trail = BridgeAuditTrail::new(&path);
+
+        trail.record(&first).expect("old duplicate is idempotent");
+
+        assert_eq!(
+            std::fs::read_to_string(path)
+                .expect("read audit trail")
+                .lines()
+                .count(),
+            records.len()
         );
     }
 

--- a/hitl-bridge/src/audit.rs
+++ b/hitl-bridge/src/audit.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use core_runtime::OutcomeProjection;
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use uuid::Uuid;
@@ -65,15 +65,37 @@ impl BridgeAuditTrail {
     }
 
     /// Append `record` as a single NDJSON line, fsync'd before returning.
+    /// Replaying the same request ID with an identical record is idempotent;
+    /// reusing an ID for different decision data is rejected.
     pub fn record(&self, record: &AuditRecord) -> Result<()> {
         let line = serde_json::to_string(record).context("failed to serialize audit record")?;
 
         let _guard = self.write_lock.lock().expect("audit trail mutex poisoned");
         let mut file = OpenOptions::new()
             .create(true)
+            .read(true)
             .append(true)
             .open(&self.path)
             .with_context(|| format!("failed to open audit trail at {}", self.path.display()))?;
+
+        for existing_line in BufReader::new(&file).lines() {
+            let existing_line = existing_line.context("failed to inspect audit trail")?;
+            if existing_line.trim().is_empty() {
+                continue;
+            }
+            let existing: AuditRecord = serde_json::from_str(&existing_line)
+                .context("failed to parse existing audit record")?;
+            if existing.id == record.id {
+                if existing != *record {
+                    anyhow::bail!(
+                        "audit record {} conflicts with an existing decision",
+                        record.id
+                    );
+                }
+                file.sync_all().context("failed to fsync audit trail")?;
+                return Ok(());
+            }
+        }
 
         writeln!(file, "{line}").context("failed to write audit record")?;
         file.sync_all().context("failed to fsync audit trail")?;
@@ -157,6 +179,19 @@ mod tests {
             assert!(parsed.get("decided_by").is_some());
             assert!(parsed.get("outcome_projection").is_some());
         }
+    }
+
+    #[test]
+    fn recording_the_same_decision_twice_is_idempotent() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("audit.ndjson");
+        let trail = BridgeAuditTrail::new(&path);
+        let record = sample_record(Uuid::new_v4(), AuditDecision::Approved);
+
+        trail.record(&record).expect("first record");
+        trail.record(&record).expect("idempotent retry");
+
+        assert_eq!(trail.read_all().expect("read audit trail"), vec![record]);
     }
 
     #[test]

--- a/hitl-bridge/src/bridge.rs
+++ b/hitl-bridge/src/bridge.rs
@@ -1,17 +1,88 @@
 //! Orchestration: polls the gateway for new approval requests, notifies chat,
-//! and resolves interactions through the lock registry, gateway, audit trail,
-//! and chat notifier — in that order, so a lock win is always followed by a
-//! durable record before the chat message is updated.
+//! and resolves interactions through resumable gateway, audit, and notifier
+//! phases. The first decision owns the request; an exact retry by the same
+//! reviewer resumes at the first incomplete phase without duplicating earlier
+//! side effects.
 
 use anyhow::Result;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 use crate::audit::{AuditDecision, AuditRecord, BridgeAuditTrail};
 use crate::gateway::ApprovalGateway;
-use crate::lock::{ClaimOutcome, Decision, SessionLockRegistry};
+use crate::lock::Decision;
 use crate::notifier::{ApprovalNotification, ChatNotifier};
+
+const MAX_RESOLUTION_ENTRIES: usize = 1024;
+
+enum NotificationState {
+    Notifying,
+    Notified(String),
+}
+
+struct ResolutionProgress {
+    decision: Decision,
+    record: AuditRecord,
+    gateway_applied: bool,
+    audited: bool,
+    chat_updated: bool,
+}
+
+impl ResolutionProgress {
+    fn new(
+        id: Uuid,
+        decision: Decision,
+        decided_by: &str,
+        outcome_projection: Option<core_runtime::OutcomeProjection>,
+    ) -> Self {
+        Self {
+            decision,
+            record: AuditRecord {
+                id,
+                decision: AuditDecision::from(decision),
+                decided_by: decided_by.to_string(),
+                decided_at_ms: epoch_millis(),
+                outcome_projection,
+            },
+            gateway_applied: false,
+            audited: false,
+            chat_updated: false,
+        }
+    }
+
+    fn is_same_decision(&self, decision: Decision, decided_by: &str) -> bool {
+        self.decision == decision && self.record.decided_by == decided_by
+    }
+}
+
+#[derive(Default)]
+struct ResolutionRegistry {
+    entries: HashMap<Uuid, Arc<Mutex<ResolutionProgress>>>,
+    terminal_order: VecDeque<Uuid>,
+}
+
+impl ResolutionRegistry {
+    fn make_room_for_claim(&mut self) -> bool {
+        while self.entries.len() >= MAX_RESOLUTION_ENTRIES {
+            let Some(expired) = self.terminal_order.pop_front() else {
+                return false;
+            };
+            self.entries.remove(&expired);
+        }
+        true
+    }
+
+    fn mark_terminal(&mut self, id: Uuid) {
+        self.terminal_order.push_back(id);
+        while self.terminal_order.len() > MAX_RESOLUTION_ENTRIES {
+            if let Some(expired) = self.terminal_order.pop_front() {
+                self.entries.remove(&expired);
+            }
+        }
+    }
+}
 
 fn epoch_millis() -> u64 {
     SystemTime::now()
@@ -20,19 +91,19 @@ fn epoch_millis() -> u64 {
         .unwrap_or(0)
 }
 
-/// Wires the gateway, notifier, lock registry, and audit trail together.
+/// Wires the gateway, notifier, resolution registry, and audit trail together.
 ///
 /// Shared between the polling loop ([`Bridge::poll_once`]) and the HTTP
 /// handler ([`Bridge::resolve`]) — both paths funnel through `resolve` so the
-/// "claim, mutate, audit, respond" ordering is enforced exactly once.
+/// "claim, mutate, audit, respond" phases are serialized and resumed safely.
 pub struct Bridge {
     gateway: Arc<dyn ApprovalGateway>,
     notifier: Arc<dyn ChatNotifier>,
-    locks: SessionLockRegistry,
     audit: BridgeAuditTrail,
+    resolutions: Mutex<ResolutionRegistry>,
     /// Maps a request ID to the notifier-issued token for its prompt message,
     /// so [`Bridge::resolve`] can update the original message in place.
-    tokens: Mutex<std::collections::HashMap<Uuid, String>>,
+    tokens: Mutex<HashMap<Uuid, NotificationState>>,
 }
 
 impl Bridge {
@@ -44,8 +115,8 @@ impl Bridge {
         Self {
             gateway,
             notifier,
-            locks: SessionLockRegistry::new(),
             audit,
+            resolutions: Mutex::new(ResolutionRegistry::default()),
             tokens: Mutex::new(std::collections::HashMap::new()),
         }
     }
@@ -60,10 +131,11 @@ impl Bridge {
         };
 
         {
-            let tokens = self.tokens.lock().expect("token map mutex poisoned");
+            let mut tokens = self.tokens.lock().expect("token map mutex poisoned");
             if tokens.contains_key(&pending.id) {
                 return Ok(None);
             }
+            tokens.insert(pending.id, NotificationState::Notifying);
         }
 
         let notification = ApprovalNotification {
@@ -73,74 +145,108 @@ impl Bridge {
             outcome: pending.outcome.clone(),
             som_image_png: None,
         };
-        let token = self.notifier.notify(&notification)?;
+        let token = match self.notifier.notify(&notification) {
+            Ok(token) => token,
+            Err(err) => {
+                self.tokens
+                    .lock()
+                    .expect("token map mutex poisoned")
+                    .remove(&pending.id);
+                return Err(err);
+            }
+        };
 
         self.tokens
             .lock()
             .expect("token map mutex poisoned")
-            .insert(pending.id, token);
+            .insert(pending.id, NotificationState::Notified(token));
 
         Ok(Some(pending.id))
     }
 
     /// Resolves the request `id` as `decision`, attributed to `decided_by`.
     ///
-    /// Enforces the session-level exclusive lock first: if another reviewer
-    /// already claimed this request, no gateway/audit/notifier mutation
-    /// happens and an error describing the existing resolution is returned —
-    /// callers should surface this as "already resolved by @X" rather than a
-    /// generic failure.
+    /// The first reviewer and decision atomically own the request. If a phase
+    /// fails, that exact reviewer/decision pair may retry; competing decisions
+    /// never mutate the gateway, audit trail, or notifier.
     pub fn resolve(&self, id: Uuid, decision: Decision, decided_by: &str) -> Result<()> {
-        match self.locks.try_claim(id, decided_by, decision) {
-            ClaimOutcome::Won => {}
-            ClaimOutcome::LostTo {
-                decided_by,
-                decision,
-            } => {
-                anyhow::bail!("request {id} was already resolved by {decided_by} ({decision:?})");
-            }
-        }
-
-        let outcome_projection = self.gateway.pending_request().and_then(|pending| {
-            if pending.id == id {
-                pending.outcome
+        let progress = {
+            let mut resolutions = self
+                .resolutions
+                .lock()
+                .expect("resolution registry mutex poisoned");
+            if let Some(progress) = resolutions.entries.get(&id) {
+                Arc::clone(progress)
             } else {
-                None
+                if !resolutions.make_room_for_claim() {
+                    anyhow::bail!(
+                        "resolution registry capacity ({MAX_RESOLUTION_ENTRIES}) reached"
+                    );
+                }
+                let outcome_projection = self.gateway.pending_request().and_then(|pending| {
+                    if pending.id == id {
+                        pending.outcome
+                    } else {
+                        None
+                    }
+                });
+                let progress = Arc::new(Mutex::new(ResolutionProgress::new(
+                    id,
+                    decision,
+                    decided_by,
+                    outcome_projection,
+                )));
+                resolutions.entries.insert(id, Arc::clone(&progress));
+                progress
             }
-        });
+        };
 
-        match decision {
-            Decision::Approved => self.gateway.approve(id)?,
-            Decision::Rejected => self.gateway.reject(id)?,
+        let mut progress_guard = progress.lock().expect("resolution progress mutex poisoned");
+        if !progress_guard.is_same_decision(decision, decided_by) || progress_guard.chat_updated {
+            anyhow::bail!(
+                "request {id} was already resolved by {} ({:?})",
+                progress_guard.record.decided_by,
+                progress_guard.decision
+            );
         }
 
-        self.audit.record(&AuditRecord {
-            id,
-            decision: AuditDecision::from(decision),
-            decided_by: decided_by.to_string(),
-            decided_at_ms: epoch_millis(),
-            outcome_projection,
-        })?;
+        if !progress_guard.gateway_applied {
+            match decision {
+                Decision::Approved => self.gateway.approve(id)?,
+                Decision::Rejected => self.gateway.reject(id)?,
+            }
+            progress_guard.gateway_applied = true;
+        }
 
-        let token = self
-            .tokens
-            .lock()
-            .expect("token map mutex poisoned")
-            .get(&id)
-            .cloned();
-        if let Some(token) = token {
-            // Only drop the token once the chat update succeeds — if
-            // `respond` fails (e.g. a transient Slack API error), the token
-            // is the only handle that lets a retry repair the now-stale
-            // prompt for a request whose gateway mutation and audit record
-            // have already been durably committed.
+        if !progress_guard.audited {
+            self.audit.record(&progress_guard.record)?;
+            progress_guard.audited = true;
+        }
+
+        let notification = {
+            let tokens = self.tokens.lock().expect("token map mutex poisoned");
+            match tokens.get(&id) {
+                Some(NotificationState::Notifying) => {
+                    anyhow::bail!("request {id} notification is still being posted")
+                }
+                Some(NotificationState::Notified(token)) => Some(token.clone()),
+                None => None,
+            }
+        };
+        if let Some(token) = notification {
             self.notifier.respond(&token, decision, decided_by)?;
             self.tokens
                 .lock()
                 .expect("token map mutex poisoned")
                 .remove(&id);
         }
+        progress_guard.chat_updated = true;
+        drop(progress_guard);
 
+        self.resolutions
+            .lock()
+            .expect("resolution registry mutex poisoned")
+            .mark_terminal(id);
         Ok(())
     }
 }
@@ -164,7 +270,112 @@ mod tests {
     use crate::gateway::PendingApproval;
     use crate::notifier::mock::{Call, MockNotifier};
     use core_runtime::{ApprovalScope, OutcomeProjection, RiskLevel};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
+
+    struct FailOnceNotifier {
+        attempts: AtomicUsize,
+        calls: Mutex<Vec<Call>>,
+    }
+
+    impl FailOnceNotifier {
+        fn new() -> Self {
+            Self {
+                attempts: AtomicUsize::new(0),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn attempts(&self) -> usize {
+            self.attempts.load(Ordering::SeqCst)
+        }
+
+        fn calls(&self) -> Vec<Call> {
+            self.calls.lock().expect("notifier calls mutex").clone()
+        }
+    }
+
+    impl ChatNotifier for FailOnceNotifier {
+        fn notify(&self, notification: &ApprovalNotification) -> Result<String> {
+            self.calls
+                .lock()
+                .expect("notifier calls mutex")
+                .push(Call::Notify(notification.clone()));
+            Ok(format!("mock-channel:{}", notification.id))
+        }
+
+        fn respond(&self, token: &str, decision: Decision, decided_by: &str) -> Result<()> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                anyhow::bail!("injected notifier failure");
+            }
+            self.calls
+                .lock()
+                .expect("notifier calls mutex")
+                .push(Call::Respond {
+                    token: token.to_string(),
+                    decision,
+                    decided_by: decided_by.to_string(),
+                });
+            Ok(())
+        }
+    }
+
+    struct FailOnceGateway {
+        pending: Mutex<Option<PendingApproval>>,
+        attempts: AtomicUsize,
+        resolutions: Mutex<Vec<Decision>>,
+    }
+
+    struct AlwaysFailGateway;
+
+    impl ApprovalGateway for AlwaysFailGateway {
+        fn pending_request(&self) -> Option<PendingApproval> {
+            None
+        }
+
+        fn approve(&self, _id: Uuid) -> Result<()> {
+            anyhow::bail!("injected permanent gateway failure")
+        }
+
+        fn reject(&self, _id: Uuid) -> Result<()> {
+            anyhow::bail!("injected permanent gateway failure")
+        }
+    }
+
+    impl FailOnceGateway {
+        fn new(pending: PendingApproval) -> Self {
+            Self {
+                pending: Mutex::new(Some(pending)),
+                attempts: AtomicUsize::new(0),
+                resolutions: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ApprovalGateway for FailOnceGateway {
+        fn pending_request(&self) -> Option<PendingApproval> {
+            self.pending.lock().expect("pending mutex").clone()
+        }
+
+        fn approve(&self, id: Uuid) -> Result<()> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                anyhow::bail!("injected gateway failure");
+            }
+            let pending = self.pending.lock().expect("pending mutex").take();
+            if pending.as_ref().map(|pending| pending.id) != Some(id) {
+                anyhow::bail!("request is no longer pending");
+            }
+            self.resolutions
+                .lock()
+                .expect("resolutions mutex")
+                .push(Decision::Approved);
+            Ok(())
+        }
+
+        fn reject(&self, _id: Uuid) -> Result<()> {
+            anyhow::bail!("unexpected rejection")
+        }
+    }
 
     fn sample_pending(id: Uuid) -> PendingApproval {
         PendingApproval {
@@ -222,6 +433,36 @@ mod tests {
             notifier.calls().len(),
             1,
             "notify must be called exactly once"
+        );
+    }
+
+    #[test]
+    fn concurrent_polls_post_only_one_prompt() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let (bridge, _gateway, notifier) = bridge_with(id, &dir);
+        let bridge = Arc::new(bridge);
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let bridge = Arc::clone(&bridge);
+                std::thread::spawn(move || bridge.poll_once())
+            })
+            .collect();
+        let newly_notified = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("poll thread").expect("poll result"))
+            .filter(Option::is_some)
+            .count();
+
+        assert_eq!(newly_notified, 1);
+        assert_eq!(
+            notifier
+                .calls()
+                .iter()
+                .filter(|call| matches!(call, Call::Notify(_)))
+                .count(),
+            1
         );
     }
 
@@ -317,6 +558,197 @@ mod tests {
                 .len(),
             1,
             "the chat token must be retained so a retry can repair the stale prompt"
+        );
+    }
+
+    #[test]
+    fn resolve_retries_only_the_failed_notifier_phase() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+        let notifier = Arc::new(FailOnceNotifier::new());
+        let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            notifier.clone() as Arc<dyn ChatNotifier>,
+            audit,
+        );
+
+        bridge.poll_once().expect("poll");
+        assert!(bridge.resolve(id, Decision::Approved, "alice").is_err());
+        let competing = bridge.resolve(id, Decision::Rejected, "bob");
+        assert!(
+            competing.is_err(),
+            "a competing decision must not take over a failed notifier phase"
+        );
+        let changed_decision = bridge.resolve(id, Decision::Rejected, "alice");
+        assert!(
+            changed_decision.is_err(),
+            "the owning reviewer must not change the claimed decision during retry"
+        );
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("the original decision may repair the chat update");
+
+        assert_eq!(gateway.resolutions().len(), 1);
+        assert_eq!(bridge_audit_records(&dir).len(), 1);
+        assert_eq!(notifier.attempts(), 2);
+        assert_eq!(
+            notifier
+                .calls()
+                .iter()
+                .filter(|call| matches!(call, Call::Respond { .. }))
+                .count(),
+            1
+        );
+        assert!(bridge.tokens.lock().expect("token map mutex").is_empty());
+    }
+
+    #[test]
+    fn resolve_retries_the_gateway_phase_for_the_original_decision() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let gateway = Arc::new(FailOnceGateway::new(sample_pending(id)));
+        let notifier = Arc::new(MockNotifier::new());
+        let audit = BridgeAuditTrail::new(dir.path().join("audit.ndjson"));
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            notifier.clone() as Arc<dyn ChatNotifier>,
+            audit,
+        );
+
+        bridge.poll_once().expect("poll");
+        assert!(bridge.resolve(id, Decision::Approved, "alice").is_err());
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("the original decision may retry the gateway");
+
+        assert_eq!(gateway.attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            gateway.resolutions.lock().expect("resolutions mutex").len(),
+            1
+        );
+        assert_eq!(bridge_audit_records(&dir).len(), 1);
+    }
+
+    #[test]
+    fn resolve_retries_audit_without_reapplying_the_gateway() {
+        let dir = tempdir().expect("tempdir");
+        let audit_dir = dir.path().join("missing");
+        let id = Uuid::new_v4();
+        let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+        let notifier = Arc::new(MockNotifier::new());
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            notifier as Arc<dyn ChatNotifier>,
+            BridgeAuditTrail::new(audit_dir.join("audit.ndjson")),
+        );
+
+        bridge.poll_once().expect("poll");
+        assert!(bridge.resolve(id, Decision::Approved, "alice").is_err());
+        std::fs::create_dir(&audit_dir).expect("create audit directory");
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("the original decision may retry the audit phase");
+
+        assert_eq!(gateway.resolutions().len(), 1);
+        let records = BridgeAuditTrail::new(audit_dir.join("audit.ndjson"))
+            .read_all()
+            .expect("read audit records");
+        assert_eq!(records.len(), 1);
+        assert!(records[0].outcome_projection.is_some());
+    }
+
+    #[test]
+    fn terminal_resolution_tracking_is_bounded() {
+        let mut registry = ResolutionRegistry::default();
+        for index in 0..=MAX_RESOLUTION_ENTRIES {
+            let id = Uuid::new_v4();
+            let mut progress =
+                ResolutionProgress::new(id, Decision::Approved, &format!("reviewer-{index}"), None);
+            progress.chat_updated = true;
+            registry.entries.insert(id, Arc::new(Mutex::new(progress)));
+            registry.mark_terminal(id);
+        }
+
+        assert_eq!(registry.entries.len(), MAX_RESOLUTION_ENTRIES);
+        assert_eq!(registry.terminal_order.len(), MAX_RESOLUTION_ENTRIES);
+    }
+
+    #[test]
+    fn completed_resolution_capacity_makes_room_for_a_new_claim() {
+        let dir = tempdir().expect("tempdir");
+        let id = Uuid::new_v4();
+        let gateway = Arc::new(MockGateway::new(Some(sample_pending(id))));
+        let bridge = Bridge::new(
+            gateway.clone() as Arc<dyn ApprovalGateway>,
+            Arc::new(MockNotifier::new()) as Arc<dyn ChatNotifier>,
+            BridgeAuditTrail::new(dir.path().join("audit.ndjson")),
+        );
+        {
+            let mut registry = bridge
+                .resolutions
+                .lock()
+                .expect("resolution registry mutex");
+            for index in 0..MAX_RESOLUTION_ENTRIES {
+                let terminal_id = Uuid::new_v4();
+                let mut progress = ResolutionProgress::new(
+                    terminal_id,
+                    Decision::Approved,
+                    &format!("reviewer-{index}"),
+                    None,
+                );
+                progress.chat_updated = true;
+                registry
+                    .entries
+                    .insert(terminal_id, Arc::new(Mutex::new(progress)));
+                registry.mark_terminal(terminal_id);
+            }
+        }
+
+        bridge
+            .resolve(id, Decision::Approved, "alice")
+            .expect("a completed entry should be evicted for the new claim");
+
+        let resolutions = gateway.resolutions();
+        assert_eq!(resolutions.len(), 1);
+        assert_eq!(resolutions[0].0, id);
+        let registry = bridge
+            .resolutions
+            .lock()
+            .expect("resolution registry mutex");
+        assert_eq!(registry.entries.len(), MAX_RESOLUTION_ENTRIES);
+        assert!(registry.entries.contains_key(&id));
+    }
+
+    #[test]
+    fn incomplete_resolution_tracking_rejects_new_claims_at_capacity() {
+        let dir = tempdir().expect("tempdir");
+        let bridge = Bridge::new(
+            Arc::new(AlwaysFailGateway) as Arc<dyn ApprovalGateway>,
+            Arc::new(MockNotifier::new()) as Arc<dyn ChatNotifier>,
+            BridgeAuditTrail::new(dir.path().join("audit.ndjson")),
+        );
+
+        for _ in 0..MAX_RESOLUTION_ENTRIES {
+            assert!(bridge
+                .resolve(Uuid::new_v4(), Decision::Approved, "alice")
+                .is_err());
+        }
+        let overflow = bridge.resolve(Uuid::new_v4(), Decision::Approved, "alice");
+
+        assert!(overflow
+            .expect_err("new claims must be rejected at capacity")
+            .to_string()
+            .contains("capacity"));
+        assert_eq!(
+            bridge
+                .resolutions
+                .lock()
+                .expect("resolution registry mutex")
+                .entries
+                .len(),
+            MAX_RESOLUTION_ENTRIES
         );
     }
 

--- a/hitl-bridge/src/bridge.rs
+++ b/hitl-bridge/src/bridge.rs
@@ -211,6 +211,7 @@ impl Bridge {
         }
 
         if !progress_guard.gateway_applied {
+            self.audit.prepare()?;
             match decision {
                 Decision::Approved => self.gateway.approve(id)?,
                 Decision::Rejected => self.gateway.reject(id)?,
@@ -632,7 +633,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_retries_audit_without_reapplying_the_gateway() {
+    fn resolve_retries_after_audit_preparation_without_reapplying_the_gateway() {
         let dir = tempdir().expect("tempdir");
         let audit_dir = dir.path().join("missing");
         let id = Uuid::new_v4();
@@ -646,6 +647,7 @@ mod tests {
 
         bridge.poll_once().expect("poll");
         assert!(bridge.resolve(id, Decision::Approved, "alice").is_err());
+        assert!(gateway.resolutions().is_empty());
         std::fs::create_dir(&audit_dir).expect("create audit directory");
         bridge
             .resolve(id, Decision::Approved, "alice")


### PR DESCRIPTION
Closes #223

## Summary
- model gateway, audit, and chat update as resumable idempotent phases
- preserve first-writer-wins while allowing an exact failed decision retry
- bound terminal resolution state and evict before accepting the next claim
- make audit replay idempotent without retaining unbounded history in memory
- document retry and retention behavior

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace: 757 passed, 8 ignored
- cargo deny check: passed
- cargo audit: reports 5 pre-existing transitive advisories in quinn-proto/rustls-webpki
- gstack review: all P1/P2 findings fixed, no unresolved findings
- backend QA: hitl-bridge 45 passed, 1 ignored; workspace E2E passed