### PR TITLE
[ISSUE-189] Enforce MCP documentation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ specific Chromium build.
 `dragon-head-mcp` currently exposes 8 tools. The source of truth is
 `McpServer::tools()` in `mcp-server/src/lib.rs`:
 
+<!-- mcp-tool-list:start -->
 | Tool | Purpose |
 | --- | --- |
 | `get_state` | Retrieve the semantic page state. |
@@ -366,6 +367,14 @@ specific Chromium build.
 | `run_skill` | Execute a declarative skill workflow. |
 | `get_usage_report` | Retrieve usage meters and plan tier summary. |
 | `extract` | Extract structured data using a Deep Lens DSL rule. |
+<!-- mcp-tool-list:end -->
+
+<!-- mcp-tool-semantics:start -->
+`extract` applies prompt-injection sanitization and PII redaction before returning
+structured page data. It is read-only and does not emit an action audit event.
+`get_usage_report` is also read-only: it reports the plan tier, usage meters, and
+the audit-retention snapshot, but does not meter itself or emit an action audit event.
+<!-- mcp-tool-semantics:end -->
 
 ## Developer Examples
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -17,6 +17,7 @@ usage meters.
 The current MCP tool contract has 8 tools, defined in `McpServer::tools()` in
 `mcp-server/src/lib.rs`:
 
+<!-- mcp-tool-list:start -->
 - `get_state`
 - `act`
 - `verify`
@@ -25,6 +26,10 @@ The current MCP tool contract has 8 tools, defined in `McpServer::tools()` in
 - `run_skill`
 - `get_usage_report`
 - `extract`
+<!-- mcp-tool-list:end -->
+
+The required `mcp_client_contract` CI suite snapshots the full tool definitions
+and checks these canonical documentation lists for exact name-set equality.
 
 ## Primary Users
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,13 +52,27 @@ flowchart TD
 | `bench` | NFR/ROI benchmarking harness producing markdown dashboards |
 | `test-bench-support` | Shared `should_skip_browser_tests()` helper for Chrome-dependent tests |
 
+The canonical MCP tool names are:
+
+<!-- mcp-tool-list:start -->
+- `get_state`
+- `act`
+- `verify`
+- `get_visual`
+- `ask_human`
+- `run_skill`
+- `get_usage_report`
+- `extract`
+<!-- mcp-tool-list:end -->
+
 ## Dependency direction
 
 `mcp-server` depends on `core-runtime`, `skills-engine`, and `plugin-host`.
-`core-runtime` has no dependency on the other workspace crates — it's the
-foundation. `hitl-bridge`, `bench`, and `marketplace` are independent
-binaries/libraries that don't feed back into `core-runtime`. There is no
-cyclic dependency between workspace crates.
+`core-runtime` depends on `plugin-host` for the concrete loaded-plugin adapters
+implemented in `plugin_hooks`; `plugin-host` does not depend on `core-runtime`,
+so this edge remains acyclic. `hitl-bridge`, `bench`, and `marketplace` are
+independent binaries/libraries that don't feed back into `core-runtime`. There
+is no cyclic dependency between workspace crates.
 
 ## Data flow: `get_state`
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -603,6 +603,11 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > typed definition の実行前検証で未対応版を拒否する。最初の未来版と version 0 の
 > 境界テストにより、未解釈のSkillが現行セマンティクスで実行されないことを固定した。
 
+> **Follow-up (ISSUE-189, done)**: runtimeの8-tool MCP contractをREADME、AI context、
+> Architecture、SPECへ同期し、`extract` / `get_usage_report` のsecurity・audit境界と
+> `core-runtime -> plugin-host` 依存を明記した。tool定義snapshotとdocs name-setの
+> 完全一致テストにより、tool追加・削除・改名時のdriftを必須CIで検出する。
+
 ## 4. 共通 Definition of Done（全PR共通）
 
 - [ ] 仕様トレーサビリティ（Spec Ref）がPR説明に記載されている。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -208,16 +208,27 @@ AI とブラウザの間の会話を「操作」から「情報の取得」へ�
 
 Model Context Protocol (MCP) 準拠のツール定義。
 
+<!-- mcp-tool-list:start -->
 | Tool Name | Arguments | Description |
 | :--- | :--- | :--- |
