### PR TITLE
[ISSUE-205] Gate shipped MCP binary stdio smoke in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,13 +366,23 @@ jobs:
 
   mcp-protocol-compliance:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+    - name: Verify Chrome is available
+      run: google-chrome --version
     - name: Run MCP client contract and protocol compliance tests
       run: |
         cargo test -p mcp-server --test mcp_client_contract --verbose
         cargo test -p mcp-server --test mcp_protocol_compliance --verbose
+    - name: Run shipped MCP binary stdio smoke test
+      run: |
+        set -o pipefail
+        chrome_path="$(command -v google-chrome)"
+        smoke_log="${RUNNER_TEMP}/mcp-binary-stdio-smoke.log"
+        CHROME_PATH="${chrome_path}" cargo test -p mcp-server --test mcp_binary_e2e test_mcp_binary_stdio_smoke -- --ignored --exact --nocapture 2>&1 | tee "${smoke_log}"
+        grep -F "test result: ok. 1 passed; 0 failed; 0 ignored;" "${smoke_log}"
 
   mcp-api-schema-diff:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,6 +1801,7 @@ dependencies = [
  "hex",
  "json-patch",
  "jsonschema",
+ "libc",
  "plugin-host",
  "serde",
  "serde_json",

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -494,6 +494,11 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > `structuredContent` と JSON を直列化した `text` content block の組み合わせへ修正し、
 > strict client との相互運用性と後方互換 fallback の一致を契約テストで固定する。
 
+> **Follow-up (ISSUE-205)**: 実配布バイナリ `dragon-head-mcp` を起動し、stdio で
+> `initialize` → `notifications/initialized` → `tools/list` を実行するスモークテストを
+> PR 必須 CI に追加する。stdout が JSON-RPC 応答だけで構成されることと、stdin 終了後の
+> 正常 shutdown を検証し、起動・framing・stdio loop の回帰を merge 前に検出する。
+
 ### PR-15: NFR Benchmark & Capacity Validation
 - Status: `DONE` (Local)
 - Spec Ref: Section 6

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,10 @@ We follow the "Testing Pyramid" approach with the following layers:
 The CI pipeline is defined in `.github/workflows/`.
 
 - **`ci.yml`**: Runs `fmt`, `clippy`, unit tests, and integration tests.
+- **MCP binary stdio smoke (PR required)**: `ci.yml` starts the shipped
+  `dragon-head-mcp` binary with Chrome and verifies `initialize`,
+  `notifications/initialized`, and `tools/list` over real stdio. The gate rejects
+  stdout contamination, missing required tools, startup hangs, and unclean shutdowns.
 - **Playwright comparison harness**: `ci.yml` installs and tests `bench-playwright` at the
   supported Node.js 20.19, 22.12, and 24 boundaries, and rejects moderate-or-higher npm
   audit findings.
@@ -141,6 +145,9 @@ automatically files or updates a GitHub Issue labelled **`nightly-failure`**.
 
    # MCP binary E2E
    CHROME_PATH=/usr/bin/chromium-browser cargo test -p mcp-server --test mcp_binary_e2e -- --ignored --nocapture
+
+   # PR-required shipped-binary stdio smoke only
+   CHROME_PATH="$(command -v google-chrome)" cargo test -p mcp-server --test mcp_binary_e2e test_mcp_binary_stdio_smoke -- --ignored --exact --nocapture
    ```
 4. Fix the regression, open a PR, and close the `nightly-failure` issue once CI is green.
 

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/main.rs"
 [dev-dependencies]
 escargot = "0.5"
 json-patch = "4.2"
+libc = "0.2"
 tempfile = "3.10"
 tokio = { workspace = true }
 urlencoding = "2.1"

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -1,10 +1,35 @@
 use mcp_server::{McpBackend, McpServer};
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Command, Stdio};
-use std::sync::OnceLock;
-use std::time::Instant;
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 use test_bench_support::should_skip_browser_tests;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+const REQUIRED_TOOL_NAMES: &[&str] = &[
+    "get_state",
+    "act",
+    "verify",
+    "get_visual",
+    "ask_human",
+    "run_skill",
+    "extract",
+    "get_usage_report",
+];
+
+fn assert_required_tools(tools: &[Value]) {
+    let tool_names: Vec<&str> = tools
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+    for name in REQUIRED_TOOL_NAMES {
+        assert!(tool_names.contains(name), "tools/list missing '{name}'");
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Fast library-level protocol tests (no Chrome / no subprocess)
@@ -82,18 +107,7 @@ fn protocol_initialize_notifications_and_tools_list() {
     let tools = resp["result"]["tools"].as_array().expect("tools is array");
     assert!(!tools.is_empty(), "tools list must not be empty");
 
-    let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-    for name in [
-        "get_state",
-        "act",
-        "verify",
-        "get_visual",
-        "ask_human",
-        "run_skill",
-        "get_usage_report",
-    ] {
-        assert!(tool_names.contains(&name), "tools/list missing '{name}'");
-    }
+    assert_required_tools(tools);
 }
 
 /// Covers: tools/call for get_usage_report (no browser I/O needed)
@@ -186,6 +200,86 @@ fn build_binary_once() -> anyhow::Result<std::path::PathBuf> {
     let path = build.path().to_owned();
     let _ = BIN.set(path.clone());
     Ok(path)
+}
+
+struct ChildGuard {
+    child: Child,
+    stdin: Option<ChildStdin>,
+}
+
+enum StdoutEvent {
+    Line(std::io::Result<String>),
+    Eof,
+}
+
+impl ChildGuard {
+    fn new(mut child: Child) -> Self {
+        let stdin = child.stdin.take();
+        Self { child, stdin }
+    }
+
+    fn stdin_mut(&mut self) -> &mut ChildStdin {
+        self.stdin.as_mut().expect("failed to open stdin")
+    }
+
+    fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
+
+    fn wait_timeout(&mut self, timeout: Duration) -> anyhow::Result<ExitStatus> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                return Ok(status);
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("dragon-head-mcp did not exit within {timeout:?}");
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.close_stdin();
+
+        let grace_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < grace_deadline {
+            if matches!(self.child.try_wait(), Ok(Some(_))) {
+                return;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        #[cfg(unix)]
+        {
+            let process_group = -(self.child.id() as i32);
+            // SAFETY: the smoke test starts the child in a fresh process group whose
+            // id is the child's pid. A negative pid targets only that test-owned group.
+            unsafe {
+                libc::kill(process_group, libc::SIGKILL);
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn receive_stdout_line(
+    receiver: &mpsc::Receiver<StdoutEvent>,
+    timeout: Duration,
+) -> anyhow::Result<String> {
+    match receiver
+        .recv_timeout(timeout)
+        .map_err(|err| anyhow::anyhow!("timed out waiting for JSON-RPC stdout: {err}"))?
+    {
+        StdoutEvent::Line(line) => line.map_err(Into::into),
+        StdoutEvent::Eof => anyhow::bail!("dragon-head-mcp closed stdout before responding"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -326,7 +420,7 @@ fn binary_doctor_fails_for_invalid_injection_mode_config() -> anyhow::Result<()>
 
 #[test]
 #[ignore = "requires Chrome; starts a real browser process (~30-60s). Run with: cargo test -p mcp-server --test mcp_binary_e2e -- --ignored"]
-fn test_mcp_binary_full_handshake_and_tools_list() -> anyhow::Result<()> {
+fn test_mcp_binary_stdio_smoke() -> anyhow::Result<()> {
     if should_skip_browser_tests() {
         eprintln!("SKIP: Chrome not available");
         return Ok(());
@@ -335,17 +429,73 @@ fn test_mcp_binary_full_handshake_and_tools_list() -> anyhow::Result<()> {
     let bin_path = build_binary_once()?;
 
     let t0 = Instant::now();
-    let mut child = Command::new(&bin_path)
+    let config_home = tempfile::tempdir()?;
+    let mut command = Command::new(&bin_path);
+    command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+        .stderr(Stdio::inherit())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env_remove("PROMPT_INJECTION_MODE")
+        .env_remove("POLICY_FILE")
+        .env_remove("AUDIT_LOG_DIR")
+        .env_remove("AUDIT_LOG_MAX_BYTES")
+        .env_remove("AUDIT_DURABILITY")
+        .env_remove("AUDIT_LOG_STDOUT");
+    #[cfg(unix)]
+    command.process_group(0);
 
-    let mut stdin = child.stdin.take().expect("failed to open stdin");
-    let stdout = child.stdout.take().expect("failed to open stdout");
-    let mut reader = BufReader::new(stdout);
+    let mut raw_child = command.spawn()?;
+    let stdout = raw_child.stdout.take().expect("failed to open stdout");
+    let mut child = ChildGuard::new(raw_child);
+    let (stdout_sender, stdout_receiver) = mpsc::channel();
+    let _stdout_reader = thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            if stdout_sender.send(StdoutEvent::Line(line)).is_err() {
+                break;
+            }
+        }
+        let _ = stdout_sender.send(StdoutEvent::Eof);
+    });
 
-    mcp_handshake(&mut stdin, &mut reader)?;
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_binary_e2e", "version": "1.0.0" }
+        }
+    });
+    writeln!(child.stdin_mut(), "{initialize}")?;
+    child.stdin_mut().flush()?;
+
+    let mut stdout_lines = vec![receive_stdout_line(
+        &stdout_receiver,
+        Duration::from_secs(120),
+    )?];
+    let initialize_response: Value = serde_json::from_str(&stdout_lines[0])?;
+    assert_eq!(initialize_response["jsonrpc"], "2.0");
+    assert_eq!(initialize_response["id"], 1);
+    assert!(initialize_response.get("result").is_some());
+    assert!(initialize_response.get("error").is_none());
+    assert_eq!(
+        initialize_response["result"]["protocolVersion"],
+        "2025-11-25"
+    );
+    assert!(initialize_response["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(
+        initialize_response["result"]["serverInfo"]["name"],
+        "dragon-head-mcp"
+    );
+
+    let initialized = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    writeln!(child.stdin_mut(), "{initialized}")?;
+    child.stdin_mut().flush()?;
     eprintln!("[timing] spawn+handshake: {:?}", t0.elapsed());
 
     let t1 = Instant::now();
@@ -355,32 +505,41 @@ fn test_mcp_binary_full_handshake_and_tools_list() -> anyhow::Result<()> {
         "method": "tools/list",
         "params": {}
     });
-    writeln!(stdin, "{}", serde_json::to_string(&request)?)?;
-    stdin.flush()?;
+    writeln!(child.stdin_mut(), "{request}")?;
+    child.stdin_mut().flush()?;
 
-    let mut response_line = String::new();
-    reader.read_line(&mut response_line)?;
-    let response: serde_json::Value = serde_json::from_str(&response_line)?;
+    stdout_lines.push(receive_stdout_line(
+        &stdout_receiver,
+        Duration::from_secs(30),
+    )?);
+    let response: Value = serde_json::from_str(&stdout_lines[1])?;
     eprintln!("[timing] tools/list: {:?}", t1.elapsed());
 
+    assert_eq!(response["jsonrpc"], "2.0");
     assert_eq!(response["id"], 2);
-    assert!(response["result"]["tools"].is_array());
+    assert!(response.get("result").is_some());
+    assert!(response.get("error").is_none());
     let tools = response["result"]["tools"]
         .as_array()
         .expect("tools is array");
     assert!(!tools.is_empty(), "tools list should not be empty");
+    assert_required_tools(tools);
 
-    let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-    assert!(tool_names.contains(&"get_state"));
-    assert!(tool_names.contains(&"act"));
-    assert!(tool_names.contains(&"verify"));
-    assert!(tool_names.contains(&"get_visual"));
-    assert!(tool_names.contains(&"ask_human"));
-    assert!(tool_names.contains(&"run_skill"));
-    assert!(tool_names.contains(&"get_usage_report"));
-
-    drop(stdin);
-    child.wait()?;
+    child.close_stdin();
+    let status = child.wait_timeout(Duration::from_secs(30))?;
+    assert!(status.success(), "dragon-head-mcp exited with {status}");
+    while let StdoutEvent::Line(line) = stdout_receiver
+        .recv_timeout(Duration::from_secs(5))
+        .map_err(|err| anyhow::anyhow!("timed out waiting for stdout EOF: {err}"))?
+    {
+        stdout_lines.push(line?);
+    }
+    assert_eq!(
+        stdout_lines.len(),
+        2,
+        "stdout must contain exactly two JSON-RPC responses: {stdout_lines:?}"
+    );
+    assert!(stdout_lines.iter().all(|line| !line.trim().is_empty()));
     eprintln!("[timing] total: {:?}", t0.elapsed());
     Ok(())
 }


### PR DESCRIPTION
Closes #205

## Summary
- run the shipped dragon-head-mcp binary over real stdio in PR CI
- verify initialize, initialized notification, tools/list, clean JSON-RPC framing, required tools, and clean shutdown
- bound startup, response, EOF, shutdown, and CI job time; clean up the full test process group on failures
- document the PR/nightly MCP binary coverage split

## Exit Criteria
- [x] PR CI spawns the shipped binary and exercises the stdio loop
- [x] stdout contamination and missing/extra responses fail the smoke
- [x] zero-test filter matches cannot pass the CI gate
- [x] Chrome path and process cleanup are deterministic

## Verification
- cargo test -p mcp-server --test mcp_binary_e2e test_mcp_binary_stdio_smoke -- --ignored --exact --nocapture: 1 passed, 0 ignored
- cargo test -p mcp-server --test mcp_binary_e2e: 7 passed, 2 ignored
- cargo test --workspace: 772 passed, 8 ignored
- cargo clippy --workspace -- -D warnings: passed
- cargo fmt --all -- --check: passed
- actionlint .github/workflows/ci.yml: passed

## Review and QA
- gstack review: four timeout/cleanup/skip-pass findings fixed; final architecture, test, and security reviews report no P1/P2 findings
- report-only QA: real binary handshake/tools-list/framing/shutdown and CI selection guard passed; no unresolved findings
