### PR TITLE
[ISSUE-211] Add config env contract and additional phrase override

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ chrome_path = "/usr/bin/chromium"
 [prompt_injection]
 # "off" | "report_only" (default) | "redact". Overridden by PROMPT_INJECTION_MODE.
 mode = "report_only"
-# Extra literal phrases to flag after the built-in prompt-injection patterns.
+# Extra literal phrases to flag after the built-in prompt-injection patterns. Overridden by
+# PROMPT_INJECTION_ADDITIONAL_PHRASES (a JSON string array).
 additional_phrases = ["reveal developer message"]
 
 [policy]
@@ -189,23 +190,34 @@ durability = "flush"  # "flush" (default) or "sync"
 
 ### Precedence
 
+<!-- config-env-contract:start -->
 | Setting | Env var (wins) | config.toml key |
 | --- | --- | --- |
 | Chrome path | `CHROME_PATH` | `chrome_path` |
 | Prompt-injection mode | `PROMPT_INJECTION_MODE` | `prompt_injection.mode` |
-| Prompt-injection additional phrases | none | `prompt_injection.additional_phrases` |
+| Prompt-injection additional phrases | `PROMPT_INJECTION_ADDITIONAL_PHRASES` | `prompt_injection.additional_phrases` |
 | Policy file | `POLICY_FILE` | `policy.file` |
 | Audit log directory | `AUDIT_LOG_DIR` | `audit.log_dir` |
 | Audit max bytes | `AUDIT_LOG_MAX_BYTES` | `audit.max_bytes` |
 | Audit durability | `AUDIT_DURABILITY` | `audit.durability` |
 | Audit stdout mirroring | `AUDIT_LOG_STDOUT` | none |
+<!-- config-env-contract:end -->
+
+`PROMPT_INJECTION_ADDITIONAL_PHRASES` must be a JSON array of strings, for
+example `["reveal developer message","ignore prior instructions"]`. It replaces
+the file value; use `[]` to clear it. Empty phrases and exact duplicates are
+removed after trimming. The same normalization and limits apply to the env value
+and `config.toml`: the effective set is limited to 64 phrases, 512 UTF-8 bytes
+per phrase, and 8 KiB total, while preserving first-seen order.
 
 `AUDIT_LOG_STDOUT` (if set, any value) mirrors audit events to **stderr**, never
 stdout — `dragon-head-mcp` uses stdout for JSON-RPC framing, so writing there
 would corrupt the protocol stream.
 