-| `get_state` | `format`: "json"\|"markdown", `force_refresh`: bool | ページ状態の取得。 |
-| `get_state` output | `security_flags`: string[] | Prompt Injection Sanitization が検出した既知リスクを要素単位で返す。 |
-| `extract` output | `result`: any, `security_flags`: string[] | Deep Lens 抽出結果。`ReportOnly` では危険文字列を保持してリスクを返し、`Redact` では同じ境界で置換する。 |
+| `get_state` | `format`: "json"\|"markdown", `force_refresh`: bool | ページ状態と、検出した既知リスクを要素単位の `security_flags` で返す。 |
 | `act` | `target_id`: int, `target_stable_key`: string, `action`: "click"\|"type", `value`: string | アクション実行。 |
 | `verify` | `target_id`: int, `expected`: {text: string} | ハルシネーション防止の事前検証。 |
 | `get_visual` | `mode`: "clean"\|"som", `viewport`: "full" | 視覚情報の取得。 |
 | `ask_human` | `reason`: string, `context`: bool, `outcome_projection`: object | HITL要求（2FA/判断不能/高額決済時）。承認要求に未来投影データを同梱。 |
 | `run_skill` | `skill_name`: string, `params`: object | 定義済みSkillの実行。 |
+| `get_usage_report` | なし | 現在のplan tier、usage meters、audit-retention snapshotを返す。 |
+| `extract` | `rule_name`: string または `inline`: object | Deep Lens抽出を実行し、`result` と `security_flags` を返す。 |
+<!-- mcp-tool-list:end -->
+
+<!-- mcp-tool-semantics:start -->
+`extract` は結果を返す前に prompt-injection sanitization と PII redaction を適用する。
+これはread-only操作であり、action audit eventは生成しない
+(does not emit an action audit event)。`get_usage_report` もread-onlyで、usage meters、
+plan tier、audit-retention snapshotを読み取る。自身の呼び出しはmeterへ加算せず
+(does not meter itself)、action audit eventも生成しない
+(does not emit an action audit event)。
+<!-- mcp-tool-semantics:end -->
 
 **ACT-05: HITL Concurrency & Safety**
 - **Session Lock**: Slack/Teams 等のチャットツール連携において、複数人による同時承認を防ぐ排他ロック機構。

--- a/mcp-server/tests/fixtures/mcp_tools.snapshot.json
+++ b/mcp-server/tests/fixtures/mcp_tools.snapshot.json
@@ -1,0 +1,353 @@
+[
+  {
+    "description": "Execute an interaction action",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "enum": [
+            "click",
+            "type"
+          ],
+          "type": "string"
+        },
+        "target_id": {
+          "maximum": 9223372036854775807,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        "target_stable_key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "name": "act"
+  },
+  {
+    "description": "Resolve pending HITL request",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "context": {
+          "type": "boolean"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "type": "object"
+    },
+    "name": "ask_human"
+  },
+  {
+    "description": "Extract structured data using Deep Lens DSL rule",
+    "inputSchema": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "rule_name": {
+              "description": "Name of a pre-registered SchemaRegistry rule",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_name"
+          ]
+        },
+        {
+          "properties": {
+            "inline": {
+              "description": "Inline Deep Lens DSL rule",
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "attribute": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "selector": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "selector"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fields": {
+                      "additionalProperties": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "selector": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "selector",
+                    "fields"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fields": {
+                          "additionalProperties": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "minProperties": 1,
+                          "type": "object"
+                        },
+                        "selector": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "selector",
+                        "fields"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "required": [
+            "inline"
+          ]
+        }
+      ],
+      "properties": {
+        "inline": {
+          "description": "Inline Deep Lens DSL rule",
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "attribute": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "selector": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "selector"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "fields": {
+                  "additionalProperties": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "minProperties": 1,
+                  "type": "object"
+                },
+                "selector": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "selector",
+                "fields"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fields": {
+                      "additionalProperties": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "selector": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "selector",
+                    "fields"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "items"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "rule_name": {
+          "description": "Name of a pre-registered SchemaRegistry rule",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "extract"
+  },
+  {
+    "description": "Retrieve the semantic page state",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "delivery": {
+          "enum": [
+            "full",
+            "delta"
+          ],
+          "type": "string"
+        },
+        "force_refresh": {
+          "type": "boolean"
+        },
+        "format": {
+          "enum": [
+            "json",
+            "markdown"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "get_state"
+  },
+  {
+    "description": "Retrieve usage meters and plan tier summary",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    },
+    "name": "get_usage_report"
+  },
+  {
+    "description": "Capture visual context with optional marks",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "enum": [
+            "clean",
+            "som"
+          ],
+          "type": "string"
+        },
+        "viewport": {
+          "enum": [
+            "full"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "get_visual"
+  },
+  {
+    "description": "Execute a declarative skill workflow",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "params": {
+          "type": "object"
+        },
+        "skill_name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill_name"
+      ],
+      "type": "object"
+    },
+    "name": "run_skill"
+  },
+  {
+    "description": "Verify precondition text before acting",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "expected": {
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "text"
+          ],
+          "type": "object"
+        },
+        "target_id": {
+          "maximum": 9223372036854775807,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        },
+        "target_stable_key": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_id",
+        "expected"
+      ],
+      "type": "object"
+    },
+    "name": "verify"
+  }
+]

