### PR TITLE
[ISSUE-207] Reject unsupported skill schema versions

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -598,6 +598,11 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > obfuscation は安全にフィールド全体を `[REDACTED_SECURITY]` へ置換する。
 > stable_key は sanitizer 適用前生成の値を保持する回帰テストで固定した。
 
+> **Follow-up (ISSUE-207, done)**: `skills-engine` の対応スキーマ版を
+> `SUPPORTED_SKILL_SCHEMA_VERSION` で一元管理し、JSON Schema、JSON parse、
+> typed definition の実行前検証で未対応版を拒否する。最初の未来版と version 0 の
+> 境界テストにより、未解釈のSkillが現行セマンティクスで実行されないことを固定した。
+
 ## 4. 共通 Definition of Done（全PR共通）
 
 - [ ] 仕様トレーサビリティ（Spec Ref）がPR説明に記載されている。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,9 @@ The CI pipeline is defined in `.github/workflows/`.
 - **Playwright comparison harness**: `ci.yml` installs and tests `bench-playwright` at the
   supported Node.js 20.19, 22.12, and 24 boundaries, and rejects moderate-or-higher npm
   audit findings.
+- **Skill schema version gate**: `skill-schema-compatibility` rejects JSON definitions above
+  the supported schema version, while `skill-conformance` rejects unsupported typed
+  definitions before any runtime operation is invoked.
 - **`e2e.yml`**: Runs E2E tests against a headless browser.
 - **Performance Gate (PR Short)**: `ci.yml` runs a short NFR suite (`ttft`, `nfr_latency`, `nfr_bandwidth`, `nfr_capacity`) and generates `core-runtime/target/nfr-dashboard.md`.
 - **Performance Gate (Nightly Full)**: `e2e.yml` runs the full NFR suite (including long TTFT and full capacity targets) and publishes the same dashboard format for regression tracking.
@@ -79,6 +82,10 @@ cargo test --workspace --doc
 
 # Run a specific integration test
 cargo test -p core-runtime --test sre_determinism --verbose
+
+# Reproduce the skill schema version contract gates
+cargo test -p skills-engine --test skill_schema_compatibility --verbose
+cargo test -p skills-engine --test skill_conformance --verbose
 
 # Run E2E tests (requires Chrome; CHROME_INSTALLED=true is set by the container)
 CHROME_INSTALLED=true cargo test -p core-runtime --test semantic_wait

--- a/skills-engine/src/lib.rs
+++ b/skills-engine/src/lib.rs
@@ -4,6 +4,8 @@ use serde_json::{Value, json};
 use std::collections::HashMap;
 use thiserror::Error;
 