-Run `dragon-head-mcp --doctor` to validate the config file. A malformed file, or
-an invalid `prompt_injection.mode` value, makes the "Config file" check fail.
+Run `dragon-head-mcp --doctor` to validate the config file and list every
+supported configuration environment variable. A malformed file or invalid env
+override makes the "Config file" check fail. The summary reports only the
+effective additional-phrase count, never the phrase contents.
 
 Setting `prompt_injection.mode` to `redact` or `off` changes the default
 security posture — see [Security: Prompt Injection

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -92,11 +92,12 @@ macOS arm64/x64、Linux x64/arm64、Windows x64 向けにビルドし、sha256
 |---|---|---|
 | `CHROME_PATH` | Chrome/Chromiumバイナリパスの上書き | 自動検出 |
 | `PROMPT_INJECTION_MODE` | `prompt_injection.mode` の上書き(`off`/`report_only`/`redact`) | `report_only` |
+| `PROMPT_INJECTION_ADDITIONAL_PHRASES` | 追加検知phraseをJSON文字列配列で上書き(`[]`で明示的に空) | `config.toml`の値 |
 | `POLICY_FILE` | `policy.file` の上書き | 未設定 |
 | `AUDIT_LOG_DIR` | 監査ログの永続化先ディレクトリ | 未設定(永続化なし) |
 | `AUDIT_LOG_MAX_BYTES` | ログローテーション閾値(バイト) | 10485760 (10MiB) |
 | `AUDIT_DURABILITY` | `flush` または `sync` | `flush` |
-| `AUDIT_LOG_STDOUT` | 設定されていれば(値は任意)監査ログを標準出力にも出力 | 未設定(出力なし) |
+| `AUDIT_LOG_STDOUT` | 設定されていれば(値は任意)監査ログを標準エラー出力にも出力(互換性のため名称を維持) | 未設定(出力なし) |
 | `CHROME_INSTALLED` | CIでChrome利用可能を示すフラグ(テストゲート用) | 未設定 |
 | `CI` | 汎用CI検出 | 未設定 |
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -608,6 +608,10 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > `core-runtime -> plugin-host` 依存を明記した。tool定義snapshotとdocs name-setの
 > 完全一致テストにより、tool追加・削除・改名時のdriftを必須CIで検出する。
 
+> **Follow-up (ISSUE-211, done)**: `prompt_injection.additional_phrases` にJSON配列形式の
+> env overrideを追加し、件数・個別長・総量を制限した。runtimeが認識するconfig env名を
+> READMEと`--doctor`へ同期し、完全一致contract testと値非開示binary testでdriftを防ぐ。
+
 ## 4. 共通 Definition of Done（全PR共通）
 
 - [ ] 仕様トレーサビリティ（Spec Ref）がPR説明に記載されている。

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -7,7 +7,35 @@
 
 use core_runtime::PromptInjectionMode;
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+pub const ENV_CHROME_PATH: &str = "CHROME_PATH";
+pub const ENV_PROMPT_INJECTION_MODE: &str = "PROMPT_INJECTION_MODE";
+pub const ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES: &str = "PROMPT_INJECTION_ADDITIONAL_PHRASES";
+pub const ENV_POLICY_FILE: &str = "POLICY_FILE";
+pub const ENV_AUDIT_LOG_DIR: &str = "AUDIT_LOG_DIR";
+pub const ENV_AUDIT_LOG_MAX_BYTES: &str = "AUDIT_LOG_MAX_BYTES";
+pub const ENV_AUDIT_DURABILITY: &str = "AUDIT_DURABILITY";
+/// Historical name retained for compatibility; audit events are mirrored to stderr.
+pub const ENV_AUDIT_LOG_STDERR_MIRROR: &str = "AUDIT_LOG_STDOUT";
+
+pub const HONORED_CONFIG_ENV_VARS: &[&str] = &[
+    ENV_CHROME_PATH,
+    ENV_PROMPT_INJECTION_MODE,
+    ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+    ENV_POLICY_FILE,
+    ENV_AUDIT_LOG_DIR,
+    ENV_AUDIT_LOG_MAX_BYTES,
+    ENV_AUDIT_DURABILITY,
+    ENV_AUDIT_LOG_STDERR_MIRROR,
+];
+
+pub const MAX_ADDITIONAL_PHRASES: usize = 64;
+pub const MAX_ADDITIONAL_PHRASE_BYTES: usize = 512;
+pub const MAX_ADDITIONAL_PHRASES_BYTES: usize = 8 * 1024;
 
 /// Raw `config.toml` contents.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -54,16 +82,36 @@ pub enum ConfigError {
         #[source]
         source: std::io::Error,
     },
-    #[error("failed to parse config file {path}: {source}")]
+    #[error("failed to parse config file {path}")]
     Parse {
         path: PathBuf,
-        #[source]
-        source: toml::de::Error,
+        details: toml::de::Error,
     },
     #[error("invalid prompt_injection.mode '{0}' (expected 'off', 'report_only', or 'redact')")]
     InvalidInjectionMode(String),
     #[error("invalid audit.durability '{0}' (expected 'flush' or 'sync')")]
     InvalidAuditDurability(String),
+    #[error(
+        "invalid {ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES} (expected a JSON array of strings)"
+    )]
+    InvalidAdditionalPhrasesFormat,
+    #[error("too many prompt-injection additional phrases (maximum {max})")]
+    TooManyAdditionalPhrases { max: usize },
+    #[error("prompt-injection additional phrase exceeds {max_bytes} UTF-8 bytes")]
+    AdditionalPhraseTooLong { max_bytes: usize },
+    #[error("prompt-injection additional phrases exceed {max_bytes} total UTF-8 bytes")]
+    AdditionalPhrasesTooLarge { max_bytes: usize },
+    #[error("environment variable {name} is not valid UTF-8")]
+    NonUnicodeEnvVar { name: &'static str },
+}
+
+pub fn validate_unicode_additional_phrases_env() -> Result<(), ConfigError> {
+    match std::env::var(ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES) {
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(()),
+        Err(std::env::VarError::NotUnicode(_)) => Err(ConfigError::NonUnicodeEnvVar {
+            name: ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+        }),
+    }
 }
 
 /// The default config file path: `$XDG_CONFIG_HOME/dragon-head/config.toml`, falling back to
@@ -103,7 +151,7 @@ pub fn load_config_file(path: &Path) -> Result<Option<FileConfig>, ConfigError> 
         .map(Some)
         .map_err(|err| ConfigError::Parse {
             path: path.to_path_buf(),
-            source: err,
+            details: err,
         })
 }
 
