### PR TITLE
fix(ci): prevent workspace tests from exhausting runner disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    # The workspace test build can exhaust the hosted runner's available disk
+    # after restoring cached artifacts. Remove unused preinstalled SDKs first.
+    - name: Free runner disk space
+      run: |
+        df -h /
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/share/swift
+        df -h /
     - uses: Swatinem/rust-cache@v2
     - name: Verify Chrome is available
       run: google-chrome --version


### PR DESCRIPTION
## Summary
- free unused preinstalled SDKs before restoring Rust test artifacts
- record root filesystem usage before and after cleanup
- keep the existing nextest and doc-test commands unchanged

## Root cause
Main CI run 29506289337 failed in the `test` job because the GitHub-hosted runner reported `No space left on device` while `cargo nextest run --workspace --profile ci` was running.

## Validation
- `actionlint .github/workflows/ci.yml`
- `cargo nextest run --workspace --profile ci` (772 passed, 7 skipped)
- `cargo test --workspace --doc`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo deny check`

## Review and QA
- gstack review: no unresolved P1/P2 findings; scope limited to one workflow file
- gstack QA-only: workflow syntax, exact CI commands, negative failure evidence, dependency gates, and security checks passed locally
- Hosted-runner exit criterion: cleanup, nextest, doc tests, and dependent coverage job must all pass in this PR CI

Related: main CI run https://github.com/takurot/dragon-head/actions/runs/29506289337