--- a/mcp-server/tests/mcp_client_contract.rs
+++ b/mcp-server/tests/mcp_client_contract.rs
@@ -2,7 +2,14 @@ use anyhow::Result;
 use json_patch::diff;
 use mcp_server::{McpBackend, McpServer};
 use serde_json::{json, Value};
-use std::{fs, path::Path};
+use std::{collections::BTreeSet, fs, path::Path};
+
+const TOOL_SNAPSHOT: &str = "tests/fixtures/mcp_tools.snapshot.json";
+const UPDATE_TOOL_SNAPSHOT: &str = "UPDATE_MCP_TOOL_SNAPSHOT";
+const TOOL_LIST_START: &str = "<!-- mcp-tool-list:start -->";
+const TOOL_LIST_END: &str = "<!-- mcp-tool-list:end -->";
+const TOOL_SEMANTICS_START: &str = "<!-- mcp-tool-semantics:start -->";
+const TOOL_SEMANTICS_END: &str = "<!-- mcp-tool-semantics:end -->";
 
 #[derive(Default)]
 struct MockBackend;
@@ -35,6 +42,170 @@ impl McpBackend for MockBackend {
     fn extract(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({"rule": "mock", "result": null}))
     }
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("mcp-server must be inside the workspace")
+}
+
+fn canonical_tool_contract() -> Value {
+    let mut tools = McpServer::new(MockBackend).tools();
+    tools.sort_by(|left, right| left.name.cmp(&right.name));
+    serde_json::to_value(tools).expect("tool definitions must serialize")
+}
+
+fn runtime_tool_names() -> BTreeSet<String> {
+    let contract = canonical_tool_contract();
+    let tools = contract.as_array().expect("tool contract must be an array");
+    let names = tools
+        .iter()
+        .map(|tool| {
+            tool["name"]
+                .as_str()
+                .expect("tool name must be a string")
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names.len(),
+        tools.len(),
+        "McpServer::tools() must not define duplicate tool names"
+    );
+    names
+}
+
+fn section_between<'a>(body: &'a str, start: &str, end: &str) -> &'a str {
+    let (_, after_start) = body
+        .split_once(start)
+        .unwrap_or_else(|| panic!("missing section start marker: {start}"));
+    let (section, _) = after_start
+        .split_once(end)
+        .unwrap_or_else(|| panic!("missing section end marker: {end}"));
+    section
+}
+
+fn documented_tool_names(body: &str) -> BTreeSet<String> {
+    let documented = section_between(body, TOOL_LIST_START, TOOL_LIST_END)
+        .lines()
+        .filter_map(|line| {
+            let (_, after_tick) = line.split_once('`')?;
+            let (name, _) = after_tick.split_once('`')?;
+            Some(name.to_string())
+        })
+        .collect::<Vec<_>>();
+    let names = documented.iter().cloned().collect::<BTreeSet<_>>();
+    assert_eq!(
+        names.len(),
+        documented.len(),
+        "canonical MCP documentation list must not contain duplicate tool names"
+    );
+    names
+}
+
+fn read_workspace_file(path: &str) -> String {
+    fs::read_to_string(workspace_root().join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn test_mcp_tool_contract_snapshot() -> Result<()> {
+    let generated = canonical_tool_contract();
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(TOOL_SNAPSHOT);
+
+    if std::env::var(UPDATE_TOOL_SNAPSHOT).as_deref() == Ok("1") {
+        anyhow::ensure!(
+            std::env::var("CI").is_err(),
+            "{UPDATE_TOOL_SNAPSHOT}=1 is not allowed in CI"
+        );
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, serde_json::to_string_pretty(&generated)?)?;
+        return Ok(());
+    }
+
+    let expected: Value = serde_json::from_str(&fs::read_to_string(&path)?)?;
+    assert_eq!(
+        generated, expected,
+        "MCP tool contract changed; update with {UPDATE_TOOL_SNAPSHOT}=1 cargo test -p mcp-server --test mcp_client_contract test_mcp_tool_contract_snapshot -- --exact"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_public_docs_tool_lists_exactly_match_runtime_contract() {
+    let runtime = runtime_tool_names();
+    for path in [
+        "README.md",
+        "docs/AI_CONTEXT.md",
+        "docs/ARCHITECTURE.md",
+        "docs/SPEC.md",
+    ] {
+        let body = read_workspace_file(path);
+        assert_eq!(
+            documented_tool_names(&body),
+            runtime,
+            "{path} MCP tool list must exactly match McpServer::tools()"
+        );
+    }
+}
+
+#[test]
+fn test_public_docs_preserve_read_only_tool_security_and_audit_semantics() {
+    for path in ["README.md", "docs/SPEC.md"] {
+        let body = read_workspace_file(path);
+        let semantics = section_between(&body, TOOL_SEMANTICS_START, TOOL_SEMANTICS_END);
+        assert!(
+            semantics.contains("prompt-injection sanitization"),
+            "{path}"
+        );
+        assert!(semantics.contains("PII redaction"), "{path}");
+        assert!(
+            semantics.contains("does not emit an action audit event"),
+            "{path}"
+        );
+        assert!(semantics.contains("does not meter itself"), "{path}");
+        assert!(semantics.contains("audit-retention snapshot"), "{path}");
+    }
+}
+
+#[test]
+fn test_architecture_dependency_direction_matches_manifests() -> Result<()> {
+    let core_manifest: toml::Value =
+        toml::from_str(&read_workspace_file("core-runtime/Cargo.toml"))?;
+    let core_depends_on_plugin_host = core_manifest
+        .get("dependencies")
+        .and_then(|dependencies| dependencies.get("plugin-host"))
+        .is_some();
+    let plugin_manifest: toml::Value =
+        toml::from_str(&read_workspace_file("plugin-host/Cargo.toml"))?;
+    let plugin_host_depends_on_core = plugin_manifest
+        .get("dependencies")
+        .and_then(|dependencies| dependencies.get("core-runtime"))
+        .is_some();
+
+    let architecture = read_workspace_file("docs/ARCHITECTURE.md");
+    let dependency_section = section_between(
+        &architecture,
+        "## Dependency direction",
+        "## Data flow: `get_state`",
+    );
+    let docs_have_core_to_plugin_edge =
+        dependency_section.contains("`core-runtime` depends on `plugin-host`");
+    let docs_have_plugin_to_core_edge =
+        dependency_section.contains("`plugin-host` depends on `core-runtime`");
+
+    assert_eq!(
+        docs_have_core_to_plugin_edge, core_depends_on_plugin_host,
+        "docs/ARCHITECTURE.md core-runtime -> plugin-host edge must match core-runtime/Cargo.toml"
+    );
+    assert_eq!(
+        docs_have_plugin_to_core_edge, plugin_host_depends_on_core,
+        "docs/ARCHITECTURE.md plugin-host -> core-runtime edge must match plugin-host/Cargo.toml"
+    );
+    Ok(())
 }
 
 /// A backend that returns controlled semantic state payloads for delta testing.


### PR DESCRIPTION
Closes #189

## Summary
- synchronize the canonical 8-tool MCP surface across README, AI context, architecture, and SPEC
- document extract and get_usage_report security, audit, and metering behavior
- correct the core-runtime to plugin-host dependency direction
- snapshot sorted MCP tool definitions and enforce exact docs/runtime name-set equality, including duplicate detection
- verify both dependency directions against crate manifests

## Exit criteria
- [x] All public MCP tool lists exactly match McpServer::tools()
- [x] extract and get_usage_report semantics include security/audit expectations
- [x] Architecture reflects the actual crate graph and remains acyclic
- [x] Required CI contract test detects schema and documentation drift

## Verification
- cargo test -p mcp-server --test mcp_client_contract: 17 passed
- cargo test -p mcp-server --test mcp_schema_diff: 1 passed
- cargo test --workspace: 783 passed, 8 ignored
- cargo test --workspace --doc: 0 passed, 1 ignored
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt --all -- --check: clean
- CI snapshot update negative path: correctly rejected UPDATE_MCP_TOOL_SNAPSHOT=1 when CI is present

## Review and QA
- gstack pre-landing review: architecture P2 and test P2 findings fixed; final architecture/test reviews clean
- security review: sanitizer, PII redaction, metering, audit, and crate trust-boundary claims checked against runtime code; no unresolved P1/P2
- report-only QA: exact set, duplicate, full schema snapshot, update guard, semantic text, and bidirectional crate-edge gates passed
- unresolved findings: none