@@ -124,7 +172,9 @@ pub struct ResolvedConfig {
 /// environment-variable overrides supplied via `lookup`.
 ///
 /// Precedence (env wins): `CHROME_PATH` > `chrome_path`; `PROMPT_INJECTION_MODE` >
-/// `prompt_injection.mode` (default `report_only`); `POLICY_FILE` > `policy.file`;
+/// `prompt_injection.mode` (default `report_only`);
+/// `PROMPT_INJECTION_ADDITIONAL_PHRASES` > `prompt_injection.additional_phrases`;
+/// `POLICY_FILE` > `policy.file`;
 /// `AUDIT_LOG_DIR`/`AUDIT_LOG_MAX_BYTES`/`AUDIT_DURABILITY` > `audit.*`.
 pub fn resolve_config(
     file_config: Option<&FileConfig>,
@@ -133,21 +183,28 @@ pub fn resolve_config(
     let empty = FileConfig::default();
     let fc = file_config.unwrap_or(&empty);
 
-    let chrome_path = lookup("CHROME_PATH").or_else(|| fc.chrome_path.clone());
+    let chrome_path = lookup(ENV_CHROME_PATH).or_else(|| fc.chrome_path.clone());
 
     let injection_mode =
-        match lookup("PROMPT_INJECTION_MODE").or_else(|| fc.prompt_injection.mode.clone()) {
+        match lookup(ENV_PROMPT_INJECTION_MODE).or_else(|| fc.prompt_injection.mode.clone()) {
             None => PromptInjectionMode::ReportOnly,
             Some(mode) => parse_injection_mode(&mode)?,
         };
 
-    let policy_file = lookup("POLICY_FILE")
+    let injection_additional_phrases = match lookup(ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES) {
+        Some(raw) => serde_json::from_str::<Vec<String>>(&raw)
+            .map_err(|_| ConfigError::InvalidAdditionalPhrasesFormat)?,
+        None => fc.prompt_injection.additional_phrases.clone(),
+    };
+    let injection_additional_phrases = normalize_additional_phrases(injection_additional_phrases)?;
+
+    let policy_file = lookup(ENV_POLICY_FILE)
         .or_else(|| fc.policy.file.clone())
         .map(PathBuf::from);
 
-    let audit_log_dir = lookup("AUDIT_LOG_DIR").or_else(|| fc.audit.log_dir.clone());
+    let audit_log_dir = lookup(ENV_AUDIT_LOG_DIR).or_else(|| fc.audit.log_dir.clone());
 
-    let audit_max_bytes = match lookup("AUDIT_LOG_MAX_BYTES") {
+    let audit_max_bytes = match lookup(ENV_AUDIT_LOG_MAX_BYTES) {
         Some(raw) => match raw.parse::<u64>() {
             Ok(bytes) => Some(bytes),
             Err(_) => {
@@ -161,7 +218,7 @@ pub fn resolve_config(
         None => fc.audit.max_bytes,
     };
 
-    let audit_durability = lookup("AUDIT_DURABILITY").or_else(|| fc.audit.durability.clone());
+    let audit_durability = lookup(ENV_AUDIT_DURABILITY).or_else(|| fc.audit.durability.clone());
     if let Some(durability) = &audit_durability {
         if durability != "flush" && durability != "sync" {
             return Err(ConfigError::InvalidAuditDurability(durability.clone()));
@@ -171,12 +228,46 @@ pub fn resolve_config(
     Ok(ResolvedConfig {
         chrome_path,
         injection_mode,
-        injection_additional_phrases: fc.prompt_injection.additional_phrases.clone(),
+        injection_additional_phrases,
         policy_file,
         audit_log_dir,
         audit_max_bytes,
         audit_durability,
     })
+}
+
+fn normalize_additional_phrases(phrases: Vec<String>) -> Result<Vec<String>, ConfigError> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    let mut total_bytes = 0usize;
+    for phrase in phrases {
+        let phrase = phrase.trim();
+        if phrase.is_empty() {
+            continue;
+        }
+        let phrase = phrase.to_string();
+        if !seen.insert(phrase.clone()) {
+            continue;
+        }
+        if normalized.len() == MAX_ADDITIONAL_PHRASES {
+            return Err(ConfigError::TooManyAdditionalPhrases {
+                max: MAX_ADDITIONAL_PHRASES,
+            });
+        }
+        if phrase.len() > MAX_ADDITIONAL_PHRASE_BYTES {
+            return Err(ConfigError::AdditionalPhraseTooLong {
+                max_bytes: MAX_ADDITIONAL_PHRASE_BYTES,
+            });
+        }
+        total_bytes += phrase.len();
+        if total_bytes > MAX_ADDITIONAL_PHRASES_BYTES {
+            return Err(ConfigError::AdditionalPhrasesTooLarge {
+                max_bytes: MAX_ADDITIONAL_PHRASES_BYTES,
+            });
+        }
+        normalized.push(phrase);
+    }
+    Ok(normalized)
 }
 
 fn parse_injection_mode(mode: &str) -> Result<PromptInjectionMode, ConfigError> {
@@ -425,6 +516,240 @@ durability = "sync"
         assert_eq!(resolved.audit_log_dir, Some("/tmp/audit".to_string()));
         assert_eq!(resolved.audit_max_bytes, Some(4096));
         assert_eq!(resolved.audit_durability, Some("flush".to_string()));
+    }
+
+    #[test]
+    fn resolve_config_additional_phrases_env_replaces_file_value() {
+        let fc = FileConfig {
+            prompt_injection: PromptInjectionFileConfig {
+                additional_phrases: vec!["from file".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let resolved = resolve_config(Some(&fc), |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
+                .then(|| r#"["from env","second phrase"]"#.to_string())
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.injection_additional_phrases,
+            vec!["from env".to_string(), "second phrase".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_config_empty_additional_phrases_env_clears_file_value() {
+        let fc = FileConfig {
+            prompt_injection: PromptInjectionFileConfig {
+                additional_phrases: vec!["from file".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let resolved = resolve_config(Some(&fc), |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| "[]".to_string())
+        })
+        .unwrap();
+
+        assert!(resolved.injection_additional_phrases.is_empty());
+    }
+
+    #[test]
+    fn resolve_config_rejects_invalid_additional_phrases_env_without_echoing_value() {
+        for raw in ["", r#"["secret phrase""#, r#"[{"secret":"phrase"}]"#] {
+            let err = resolve_config(None, |key| {
+                (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| raw.to_string())
+            })
+            .unwrap_err();
+            assert!(matches!(err, ConfigError::InvalidAdditionalPhrasesFormat));
+            if !raw.is_empty() {
+                assert!(!err.to_string().contains(raw));
+            }
+            assert!(!err.to_string().contains("secret phrase"));
+        }
+    }
+
+    #[test]
+    fn resolve_config_normalizes_empty_and_duplicate_additional_phrases() {
+        let resolved = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
+                .then(|| r#"["  keep me  ","","keep me","   "]"#.to_string())
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.injection_additional_phrases,
+            vec!["keep me".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_config_normalizes_file_additional_phrases_preserving_order() {
+        let fc = FileConfig {
+            prompt_injection: PromptInjectionFileConfig {
+                additional_phrases: vec![
+                    "  first phrase  ".to_string(),
+                    "".to_string(),
+                    "second phrase".to_string(),
+                    "first phrase".to_string(),
+                    "   ".to_string(),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let resolved = resolve_config(Some(&fc), no_env).unwrap();
+
+        assert_eq!(
+            resolved.injection_additional_phrases,
+            vec!["first phrase".to_string(), "second phrase".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_config_counts_effective_additional_phrases_after_normalization() {
+        let raw = serde_json::to_string(
+            &(0..=MAX_ADDITIONAL_PHRASES)
+                .map(|_| " duplicate phrase ")
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        let resolved = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| raw.clone())
+        })
+        .unwrap();
+
+        assert_eq!(
+            resolved.injection_additional_phrases,
+            vec!["duplicate phrase".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_config_rejects_file_additional_phrase_limits_without_disclosure() {
+        let secret = "file-secret-phrase";
+        let fc = FileConfig {
+            prompt_injection: PromptInjectionFileConfig {
+                additional_phrases: (0..=MAX_ADDITIONAL_PHRASES)
+                    .map(|index| format!("{secret}-{index}"))
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = resolve_config(Some(&fc), no_env).unwrap_err();
+
+        assert!(matches!(err, ConfigError::TooManyAdditionalPhrases { .. }));
+        assert!(!err.to_string().contains(secret));
+    }
+
+    #[test]
+    fn resolve_config_rejects_additional_phrase_resource_limits() {
+        let too_many = serde_json::to_string(
+            &(0..=MAX_ADDITIONAL_PHRASES)
+                .map(|index| format!("phrase {index}"))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let err = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| too_many.clone())
+        })
+        .unwrap_err();
+        assert!(matches!(err, ConfigError::TooManyAdditionalPhrases { .. }));
+
+        let too_long =
+            serde_json::to_string(&vec!["x".repeat(MAX_ADDITIONAL_PHRASE_BYTES + 1)]).unwrap();
+        let err = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| too_long.clone())
+        })
+        .unwrap_err();
+        assert!(matches!(err, ConfigError::AdditionalPhraseTooLong { .. }));
+
+        let count = MAX_ADDITIONAL_PHRASES_BYTES / MAX_ADDITIONAL_PHRASE_BYTES + 1;
+        let too_large = serde_json::to_string(
+            &(0..count)
+                .map(|index| format!("{index:04}{}", "x".repeat(MAX_ADDITIONAL_PHRASE_BYTES - 4)))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let err = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| too_large.clone())
+        })
+        .unwrap_err();
+        assert!(matches!(err, ConfigError::AdditionalPhrasesTooLarge { .. }));
+    }
+
+    #[test]
+    fn resolve_config_accepts_additional_phrase_resource_boundaries() {
+        let max_count = serde_json::to_string(
+            &(0..MAX_ADDITIONAL_PHRASES)
+                .map(|index| format!("phrase {index}"))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let resolved = resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| max_count.clone())
+        })
+        .unwrap();
+        assert_eq!(
+            resolved.injection_additional_phrases.len(),
+            MAX_ADDITIONAL_PHRASES
+        );
+
+        let exact_total = serde_json::to_string(
+            &(0..(MAX_ADDITIONAL_PHRASES_BYTES / MAX_ADDITIONAL_PHRASE_BYTES))
+                .map(|index| format!("{index:04}{}", "x".repeat(MAX_ADDITIONAL_PHRASE_BYTES - 4)))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        resolve_config(None, |key| {
+            (key == ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES).then(|| exact_total.clone())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn resolve_config_applies_additional_phrase_limits_to_file_values() {
+        let fc = FileConfig {
+            prompt_injection: PromptInjectionFileConfig {
+                additional_phrases: (0..=MAX_ADDITIONAL_PHRASES)
+                    .map(|index| format!("phrase {index}"))
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let err = resolve_config(Some(&fc), no_env).unwrap_err();
+        assert!(matches!(err, ConfigError::TooManyAdditionalPhrases { .. }));
+    }
+
+    #[test]
+    fn resolve_config_queries_every_registered_resolver_env_var() {
+        use std::cell::RefCell;
+        use std::collections::BTreeSet;
+
+        let queried = RefCell::new(BTreeSet::new());
+        resolve_config(None, |key| {
+            queried.borrow_mut().insert(key.to_string());
+            None
+        })
+        .unwrap();
+
+        let expected = HONORED_CONFIG_ENV_VARS
+            .iter()
+            .copied()
+            .filter(|key| *key != ENV_AUDIT_LOG_STDERR_MIRROR)
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(*queried.borrow(), expected);
     }
 
     #[test]

--- a/mcp-server/src/doctor.rs
+++ b/mcp-server/src/doctor.rs
@@ -133,14 +133,17 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
     }
 
     let summary = format!(
-        "chrome_path={}, prompt_injection.mode={:?}, policy.file={}",
+        "chrome_path={}, prompt_injection.mode={:?}, \
+         prompt_injection.additional_phrases={}, policy.file={}, supported_env=[{}]",
         resolved.chrome_path.as_deref().unwrap_or("<unset>"),
         resolved.injection_mode,
+        resolved.injection_additional_phrases.len(),
         resolved
             .policy_file
             .as_ref()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "<unset>".to_string()),
+        config::HONORED_CONFIG_ENV_VARS.join(","),
     );
 
     let detail = match (&path, &file_config) {
@@ -158,6 +161,9 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
 }
 
 fn config_file_detail() -> (bool, String, bool) {
+    if let Err(err) = config::validate_unicode_additional_phrases_env() {
+        return (false, format!("environment — {err}"), false);
+    }
     config_file_detail_with(|key| std::env::var(key).ok())
 }
 
@@ -451,5 +457,48 @@ mod tests {
         if !config_path.exists() {
             assert!(informational, "missing config file should be informational");
         }
+    }
+
+    #[test]
+    fn config_summary_advertises_exact_supported_env_contract() {
+        use std::collections::BTreeSet;
+
+        let (passed, detail, _) = config_file_detail_with(|_| None);
+        assert!(passed, "detail: {detail}");
+        let advertised = detail
+            .split_once("supported_env=[")
+            .and_then(|(_, rest)| rest.split_once(']'))
+            .map(|(names, _)| {
+                names
+                    .split(',')
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_else(|| panic!("missing supported_env list: {detail}"));
+        let unique = advertised.iter().cloned().collect::<BTreeSet<_>>();
+
+        assert_eq!(advertised.len(), unique.len(), "detail: {detail}");
+        assert_eq!(
+            unique,
+            config::HONORED_CONFIG_ENV_VARS
+                .iter()
+                .copied()
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn config_summary_reports_phrase_count_without_phrase_contents() {
+        let secret = "doctor-must-not-print-this-phrase";
+        let (passed, detail, _) = config_file_detail_with(|key| {
+            (key == config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
+                .then(|| format!(r#"["{secret}"]"#))
+        });
+
+        assert!(passed, "detail: {detail}");
+        assert!(detail.contains("prompt_injection.additional_phrases=1"));
+        assert!(!detail.contains(secret));
     }
 }

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -94,6 +94,8 @@ fn main() -> anyhow::Result<()> {
             .with_context(|| format!("failed to load config file {}", path.display()))?,
         None => None,
     };
+    config::validate_unicode_additional_phrases_env()
+        .context("failed to resolve dragon-head-mcp configuration")?;
     let resolved = config::resolve_config(file_config.as_ref(), env_lookup)
         .context("failed to resolve dragon-head-mcp configuration")?;
 
@@ -109,9 +111,11 @@ fn main() -> anyhow::Result<()> {
         let resolved = resolved.clone();
         move |key: &str| -> Option<String> {
             std::env::var(key).ok().or_else(|| match key {
-                "AUDIT_LOG_DIR" => resolved.audit_log_dir.clone(),
-                "AUDIT_LOG_MAX_BYTES" => resolved.audit_max_bytes.map(|bytes| bytes.to_string()),
-                "AUDIT_DURABILITY" => resolved.audit_durability.clone(),
+                config::ENV_AUDIT_LOG_DIR => resolved.audit_log_dir.clone(),
+                config::ENV_AUDIT_LOG_MAX_BYTES => {
+                    resolved.audit_max_bytes.map(|bytes| bytes.to_string())
+                }
+                config::ENV_AUDIT_DURABILITY => resolved.audit_durability.clone(),
                 _ => None,
             })
         }

--- a/mcp-server/tests/config_env_contract.rs
+++ b/mcp-server/tests/config_env_contract.rs
@@ -1,0 +1,61 @@
+use mcp_server::config::{ENV_AUDIT_LOG_STDERR_MIRROR, HONORED_CONFIG_ENV_VARS};
+use std::collections::BTreeSet;
+
+const CONTRACT_START: &str = "<!-- config-env-contract:start -->";
+const CONTRACT_END: &str = "<!-- config-env-contract:end -->";
+
+fn contract_section(body: &str) -> &str {
+    let (_, after_start) = body
+        .split_once(CONTRACT_START)
+        .expect("README config env table must have a start marker");
+    let (section, _) = after_start
+        .split_once(CONTRACT_END)
+        .expect("README config env table must have an end marker");
+    section
+}
+
+#[test]
+fn readme_config_env_table_exactly_matches_runtime_contract() {
+    let readme = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../README.md"),
+    )
+    .expect("README.md must be readable");
+    let documented = contract_section(&readme)
+        .lines()
+        .filter_map(|line| {
+            let cells = line.split('|').map(str::trim).collect::<Vec<_>>();
+            let env_cell = cells.get(2)?;
+            let (_, after_tick) = env_cell.split_once('`')?;
+            let (name, _) = after_tick.split_once('`')?;
+            Some(name.to_string())
+        })
+        .collect::<Vec<_>>();
+    let unique = documented.iter().cloned().collect::<BTreeSet<_>>();
+    let runtime = HONORED_CONFIG_ENV_VARS
+        .iter()
+        .copied()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(documented.len(), unique.len(), "duplicate README env row");
+    assert_eq!(unique, runtime);
+}
+
+#[test]
+fn audit_stderr_mirror_registry_name_is_consumed_by_production_lookup() {
+    use std::cell::RefCell;
+
+    let queried = RefCell::new(Vec::new());
+    let _logger = core_runtime::audit::AuditLogger::from_env_with(|key| {
+        queried.borrow_mut().push(key.to_string());
+        None
+    });
+
+    assert!(
+        queried
+            .borrow()
+            .iter()
+            .any(|key| key == ENV_AUDIT_LOG_STDERR_MIRROR),
+        "AuditLogger::from_env_with must consume the registered stderr mirror env name"
+    );
+}

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -362,6 +362,10 @@ fn binary_doctor_reports_resolved_summary_for_valid_config() -> anyhow::Result<(
         .arg("--doctor")
         .env("XDG_CONFIG_HOME", dir.path())
         .env_remove("PROMPT_INJECTION_MODE")
+        .env(
+            mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+            r#"["doctor-secret-phrase"]"#,
+        )
         .output()?;
 
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -373,6 +377,164 @@ fn binary_doctor_reports_resolved_summary_for_valid_config() -> anyhow::Result<(
         !stdout.contains("✗ Config file"),
         "a valid config file must not fail the Config file check: {stdout}"
     );
+    assert!(
+        stdout.contains("prompt_injection.additional_phrases=1"),
+        "stdout should report only the effective phrase count: {stdout}"
+    );
+    assert!(!stdout.contains("doctor-secret-phrase"));
+    assert!(!String::from_utf8_lossy(&out.stderr).contains("doctor-secret-phrase"));
+    for name in mcp_server::config::HONORED_CONFIG_ENV_VARS {
+        assert!(stdout.contains(name), "missing {name} in: {stdout}");
+    }
+    Ok(())
+}
+
+#[test]
+fn binary_doctor_rejects_file_additional_phrase_limits_without_disclosure() -> anyhow::Result<()> {
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let dragon_head_dir = dir.path().join("dragon-head");
+    std::fs::create_dir_all(&dragon_head_dir)?;
+    let phrases = (0..=mcp_server::config::MAX_ADDITIONAL_PHRASES)
+        .map(|index| format!("file-secret-phrase-{index}"))
+        .map(|phrase| format!("{phrase:?}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        format!("[prompt_injection]\nadditional_phrases = [{phrases}]"),
+    )?;
+
+    let out = Command::new(&bin)
+        .arg("--doctor")
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env_remove(mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
+        .output()?;
+
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("✗ Config file"));
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("file-secret-phrase"));
+    assert!(!String::from_utf8_lossy(&out.stderr).contains("file-secret-phrase"));
+    Ok(())
+}
+
+#[test]
+fn binary_rejects_malformed_config_without_disclosing_phrase_contents() -> anyhow::Result<()> {
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let dragon_head_dir = dir.path().join("dragon-head");
+    std::fs::create_dir_all(&dragon_head_dir)?;
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        "[prompt_injection]\nadditional_phrases = [\"file-parse-secret-phrase\"",
+    )?;
+
+    for args in [&["--doctor"][..], &[][..]] {
+        let out = Command::new(&bin)
+            .args(args)
+            .env("XDG_CONFIG_HOME", dir.path())
+            .env_remove(mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
+            .output()?;
+
+        assert!(!out.status.success());
+        if args.is_empty() {
+            assert!(out.stdout.is_empty(), "stdout must remain JSON-RPC clean");
+        }
+        assert!(!String::from_utf8_lossy(&out.stdout).contains("file-parse-secret-phrase"));
+        assert!(!String::from_utf8_lossy(&out.stderr).contains("file-parse-secret-phrase"));
+    }
+    Ok(())
+}
+
+#[test]
+fn binary_doctor_rejects_invalid_additional_phrase_env_without_disclosure() -> anyhow::Result<()> {
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let too_many = serde_json::to_string(
+        &(0..=mcp_server::config::MAX_ADDITIONAL_PHRASES)
+            .map(|index| format!("doctor-secret-phrase-{index}"))
+            .collect::<Vec<_>>(),
+    )?;
+
+    for raw in [
+        "".to_string(),
+        r#"["doctor-secret-phrase""#.to_string(),
+        r#"[{"secret":"doctor-secret-phrase"}]"#.to_string(),
+        too_many,
+    ] {
+        let out = Command::new(&bin)
+            .arg("--doctor")
+            .env("XDG_CONFIG_HOME", dir.path())
+            .env(
+                mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+                &raw,
+            )
+            .output()?;
+
+        assert!(!out.status.success(), "raw={raw:?}");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(!stdout.contains("doctor-secret-phrase"), "{stdout}");
+        assert!(!stderr.contains("doctor-secret-phrase"), "{stderr}");
+    }
+    Ok(())
+}
+
+#[test]
+fn binary_startup_rejects_invalid_additional_phrase_env_without_stdout_or_disclosure(
+) -> anyhow::Result<()> {
+    let bin = build_binary_once()?;
+    let too_many = serde_json::to_string(
+        &(0..=mcp_server::config::MAX_ADDITIONAL_PHRASES)
+            .map(|index| format!("startup-secret-phrase-{index}"))
+            .collect::<Vec<_>>(),
+    )?;
+    for raw in [
+        r#"["startup-secret-phrase""#.to_string(),
+        r#"[{"secret":"startup-secret-phrase"}]"#.to_string(),
+        too_many,
+    ] {
+        let out = Command::new(&bin)
+            .env(
+                mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+                &raw,
+            )
+            .output()?;
+
+        assert!(!out.status.success());
+        assert!(out.stdout.is_empty(), "stdout must remain JSON-RPC clean");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(!stderr.contains("startup-secret-phrase"), "{stderr}");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn binary_doctor_rejects_non_unicode_additional_phrase_env() -> anyhow::Result<()> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let bin = build_binary_once()?;
+    let out = Command::new(&bin)
+        .arg("--doctor")
+        .env(
+            mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+            OsString::from_vec(vec![b'[', b'"', 0xff, b'"', b']']),
+        )
+        .output()?;
+
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("✗ Config file"));
+
+    let out = Command::new(&bin)
+        .env(
+            mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+            OsString::from_vec(vec![b'[', b'"', 0xff, b'"', b']']),
+        )
+        .output()?;
+    assert!(!out.status.success());
+    assert!(out.stdout.is_empty(), "stdout must remain JSON-RPC clean");
     Ok(())
 }
 
@@ -391,6 +553,7 @@ fn binary_doctor_fails_for_invalid_injection_mode_config() -> anyhow::Result<()>
         .arg("--doctor")
         .env("XDG_CONFIG_HOME", dir.path())
         .env_remove("PROMPT_INJECTION_MODE")
+        .env_remove(mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
         .output()?;
 
     assert!(
@@ -437,6 +600,7 @@ fn test_mcp_binary_stdio_smoke() -> anyhow::Result<()> {
         .stderr(Stdio::inherit())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env_remove("PROMPT_INJECTION_MODE")
+        .env_remove(mcp_server::config::ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES)
         .env_remove("POLICY_FILE")
         .env_remove("AUDIT_LOG_DIR")
         .env_remove("AUDIT_LOG_MAX_BYTES")


### PR DESCRIPTION
Closes #211\n\n## Summary\n- add PROMPT_INJECTION_ADDITIONAL_PHRASES as a JSON string-array override for prompt_injection.additional_phrases\n- centralize the eight honored config environment variables and expose the exact registry through README and --doctor\n- enforce shared file/env normalization and resource limits while keeping phrase contents out of diagnostics\n- correct AUDIT_LOG_STDOUT documentation to its compatibility behavior: audit events mirror to stderr, never JSON-RPC stdout\n\n## Spec / Plan traceability\n- docs/PLAN.md Issue 211 follow-up\n- README Configuration contract\n- docs/DEVELOPMENT_GUIDE.md environment variable contract\n\n## Exit criteria\n- env replaces file configuration; [] explicitly clears it\n- invalid JSON, non-string elements, non-UTF-8 values, and resource-limit violations fail closed\n- effective phrases are trimmed, empty entries discarded, exact duplicates removed in first-seen order\n- maximum effective set: 64 phrases, 512 UTF-8 bytes per phrase, 8 KiB total\n- --doctor lists every honored config env name and only the effective phrase count\n- malformed env/config diagnostics do not disclose phrase contents\n- AUDIT_LOG_STDOUT remains stderr-only\n\n## Verification\n- cargo test --workspace: passed\n- cargo test --workspace --doc: 0 passed, 1 ignored, no failures\n- cargo test -p mcp-server: passed; binary E2E 12 passed, 2 Chrome-only ignored\n- cargo fmt --all -- --check: passed\n- cargo clippy --workspace -- -D warnings: passed\n- config env documentation contract: 2 passed\n- audit stdout regression: 2 passed\n- real binary QA: valid env count=1; [] count=0; malformed JSON exits 1 without sentinel disclosure\n\n## Review and QA\n- architecture, test, and security final reviews: CLEAN\n- gstack pre-landing review: one malformed-TOML disclosure finding fixed with a binary regression test; re-review CLEAN\n- gstack qa-only equivalent: CLI/config contract QA, no unresolved findings\n\nNo unresolved P1/P2 findings.