+pub const SUPPORTED_SKILL_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillDefinition {
     pub schema_version: u32,
@@ -175,6 +177,8 @@ pub struct SkillRunReport {
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum SkillEngineError {
+    #[error("unsupported skill schema version {version} (max {max})")]
+    UnsupportedSchemaVersion { version: u64, max: u32 },
     #[error("skill definition contains no steps")]
     EmptySkill,
     #[error("duplicate step id found: {step_id}")]
@@ -443,6 +447,13 @@ fn build_step_index(skill: &SkillDefinition) -> Result<HashMap<String, usize>, S
 }
 
 pub fn validate_skill_definition(skill: &SkillDefinition) -> Result<(), SkillEngineError> {
+    if skill.schema_version == 0 || skill.schema_version > SUPPORTED_SKILL_SCHEMA_VERSION {
+        return Err(SkillEngineError::UnsupportedSchemaVersion {
+            version: u64::from(skill.schema_version),
+            max: SUPPORTED_SKILL_SCHEMA_VERSION,
+        });
+    }
+
     if skill.steps.is_empty() {
         return Err(SkillEngineError::EmptySkill);
     }
@@ -590,7 +601,11 @@ pub fn skill_definition_schema() -> Value {
         "additionalProperties": false,
         "required": ["schema_version", "name", "steps"],
         "properties": {
-            "schema_version": { "type": "integer", "minimum": 1 },
+            "schema_version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": SUPPORTED_SKILL_SCHEMA_VERSION
+            },
             "name": { "type": "string", "minLength": 1 },
             "steps": {
                 "type": "array",
@@ -695,6 +710,15 @@ pub fn validate_skill_json(value: &Value) -> Result<(), SkillSchemaError> {
 }
 
 pub fn parse_skill_definition(value: &Value) -> Result<SkillDefinition, SkillEngineError> {
+    if let Some(version) = value.get("schema_version").and_then(Value::as_u64)
+        && version > u64::from(SUPPORTED_SKILL_SCHEMA_VERSION)
+    {
+        return Err(SkillEngineError::UnsupportedSchemaVersion {
+            version,
+            max: SUPPORTED_SKILL_SCHEMA_VERSION,
+        });
+    }
+
     validate_skill_json(value).map_err(|err| SkillEngineError::SchemaValidation {
         message: err.to_string(),
     })?;

--- a/skills-engine/tests/fixtures/skill/skill_definition.schema.json
+++ b/skills-engine/tests/fixtures/skill/skill_definition.schema.json
@@ -7,6 +7,7 @@
       "type": "string"
     },
     "schema_version": {
+      "maximum": 1,
       "minimum": 1,
       "type": "integer"
     },

--- a/skills-engine/tests/skill_conformance.rs
+++ b/skills-engine/tests/skill_conformance.rs
@@ -1,6 +1,7 @@
 use skills_engine::{
-    ActStep, ExtractStep, HandoffStep, LocateStep, OperationOutcome, SkillDefinition, SkillEngine,
-    SkillEngineError, SkillRunStatus, SkillRuntime, SkillStep, StepControl, VerifyStep,
+    ActStep, ExtractStep, HandoffStep, LocateStep, OperationOutcome,
+    SUPPORTED_SKILL_SCHEMA_VERSION, SkillDefinition, SkillEngine, SkillEngineError, SkillRunStatus,
+    SkillRuntime, SkillStep, StepControl, VerifyStep, validate_skill_definition,
 };
 use std::collections::{HashMap, VecDeque};
 
@@ -66,6 +67,18 @@ impl SkillRuntime for MockRuntime {
     }
 }
 
+struct PanicRuntime;
+
+impl SkillRuntime for PanicRuntime {
+    fn locate(
+        &mut self,
+        _step: &LocateStep,
+        _ctx: &mut skills_engine::SkillExecutionContext,
+    ) -> OperationOutcome {
+        panic!("unsupported skill must be rejected before runtime calls")
+    }
+}
+
 fn happy_path_skill() -> SkillDefinition {
     SkillDefinition {
         schema_version: 1,
@@ -96,6 +109,43 @@ fn happy_path_skill() -> SkillDefinition {
                 control: StepControl::default(),
             }),
         ],
+    }
+}
+
+fn single_locate_skill(schema_version: u32) -> SkillDefinition {
+    SkillDefinition {
+        schema_version,
+        name: "version-boundary".to_string(),
+        steps: vec![SkillStep::Locate(LocateStep {
+            id: Some("locate".to_string()),
+            query: "button".to_string(),
+            control: StepControl::default(),
+        })],
+    }
+}
+
+#[test]
+fn test_validate_rejects_unsupported_typed_schema_versions() {
+    for version in [0, SUPPORTED_SKILL_SCHEMA_VERSION + 1] {
+        let error = validate_skill_definition(&single_locate_skill(version))
+            .expect_err("unsupported typed schema version must be rejected");
+        assert!(matches!(
+            error,
+            SkillEngineError::UnsupportedSchemaVersion { .. }
+        ));
+    }
+}
+
+#[test]
+fn test_run_rejects_unsupported_schema_versions_before_runtime_calls() {
+    for version in [0, SUPPORTED_SKILL_SCHEMA_VERSION + 1] {
+        let error = SkillEngine::new()
+            .run(&single_locate_skill(version), &mut PanicRuntime)
+            .expect_err("unsupported schema version must be rejected before execution");
+        assert!(matches!(
+            error,
+            SkillEngineError::UnsupportedSchemaVersion { .. }
+        ));
     }
 }
 

--- a/skills-engine/tests/skill_schema_compatibility.rs
+++ b/skills-engine/tests/skill_schema_compatibility.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, ensure};
 use skills_engine::{
-    SkillDefinition, skill_definition_schema, validate_skill_definition, validate_skill_json,
+    SUPPORTED_SKILL_SCHEMA_VERSION, SkillDefinition, SkillEngineError, parse_skill_definition,
+    skill_definition_schema, validate_skill_definition, validate_skill_json,
 };
 use std::{fs, path::PathBuf};
 
@@ -9,6 +10,42 @@ const UPDATE_ENV: &str = "UPDATE_SKILL_SCHEMA";
 
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_FIXTURE)
+}
+
+fn valid_skill_json() -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": SUPPORTED_SKILL_SCHEMA_VERSION,
+        "name": "search-and-extract",
+        "steps": [
+            {
+                "type": "locate",
+                "id": "locate_product",
+                "query": "search button",
+                "control": { "max_retries": 0 }
+            },
+            {
+                "type": "verify",
+                "id": "verify_product",
+                "target": "search button",
+                "expected": "enabled",
+                "control": {}
+            },
+            {
+                "type": "act",
+                "id": "click_product",
+                "action": "click",
+                "target": "search button",
+                "control": {}
+            },
+            {
+                "type": "extract",
+                "id": "extract_product",
+                "key": "product_name",
+                "selector": "#product-name",
+                "control": {}
+            }
+        ]
+    })
 }
 
 #[test]
@@ -50,39 +87,7 @@ fn test_skill_schema_backward_compatibility_fixture() -> Result<()> {
 
 #[test]
 fn test_skill_schema_validates_examples() {
-    let valid = serde_json::json!({
-        "schema_version": 1,
-        "name": "search-and-extract",
-        "steps": [
-            {
-                "type": "locate",
-                "id": "locate_product",
-                "query": "search button",
-                "control": { "max_retries": 0 }
-            },
-            {
-                "type": "verify",
-                "id": "verify_product",
-                "target": "search button",
-                "expected": "enabled",
-                "control": {}
-            },
-            {
-                "type": "act",
-                "id": "click_product",
-                "action": "click",
-                "target": "search button",
-                "control": {}
-            },
-            {
-                "type": "extract",
-                "id": "extract_product",
-                "key": "product_name",
-                "selector": "#product-name",
-                "control": {}
-            }
-        ]
-    });
+    let valid = valid_skill_json();
 
     validate_skill_json(&valid).expect("valid example should satisfy skill schema");
 
@@ -103,6 +108,63 @@ fn test_skill_schema_validates_examples() {
         validate_skill_json(&invalid).is_err(),
         "invalid skill json should fail schema validation"
     );
+}
+
+#[test]
+fn test_skill_schema_maximum_matches_supported_version() {
+    let schema = skill_definition_schema();
+    assert_eq!(
+        schema["properties"]["schema_version"]["maximum"],
+        serde_json::json!(SUPPORTED_SKILL_SCHEMA_VERSION)
+    );
+}
+
+#[test]
+fn test_skill_schema_rejects_first_unsupported_version() {
+    let mut future = valid_skill_json();
+    future["schema_version"] = serde_json::json!(SUPPORTED_SKILL_SCHEMA_VERSION + 1);
+
+    validate_skill_json(&future).expect_err("future skill schema must be rejected");
+}
+
+#[test]
+fn test_parse_skill_rejects_first_unsupported_version_with_dedicated_error() {
+    let version = SUPPORTED_SKILL_SCHEMA_VERSION + 1;
+    let mut future = valid_skill_json();
+    future["schema_version"] = serde_json::json!(version);
+
+    let error = parse_skill_definition(&future).expect_err("future skill schema must be rejected");
+    assert_eq!(
+        error,
+        SkillEngineError::UnsupportedSchemaVersion {
+            version: u64::from(version),
+            max: SUPPORTED_SKILL_SCHEMA_VERSION,
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "unsupported skill schema version {version} (max {SUPPORTED_SKILL_SCHEMA_VERSION})"
+        )
+    );
+}
+
+#[test]
+fn test_parse_skill_accepts_supported_version() {
+    let skill = parse_skill_definition(&valid_skill_json())
+        .expect("supported skill schema version must parse");
+    assert_eq!(skill.schema_version, SUPPORTED_SKILL_SCHEMA_VERSION);
+}
+
+#[test]
+fn test_parse_skill_keeps_generic_schema_errors_for_malformed_versions() {
+    for malformed in [serde_json::json!("2"), serde_json::json!(1.5)] {
+        let mut value = valid_skill_json();
+        value["schema_version"] = malformed;
+
+        let error = parse_skill_definition(&value).expect_err("malformed version must be rejected");
+        assert!(matches!(error, SkillEngineError::SchemaValidation { .. }));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #207

## Summary
- centralize the supported skill schema maximum in SUPPORTED_SKILL_SCHEMA_VERSION
- reject future versions during raw JSON parsing and reject version 0 or above-max typed definitions before runtime calls
- add the maximum to the generated JSON Schema and committed compatibility fixture
- document the schema-version CI gates and Issue follow-up

## Exit criteria
- [x] Future skill schemas fail closed instead of executing with v1 semantics
- [x] parse returns the dedicated unsupported skill schema version error
- [x] JSON, typed validation, and execution boundaries are covered
- [x] malformed versions retain schema-validation errors
- [x] no runtime operation occurs for unsupported typed definitions

## Validation
- TDD Red: missing constant and error produced 5 compile failures
- skills-engine targeted suites: 23 passed
- skills-engine crate: 24 passed
- workspace: 778 passed, 8 ignored
- workspace clippy with warnings denied: passed
- cargo fmt check: passed
- Skills Engine comprehensive evaluation: 1 passed
- MCP run_skill audit integration: 1 passed

## Review and QA
- gstack pre-landing review: one P2 backward-compatibility issue found and fixed; final P1/P2 findings: none
- report-only QA: schema compatibility, conformance, evaluation bench, and MCP integration all passed
- architecture, test, and security final reviews: no remaining P1/P2 findings