### PR TITLE
[ISSUE-244] Add policy-aware navigate tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ additional_phrases = ["reveal developer message"]
 # Path to a PolicyRule JSON file (see examples/policies/). Overridden by POLICY_FILE.
 file = "/etc/dragon-head/policy.json"
 
+[navigation]
+# Trusted local deployments only. Overridden by NAVIGATION_ALLOW_PRIVATE_NETWORK.
+allow_private_network = false
+
 [audit]
 # Mirrors AUDIT_LOG_DIR / AUDIT_LOG_MAX_BYTES / AUDIT_DURABILITY.
 log_dir = "/var/log/dragon-head"
@@ -197,6 +201,7 @@ durability = "flush"  # "flush" (default) or "sync"
 | Prompt-injection mode | `PROMPT_INJECTION_MODE` | `prompt_injection.mode` |
 | Prompt-injection additional phrases | `PROMPT_INJECTION_ADDITIONAL_PHRASES` | `prompt_injection.additional_phrases` |
 | Policy file | `POLICY_FILE` | `policy.file` |
+| Navigation private-network opt-in | `NAVIGATION_ALLOW_PRIVATE_NETWORK` | `navigation.allow_private_network` |
 | Audit log directory | `AUDIT_LOG_DIR` | `audit.log_dir` |
 | Audit max bytes | `AUDIT_LOG_MAX_BYTES` | `audit.max_bytes` |
 | Audit durability | `AUDIT_DURABILITY` | `audit.durability` |
@@ -213,6 +218,12 @@ per phrase, and 8 KiB total, while preserving first-seen order.
 `AUDIT_LOG_STDOUT` (if set, any value) mirrors audit events to **stderr**, never
 stdout — `dragon-head-mcp` uses stdout for JSON-RPC framing, so writing there
 would corrupt the protocol stream.
+
+`NAVIGATION_ALLOW_PRIVATE_NETWORK` accepts exactly `true` or `false`; invalid
+values fail configuration without echoing their contents. The default blocks
+loopback, private, link-local, and other non-global navigation destinations.
+Enable it only for trusted local deployments and tests. This application-level
+switch does not replace OS/container network isolation or deployment egress controls.
 
 Run `dragon-head-mcp --doctor` to validate the config file and list every
 supported configuration environment variable. A malformed file or invalid env
@@ -365,13 +376,14 @@ specific Chromium build.
 
 ## Available MCP Tools
 
-`dragon-head-mcp` currently exposes 8 tools. The source of truth is
+`dragon-head-mcp` currently exposes 9 tools. The source of truth is
 `McpServer::tools()` in `mcp-server/src/lib.rs`:
 
 <!-- mcp-tool-list:start -->
 | Tool | Purpose |
 | --- | --- |
 | `get_state` | Retrieve the semantic page state. |
+| `navigate` | Load an HTTP(S) URL through destination and redirect policy checks. |
 | `act` | Execute an interaction action. |
 | `verify` | Verify precondition text before acting. |
 | `get_visual` | Capture visual context with optional marks. |
@@ -386,6 +398,9 @@ specific Chromium build.
 structured page data. It is read-only and does not emit an action audit event.
 `get_usage_report` is also read-only: it reports the plan tier, usage meters, and
 the audit-retention snapshot, but does not meter itself or emit an action audit event.
+`navigate` accepts absolute HTTP(S) URLs without embedded credentials, strips
+fragments, evaluates the requested destination and each top-level redirect before
+network access, and logs only a sanitized destination projection without query data.
 <!-- mcp-tool-semantics:end -->
 
 ## Developer Examples

--- a/core-runtime/src/audit.rs
+++ b/core-runtime/src/audit.rs
@@ -39,6 +39,8 @@ pub enum AuditEvent {
         rule_id: String,
         action: String,
         decision: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        destination_fingerprint: Option<String>,
         timestamp: u64,
     },
     #[serde(rename = "HITL_EVENT")]
@@ -358,6 +360,25 @@ fn sanitize_audit_event(event: AuditEvent) -> AuditEvent {
             timestamp,
             patch: r.redact_json(&patch),
         },
+        AuditEvent::PolicyDecision {
+            rule_id,
+            action,
+            decision,
+            destination_fingerprint,
+            timestamp,
+        } => AuditEvent::PolicyDecision {
+            rule_id,
+            action,
+            decision,
+            destination_fingerprint: destination_fingerprint.filter(|fingerprint| {
+                fingerprint.len() == 71
+                    && fingerprint.starts_with("sha256:")
+                    && fingerprint[7..]
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit())
+            }),
+            timestamp,
+        },
         // Plugin-supplied strings (error_message, reason) may contain PII from
         // page content (URLs with tokens, emails, etc.).  Truncate them to a safe
         // maximum length and redact any recognised sensitive patterns.
@@ -618,5 +639,41 @@ mod tests {
         {
             assert!(reason.is_none());
         }
+    }
+
+    #[test]
+    fn sanitize_policy_destination_accepts_only_sha256_fingerprints() {
+        let raw = AuditEvent::PolicyDecision {
+            rule_id: "r".to_string(),
+            action: "navigate".to_string(),
+            decision: "allow".to_string(),
+            destination_fingerprint: Some(
+                "https://example.com/path?query-secret#fragment-secret".to_string(),
+            ),
+            timestamp: 0,
+        };
+        assert!(matches!(
+            sanitize_audit_event(raw),
+            AuditEvent::PolicyDecision {
+                destination_fingerprint: None,
+                ..
+            }
+        ));
+
+        let fingerprint = format!("sha256:{}", "01".repeat(32));
+        let safe = AuditEvent::PolicyDecision {
+            rule_id: "r".to_string(),
+            action: "navigate".to_string(),
+            decision: "allow".to_string(),
+            destination_fingerprint: Some(fingerprint.clone()),
+            timestamp: 0,
+        };
+        assert!(matches!(
+            sanitize_audit_event(safe),
+            AuditEvent::PolicyDecision {
+                destination_fingerprint: Some(value),
+                ..
+            } if value == fingerprint
+        ));
     }
 }

--- a/core-runtime/src/audit_replay.rs
+++ b/core-runtime/src/audit_replay.rs
@@ -44,6 +44,8 @@ pub struct PolicyDecisionEntry {
     pub rule_id: String,
     pub action: String,
     pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_fingerprint: Option<String>,
     pub timestamp: u64,
 }
 
@@ -159,12 +161,14 @@ pub fn replay_events(events: &[AuditEvent]) -> Result<ReplayReport, ReplayError>
                 rule_id,
                 action,
                 decision,
+                destination_fingerprint,
                 timestamp,
             } => {
                 policy_decisions.push(PolicyDecisionEntry {
                     rule_id: rule_id.clone(),
                     action: action.clone(),
                     decision: decision.clone(),
+                    destination_fingerprint: destination_fingerprint.clone(),
                     timestamp: *timestamp,
                 });
             }
@@ -252,14 +256,19 @@ pub fn report_to_markdown(report: &ReplayReport) -> String {
     if report.policy_decisions.is_empty() {
         out.push_str("_(no policy decisions)_\n");
     } else {
-        out.push_str("| Rule | Action | Decision | Timestamp (ms) |\n");
-        out.push_str("|------|--------|----------|----------------|\n");
+        out.push_str("| Rule | Action | Decision | Destination | Timestamp (ms) |\n");
+        out.push_str("|------|--------|----------|-------------|----------------|\n");
         for pd in &report.policy_decisions {
             out.push_str(&format!(
-                "| `{}` | {} | **{}** | {} |\n",
+                "| `{}` | {} | **{}** | {} | {} |\n",
                 escape_md(&pd.rule_id),
                 escape_md(&pd.action),
                 escape_md(&pd.decision),
+                pd.destination_fingerprint
+                    .as_deref()
+                    .map(escape_md)
+                    .map(|fingerprint| format!("`{fingerprint}`"))
+                    .unwrap_or_else(|| "—".to_string()),
                 pd.timestamp
             ));
         }
@@ -389,6 +398,7 @@ mod tests {
                 rule_id: "R-1".to_string(),
                 action: "redact".to_string(),
                 decision: "allow".to_string(),
+                destination_fingerprint: None,
                 timestamp: 3000,
             }],
             hitl_events: vec![],
@@ -400,5 +410,40 @@ mod tests {
         assert!(md.contains("SNAPSHOT"));
         assert!(md.contains("sha256:abc"));
         assert!(md.contains("R-1"));
+    }
+
+    #[test]
+    fn replay_carries_navigation_fingerprint_into_json_and_markdown_only() {
+        let fingerprint = format!("sha256:{}", "ab".repeat(32));
+        let events = [AuditEvent::PolicyDecision {
+            rule_id: "NAV-1".to_string(),
+            action: "navigate".to_string(),
+            decision: "allow".to_string(),
+            destination_fingerprint: Some(fingerprint.clone()),
+            timestamp: 4000,
+        }];
+        let report = replay_events(&events).unwrap();
+        assert_eq!(
+            report.policy_decisions[0]
+                .destination_fingerprint
+                .as_deref(),
+            Some(fingerprint.as_str())
+        );
+
+        let json = serde_json::to_string(&report).unwrap();
+        let markdown = report_to_markdown(&report);
+        for rendered in [&json, &markdown] {
+            assert!(rendered.contains(&fingerprint));
+            assert!(!rendered.contains("query-secret"));
+            assert!(!rendered.contains("fragment-secret"));
+            assert!(!rendered.contains("https://"));
+        }
+    }
+
+    #[test]
+    fn policy_decision_entry_deserializes_legacy_json_without_fingerprint() {
+        let legacy = r#"{"rule_id":"R-1","action":"click","decision":"allow","timestamp":1}"#;
+        let entry: PolicyDecisionEntry = serde_json::from_str(legacy).unwrap();
+        assert!(entry.destination_fingerprint.is_none());
     }
 }

--- a/core-runtime/src/audit_sink.rs
+++ b/core-runtime/src/audit_sink.rs
@@ -673,6 +673,7 @@ mod tests {
                 rule_id: "R1".into(),
                 action: "click".into(),
                 decision: "allow".into(),
+                destination_fingerprint: None,
                 timestamp: 43,
             },
         ];

--- a/core-runtime/src/browser/mod.rs
+++ b/core-runtime/src/browser/mod.rs
@@ -1,4 +1,5 @@
 mod helpers;
+mod navigation;
 use helpers::{
     build_semantic_path_index, collect_stable_key_entries, duration_to_millis, epoch_millis,
     epoch_millis_u64, error_chain_contains_any, find_node_by_id, find_node_by_key,
@@ -7,12 +8,16 @@ use helpers::{
     state_contains_intent, target_matches_state, transient_error_backoff, value_to_string_vec,
     value_to_u64,
 };
+pub use navigation::{
+    validate_public_navigation_url, validate_public_navigation_url_with, NavigationNetworkPolicy,
+    NavigationValidationError, ValidatedNavigationUrl, MAX_PUBLIC_NAVIGATION_URL_BYTES,
+};
 
 use anyhow::{Context, Result};
 use headless_chrome::{Browser, LaunchOptions};
 use std::{
     cmp::min,
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -146,6 +151,59 @@ struct GrantedPolicyApproval {
 struct PolicyApprovalState {
     pending: Option<PolicyApprovalRequest>,
     granted: Vec<GrantedPolicyApproval>,
+}
+
+#[derive(Debug, Clone)]
+enum NavigationPolicyFailure {
+    Blocked {
+        rule_id: String,
+    },
+    HumanApprovalRequired {
+        rule_id: String,
+        scope: ApprovalScope,
+        outcome: Option<OutcomeProjection>,
+    },
+    Rejected {
+        message: String,
+    },
+}
+
+impl NavigationPolicyFailure {
+    fn into_error(self) -> anyhow::Error {
+        match self {
+            Self::Blocked { rule_id } => ActionError::Blocked { rule_id }.into(),
+            Self::HumanApprovalRequired {
+                rule_id,
+                scope,
+                outcome,
+            } => ActionError::HumanApprovalRequired {
+                rule_id,
+                scope,
+                outcome,
+            }
+            .into(),
+            Self::Rejected { message } => anyhow::anyhow!(message),
+        }
+    }
+}
+
+struct RedirectInterceptionState {
+    main_frame_id: String,
+    initial_url: String,
+    original_url: String,
+    network_policy: NavigationNetworkPolicy,
+    request_chain: HashSet<String>,
+    evaluated_destinations: HashSet<String>,
+    failure: Option<NavigationPolicyFailure>,
+}
+
+struct NavigationPolicyContext {
+    policy_engine: Arc<Mutex<PolicyEngine>>,
+    policy_approvals: Arc<Mutex<PolicyApprovalState>>,
+    navigation_epoch: Arc<AtomicU64>,
+    audit_logger: Arc<AuditLogger>,
+    plugin_hooks: Arc<PluginHookConfig>,
+    approval_context_url: String,
 }
 
 #[derive(Clone, Default)]
@@ -282,6 +340,8 @@ impl BrowserClient {
             policy_engine: Arc::new(Mutex::new(PolicyEngine::default())),
             policy_approvals: Arc::new(Mutex::new(PolicyApprovalState::default())),
             navigation_epoch: Arc::new(AtomicU64::new(0)),
+            public_navigation_attempts: Arc::new(AtomicU64::new(0)),
+            public_navigation_lock: Arc::new(Mutex::new(())),
             audit_logger: Arc::new(audit_logger),
             semantic_capture_cache: Arc::new(Mutex::new(SemanticCaptureCache::default())),
             vault: Arc::clone(&self.vault),
@@ -390,6 +450,8 @@ pub struct PageSession {
     policy_engine: Arc<Mutex<PolicyEngine>>,
     policy_approvals: Arc<Mutex<PolicyApprovalState>>,
     navigation_epoch: Arc<AtomicU64>,
+    public_navigation_attempts: Arc<AtomicU64>,
+    public_navigation_lock: Arc<Mutex<()>>,
     pub(crate) audit_logger: Arc<AuditLogger>,
     semantic_capture_cache: Arc<Mutex<SemanticCaptureCache>>,
     vault: Arc<dyn SessionVault>,
@@ -435,6 +497,246 @@ impl PageSession {
         self.navigation_epoch.fetch_add(1, Ordering::Relaxed);
         self.clear_pending_policy_approval();
         Ok(())
+    }
+
+    /// Navigate an untrusted public MCP destination through URL/network validation,
+    /// destination-aware policy evaluation, and top-level redirect interception.
+    ///
+    /// Unlike [`navigate`](Self::navigate), this boundary accepts only HTTP(S).
+    /// The internal method intentionally retains support for `data:` fixtures.
+    pub fn navigate_public(&self, url: &str, allow_private_network: bool) -> Result<String> {
+        use headless_chrome::{
+            browser::{
+                tab::RequestPausedDecision,
+                transport::{SessionId, Transport},
+            },
+            protocol::cdp::{
+                Fetch::{self, FailRequest, RequestPattern, RequestStage},
+                Network::{ErrorReason, ResourceType},
+                Page,
+            },
+        };
+
+        let _serialized = self
+            .public_navigation_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("public navigation lock is unavailable"))?;
+        let network_policy = if allow_private_network {
+            NavigationNetworkPolicy::AllowPrivate
+        } else {
+            NavigationNetworkPolicy::PublicOnly
+        };
+        let requested = validate_public_navigation_url(url, network_policy)?;
+        self.audit_logger.log(AuditEvent::ToolCall {
+            tool_name: "navigate".to_string(),
+            args: serde_json::json!({ "destination": requested.sanitized_projection() }),
+            timestamp: epoch_millis_u64(),
+        });
+
+        let approval_context_url = self.current_url().unwrap_or_default();
+        let policy_context = Arc::new(NavigationPolicyContext {
+            policy_engine: Arc::clone(&self.policy_engine),
+            policy_approvals: Arc::clone(&self.policy_approvals),
+            navigation_epoch: Arc::clone(&self.navigation_epoch),
+            audit_logger: Arc::clone(&self.audit_logger),
+            plugin_hooks: Arc::clone(&self.plugin_hooks),
+            approval_context_url,
+        });
+        evaluate_navigation_destination(
+            &policy_context,
+            &requested,
+            requested.destination_digest(),
+            false,
+        )
+        .map_err(NavigationPolicyFailure::into_error)?;
+
+        let frame_tree = self
+            .inner
+            .call_method(Page::GetFrameTree(None))
+            .context("failed to inspect the main frame before public navigation")?;
+        let main_frame_id = frame_tree.frame_tree.frame.id;
+        let interception_state = Arc::new(Mutex::new(RedirectInterceptionState {
+            main_frame_id,
+            initial_url: requested.canonical_url().to_string(),
+            original_url: requested.canonical_url().to_string(),
+            network_policy,
+            request_chain: HashSet::new(),
+            evaluated_destinations: HashSet::from([requested.destination_digest().to_string()]),
+            failure: None,
+        }));
+
+        let callback_state = Arc::clone(&interception_state);
+        let callback_policy = Arc::clone(&policy_context);
+        let interceptor = Arc::new(
+            move |_transport: Arc<Transport>,
+                  _session_id: SessionId,
+                  event: Fetch::events::RequestPausedEvent| {
+                let mut state = match callback_state.lock() {
+                    Ok(state) => state,
+                    Err(_) => {
+                        return RequestPausedDecision::Fail(FailRequest {
+                            request_id: event.params.request_id,
+                            error_reason: ErrorReason::BlockedByClient,
+                        })
+                    }
+                };
+                if event.params.frame_id != state.main_frame_id
+                    || event.params.resource_Type != ResourceType::Document
+                {
+                    return RequestPausedDecision::Continue(None);
+                }
+                if state.failure.is_some() {
+                    return RequestPausedDecision::Fail(FailRequest {
+                        request_id: event.params.request_id,
+                        error_reason: ErrorReason::BlockedByClient,
+                    });
+                }
+
+                let request_id = event.params.request_id.clone();
+                let Some(parent_request_id) = event.params.redirected_request_id.as_ref() else {
+                    let canonical = validate_public_navigation_url_with(
+                        &event.params.request.url,
+                        NavigationNetworkPolicy::AllowPrivate,
+                        |_, _| Ok(Vec::new()),
+                    );
+                    if canonical
+                        .as_ref()
+                        .is_ok_and(|candidate| candidate.canonical_url() == state.initial_url)
+                    {
+                        state.request_chain.insert(request_id);
+                    }
+                    return RequestPausedDecision::Continue(None);
+                };
+                if !state.request_chain.contains(parent_request_id) {
+                    return RequestPausedDecision::Continue(None);
+                }
+
+                let destination = match validate_public_navigation_url(
+                    &event.params.request.url,
+                    state.network_policy,
+                ) {
+                    Ok(destination) => destination,
+                    Err(error) => {
+                        state.failure = Some(NavigationPolicyFailure::Rejected {
+                            message: error.to_string(),
+                        });
+                        return RequestPausedDecision::Fail(FailRequest {
+                            request_id,
+                            error_reason: ErrorReason::BlockedByClient,
+                        });
+                    }
+                };
+                let approval_digest = navigation::redirect_approval_digest(
+                    &state.original_url,
+                    destination.canonical_url(),
+                );
+                let first_evaluation = state
+                    .evaluated_destinations
+                    .insert(destination.destination_digest().to_string());
+                if first_evaluation {
+                    if let Err(failure) = evaluate_navigation_destination(
+                        &callback_policy,
+                        &destination,
+                        &approval_digest,
+                        true,
+                    ) {
+                        state.failure = Some(failure);
+                        return RequestPausedDecision::Fail(FailRequest {
+                            request_id,
+                            error_reason: ErrorReason::BlockedByClient,
+                        });
+                    }
+                }
+                state.request_chain.insert(request_id);
+                RequestPausedDecision::Continue(None)
+            },
+        );
+        let patterns = [RequestPattern {
+            url_pattern: None,
+            resource_Type: None,
+            request_stage: Some(RequestStage::Request),
+        }];
+        let mut interception =
+            NavigationInterceptionGuard::install(Arc::clone(&self.inner), interceptor, &patterns)?;
+
+        let previous_url = self.current_url().ok();
+        self.public_navigation_attempts
+            .fetch_add(1, Ordering::Relaxed);
+        let navigation_result =
+            self.inner
+                .navigate_to(requested.canonical_url())
+                .context("public navigation request failed")
+                .and_then(|_| {
+                    self.inner.wait_until_navigated().map(|_| ()).or_else(|_| {
+                        self.wait_for_public_navigation_fallback(previous_url.as_deref())
+                    })
+                });
+
+        self.clear_stable_key_index();
+        self.clear_semantic_capture_cache();
+        // Conservatively advance after every started navigation. In particular,
+        // this covers document commits followed by timeout/CDP failure. Delaying
+        // the bump until interception completes lets a grant created for a blocked
+        // redirect be consumed when the original URL is retried.
+        self.navigation_epoch.fetch_add(1, Ordering::Relaxed);
+
+        let interception_failure = interception_state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("public navigation outcome is unavailable"))?
+            .failure
+            .clone();
+        if let Ok(mut approvals) = self.policy_approvals.lock() {
+            approvals.granted.clear();
+            if !matches!(
+                &interception_failure,
+                Some(NavigationPolicyFailure::HumanApprovalRequired { .. })
+            ) {
+                approvals.pending = None;
+            }
+        }
+        let cleanup_result = interception.finish();
+        if let Some(failure) = interception_failure {
+            return Err(failure.into_error());
+        }
+        navigation_result.context("public navigation did not complete")?;
+        cleanup_result?;
+
+        let final_url = self
+            .current_url()
+            .context("failed to read final public navigation URL")?;
+        let final_url = validate_public_navigation_url_with(
+            &final_url,
+            NavigationNetworkPolicy::AllowPrivate,
+            |_, _| Ok(Vec::new()),
+        )?;
+        Ok(final_url.canonical_url().to_string())
+    }
+
+    pub fn public_navigation_attempt_count(&self) -> u64 {
+        self.public_navigation_attempts.load(Ordering::Relaxed)
+    }
+
+    fn wait_for_public_navigation_fallback(&self, previous_url: Option<&str>) -> Result<()> {
+        let started = Instant::now();
+        loop {
+            let current_url = self.current_url().ok();
+            let ready_state = self.document_ready_state().ok();
+            let dom_non_empty = self
+                .get_content()
+                .map(|content| !content.trim().is_empty())
+                .unwrap_or(false);
+            if current_url.as_deref() != previous_url
+                && matches!(ready_state.as_deref(), Some("interactive" | "complete"))
+                && dom_non_empty
+            {
+                return Ok(());
+            }
+            let remaining = remaining_timeout(started, NAVIGATION_FALLBACK_TIMEOUT);
+            if remaining.is_zero() {
+                anyhow::bail!("public navigation timed out");
+            }
+            thread::sleep(min(NAVIGATION_FALLBACK_POLL_INTERVAL, remaining));
+        }
     }
 
     pub fn get_content(&self) -> Result<String> {
@@ -1385,6 +1687,7 @@ impl PageSession {
                 PolicyAction::Block => "block".to_string(),
                 PolicyAction::RequireHumanApproval => "require_human_approval".to_string(),
             },
+            destination_fingerprint: None,
             timestamp: epoch_millis_u64(),
         });
 
@@ -2278,6 +2581,271 @@ fn push_policy_text_part(parts: &mut Vec<String>, value: Option<&str>) {
     parts.push(normalized.to_string());
 }
 
+type NavigationRequestInterceptor =
+    dyn headless_chrome::browser::tab::RequestInterceptor + Send + Sync;
+
+trait NavigationInterceptionControl: Send + Sync {
+    fn install_interceptor(&self, interceptor: Arc<NavigationRequestInterceptor>) -> Result<()>;
+    fn enable_fetch(
+        &self,
+        patterns: &[headless_chrome::protocol::cdp::Fetch::RequestPattern],
+    ) -> Result<()>;
+    fn restore_default_interceptor(&self) -> Result<()>;
+    fn disable_fetch(&self) -> Result<()>;
+}
+
+struct TabNavigationInterceptionControl {
+    tab: Arc<headless_chrome::Tab>,
+}
+
+impl NavigationInterceptionControl for TabNavigationInterceptionControl {
+    fn install_interceptor(&self, interceptor: Arc<NavigationRequestInterceptor>) -> Result<()> {
+        self.tab.enable_request_interception(interceptor)
+    }
+
+    fn enable_fetch(
+        &self,
+        patterns: &[headless_chrome::protocol::cdp::Fetch::RequestPattern],
+    ) -> Result<()> {
+        self.tab.enable_fetch(Some(patterns), None).map(|_| ())
+    }
+
+    fn restore_default_interceptor(&self) -> Result<()> {
+        self.tab.enable_request_interception(Arc::new(
+            |_: Arc<headless_chrome::browser::transport::Transport>,
+             _: headless_chrome::browser::transport::SessionId,
+             _: headless_chrome::protocol::cdp::Fetch::events::RequestPausedEvent| {
+                headless_chrome::browser::tab::RequestPausedDecision::Continue(None)
+            },
+        ))
+    }
+
+    fn disable_fetch(&self) -> Result<()> {
+        self.tab.disable_fetch().map(|_| ())
+    }
+}
+
+struct NavigationInterceptionGuard {
+    control: Arc<dyn NavigationInterceptionControl>,
+    active: bool,
+}
+
+impl NavigationInterceptionGuard {
+    fn install<F>(
+        tab: Arc<headless_chrome::Tab>,
+        interceptor: Arc<F>,
+        patterns: &[headless_chrome::protocol::cdp::Fetch::RequestPattern],
+    ) -> Result<Self>
+    where
+        F: headless_chrome::browser::tab::RequestInterceptor + Send + Sync + 'static,
+    {
+        Self::install_with_control(
+            Arc::new(TabNavigationInterceptionControl { tab }),
+            interceptor,
+            patterns,
+        )
+    }
+
+    fn install_with_control<F>(
+        control: Arc<dyn NavigationInterceptionControl>,
+        interceptor: Arc<F>,
+        patterns: &[headless_chrome::protocol::cdp::Fetch::RequestPattern],
+    ) -> Result<Self>
+    where
+        F: headless_chrome::browser::tab::RequestInterceptor + Send + Sync + 'static,
+    {
+        let guard = Self {
+            control,
+            active: true,
+        };
+        let interceptor: Arc<NavigationRequestInterceptor> = interceptor;
+        guard
+            .control
+            .install_interceptor(interceptor)
+            .context("failed to install public navigation interceptor")?;
+        guard
+            .control
+            .enable_fetch(patterns)
+            .context("failed to enable public navigation interception")?;
+        Ok(guard)
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        self.active = false;
+        let restore_result = self
+            .control
+            .restore_default_interceptor()
+            .context("failed to restore default request interceptor");
+        let disable_result = self
+            .control
+            .disable_fetch()
+            .context("failed to disable public navigation interception");
+        restore_result.and(disable_result)
+    }
+}
+
+impl Drop for NavigationInterceptionGuard {
+    fn drop(&mut self) {
+        let _ = self.finish();
+    }
+}
+
+fn evaluate_navigation_destination(
+    context: &NavigationPolicyContext,
+    destination: &ValidatedNavigationUrl,
+    approval_signature: &str,
+    clear_pending_on_block: bool,
+) -> std::result::Result<(), NavigationPolicyFailure> {
+    let decision = context
+        .policy_engine
+        .lock()
+        .map_err(|_| NavigationPolicyFailure::Rejected {
+            message: "navigation policy engine is unavailable".to_string(),
+        })?
+        .evaluate(&PolicyContext {
+            url: destination.canonical_url().to_string(),
+            action: "navigate".to_string(),
+            target_role: None,
+            target_text: None,
+            surrounding_text: None,
+        });
+    let rule_id = decision
+        .rule_id
+        .clone()
+        .unwrap_or_else(|| "unnamed-policy-rule".to_string());
+    context.audit_logger.log(AuditEvent::PolicyDecision {
+        rule_id: rule_id.clone(),
+        action: "navigate".to_string(),
+        decision: match decision.action {
+            PolicyAction::Allow => "allow",
+            PolicyAction::Block => "block",
+            PolicyAction::RequireHumanApproval => "require_human_approval",
+        }
+        .to_string(),
+        destination_fingerprint: Some(format!("sha256:{}", destination.destination_digest())),
+        timestamp: epoch_millis_u64(),
+    });
+
+    let run_plugins = || {
+        let intent = serde_json::json!({
+            "action": "navigate",
+            "url": destination.canonical_url(),
+        })
+        .to_string();
+        let (outcome, events) = run_policy_hooks(
+            &intent,
+            context
+                .plugin_hooks
+                .policy_plugins
+                .iter()
+                .map(|p| p.as_ref()),
+        );
+        // Plugin reasons are untrusted and may echo the full destination URL.
+        // Keep attribution and allow/block result, but never persist the reason.
+        for event in events {
+            if let AuditEvent::PluginPolicyDecision {
+                plugin_id,
+                allowed,
+                timestamp,
+                ..
+            } = event
+            {
+                context.audit_logger.log(AuditEvent::PluginPolicyDecision {
+                    plugin_id,
+                    allowed,
+                    reason: None,
+                    timestamp,
+                });
+            }
+        }
+        match outcome {
+            PolicyHookOutcome::Allow => Ok(()),
+            PolicyHookOutcome::Block { plugin_id, .. } => Err(NavigationPolicyFailure::Blocked {
+                rule_id: format!("plugin:{plugin_id}"),
+            }),
+        }
+    };
+
+    match decision.action {
+        PolicyAction::Allow => run_plugins(),
+        PolicyAction::Block => {
+            if clear_pending_on_block {
+                if let Ok(mut approvals) = context.policy_approvals.lock() {
+                    approvals.pending = None;
+                }
+            }
+            Err(NavigationPolicyFailure::Blocked { rule_id })
+        }
+        PolicyAction::RequireHumanApproval => {
+            let scope = decision.scope.unwrap_or(ApprovalScope::ActionOnly);
+            if consume_navigation_approval(context, &rule_id, scope, approval_signature) {
+                return run_plugins();
+            }
+            let request = PolicyApprovalRequest {
+                rule_id: rule_id.clone(),
+                scope,
+                action: "navigate".to_string(),
+                target_signature: approval_signature.to_string(),
+                outcome: decision.outcome.clone(),
+            };
+            context
+                .policy_approvals
+                .lock()
+                .map_err(|_| NavigationPolicyFailure::Rejected {
+                    message: "navigation approval state is unavailable".to_string(),
+                })?
+                .pending = Some(request);
+            context.audit_logger.log(AuditEvent::HitlEvent {
+                event_type: "request".to_string(),
+                reason: Some(format!("Requires human approval for rule {rule_id}")),
+                user_id: None,
+                timestamp: epoch_millis_u64(),
+            });
+            Err(NavigationPolicyFailure::HumanApprovalRequired {
+                rule_id,
+                scope,
+                outcome: decision.outcome,
+            })
+        }
+    }
+}
+
+fn consume_navigation_approval(
+    context: &NavigationPolicyContext,
+    rule_id: &str,
+    scope: ApprovalScope,
+    approval_signature: &str,
+) -> bool {
+    let now_ms = epoch_millis();
+    let navigation_epoch = context.navigation_epoch.load(Ordering::Relaxed);
+    let Ok(mut approvals) = context.policy_approvals.lock() else {
+        return false;
+    };
+    approvals.granted.retain(|grant| {
+        is_grant_valid(
+            grant,
+            navigation_epoch,
+            &context.approval_context_url,
+            now_ms,
+        )
+    });
+    let Some(index) = approvals.granted.iter().position(|grant| {
+        grant.request.rule_id == rule_id
+            && grant.request.scope == scope
+            && grant.request.action == "navigate"
+            && grant.request.target_signature == approval_signature
+    }) else {
+        return false;
+    };
+    if scope == ApprovalScope::ActionOnly {
+        approvals.granted.remove(index);
+    }
+    true
+}
+
 fn policy_target_signature(
     node: Option<&SemanticNode>,
     target_id: Option<i64>,
@@ -2332,6 +2900,138 @@ pub const STABLE_KEY_SHORT_LEN: usize = 16;
 mod tests {
     use super::*;
     use helpers::{node_is_enabled, normalized_poll_interval};
+
+    #[derive(Default)]
+    struct RecordingInterceptionControl {
+        operations: Mutex<Vec<&'static str>>,
+        fail_at: Option<&'static str>,
+    }
+
+    impl RecordingInterceptionControl {
+        fn failing_at(operation: &'static str) -> Self {
+            Self {
+                operations: Mutex::new(Vec::new()),
+                fail_at: Some(operation),
+            }
+        }
+
+        fn record(&self, operation: &'static str) -> Result<()> {
+            self.operations.lock().unwrap().push(operation);
+            if self.fail_at == Some(operation) {
+                anyhow::bail!("injected {operation} failure");
+            }
+            Ok(())
+        }
+
+        fn recorded(&self) -> Vec<&'static str> {
+            self.operations.lock().unwrap().clone()
+        }
+    }
+
+    impl NavigationInterceptionControl for RecordingInterceptionControl {
+        fn install_interceptor(
+            &self,
+            _interceptor: Arc<NavigationRequestInterceptor>,
+        ) -> Result<()> {
+            self.record("install_interceptor")
+        }
+
+        fn enable_fetch(
+            &self,
+            _patterns: &[headless_chrome::protocol::cdp::Fetch::RequestPattern],
+        ) -> Result<()> {
+            self.record("enable_fetch")
+        }
+
+        fn restore_default_interceptor(&self) -> Result<()> {
+            self.record("restore_default_interceptor")
+        }
+
+        fn disable_fetch(&self) -> Result<()> {
+            self.record("disable_fetch")
+        }
+    }
+
+    fn recording_interceptor() -> Arc<impl headless_chrome::browser::tab::RequestInterceptor> {
+        Arc::new(
+            |_: Arc<headless_chrome::browser::transport::Transport>,
+             _: headless_chrome::browser::transport::SessionId,
+             _: headless_chrome::protocol::cdp::Fetch::events::RequestPausedEvent| {
+                headless_chrome::browser::tab::RequestPausedDecision::Continue(None)
+            },
+        )
+    }
+
+    #[test]
+    fn navigation_interception_partial_enable_failure_restores_and_disables() {
+        let control = Arc::new(RecordingInterceptionControl::failing_at("enable_fetch"));
+        let result = NavigationInterceptionGuard::install_with_control(
+            control.clone(),
+            recording_interceptor(),
+            &[],
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            control.recorded(),
+            vec![
+                "install_interceptor",
+                "enable_fetch",
+                "restore_default_interceptor",
+                "disable_fetch"
+            ]
+        );
+    }
+
+    #[test]
+    fn navigation_interception_success_finishes_restore_before_disable_once() {
+        let control = Arc::new(RecordingInterceptionControl::default());
+        let mut guard = NavigationInterceptionGuard::install_with_control(
+            control.clone(),
+            recording_interceptor(),
+            &[],
+        )
+        .expect("install interception");
+
+        guard.finish().expect("finish interception");
+        guard.finish().expect("second finish is idempotent");
+        drop(guard);
+
+        assert_eq!(
+            control.recorded(),
+            vec![
+                "install_interceptor",
+                "enable_fetch",
+                "restore_default_interceptor",
+                "disable_fetch"
+            ]
+        );
+    }
+
+    #[test]
+    fn navigation_interception_finish_attempts_disable_after_cleanup_errors() {
+        for failure in ["restore_default_interceptor", "disable_fetch"] {
+            let control = Arc::new(RecordingInterceptionControl::failing_at(failure));
+            let mut guard = NavigationInterceptionGuard::install_with_control(
+                control.clone(),
+                recording_interceptor(),
+                &[],
+            )
+            .expect("install interception");
+
+            assert!(guard.finish().is_err(), "failure point: {failure}");
+            assert_eq!(
+                control.recorded(),
+                vec![
+                    "install_interceptor",
+                    "enable_fetch",
+                    "restore_default_interceptor",
+                    "disable_fetch"
+                ],
+                "failure point: {failure}"
+            );
+        }
+    }
 
     #[test]
     fn test_state_contains_intent_exact_match() {

--- a/core-runtime/src/browser/mod.rs
+++ b/core-runtime/src/browser/mod.rs
@@ -190,6 +190,7 @@ impl NavigationPolicyFailure {
 struct RedirectInterceptionState {
     main_frame_id: String,
     initial_url: String,
+    initial_request_seen: bool,
     original_url: String,
     network_policy: NavigationNetworkPolicy,
     request_chain: HashSet<String>,
@@ -558,6 +559,7 @@ impl PageSession {
         let interception_state = Arc::new(Mutex::new(RedirectInterceptionState {
             main_frame_id,
             initial_url: requested.canonical_url().to_string(),
+            initial_request_seen: false,
             original_url: requested.canonical_url().to_string(),
             network_policy,
             request_chain: HashSet::new(),
@@ -593,22 +595,25 @@ impl PageSession {
                 }
 
                 let request_id = event.params.request_id.clone();
-                let Some(parent_request_id) = event.params.redirected_request_id.as_ref() else {
+                if let Some(parent_request_id) = event.params.redirected_request_id.as_ref() {
+                    if !state.request_chain.contains(parent_request_id) {
+                        return RequestPausedDecision::Continue(None);
+                    }
+                } else {
                     let canonical = validate_public_navigation_url_with(
                         &event.params.request.url,
                         NavigationNetworkPolicy::AllowPrivate,
                         |_, _| Ok(Vec::new()),
                     );
-                    if canonical
-                        .as_ref()
-                        .is_ok_and(|candidate| candidate.canonical_url() == state.initial_url)
+                    if !state.initial_request_seen
+                        && canonical
+                            .as_ref()
+                            .is_ok_and(|candidate| candidate.canonical_url() == state.initial_url)
                     {
+                        state.initial_request_seen = true;
                         state.request_chain.insert(request_id);
+                        return RequestPausedDecision::Continue(None);
                     }
-                    return RequestPausedDecision::Continue(None);
-                };
-                if !state.request_chain.contains(parent_request_id) {
-                    return RequestPausedDecision::Continue(None);
                 }
 
                 let destination = match validate_public_navigation_url(

--- a/core-runtime/src/browser/navigation.rs
+++ b/core-runtime/src/browser/navigation.rs
@@ -1,0 +1,262 @@
+use sha2::{Digest, Sha256};
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs},
+};
+use url::{Host, Url};
+
+pub const MAX_PUBLIC_NAVIGATION_URL_BYTES: usize = 8192;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavigationNetworkPolicy {
+    PublicOnly,
+    AllowPrivate,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum NavigationValidationError {
+    #[error("navigation URL is empty")]
+    Empty,
+    #[error("navigation URL exceeds {max_bytes} UTF-8 bytes")]
+    TooLong { max_bytes: usize },
+    #[error("navigation URL must be an absolute HTTP(S) URL with a host")]
+    InvalidUrl,
+    #[error("navigation URL must not contain credentials")]
+    CredentialsNotAllowed,
+    #[error("navigation destination could not be resolved")]
+    ResolutionFailed,
+    #[error("navigation destination is not a public network address")]
+    NonPublicAddress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedNavigationUrl {
+    canonical_url: String,
+    sanitized_projection: String,
+    destination_digest: String,
+}
+
+impl ValidatedNavigationUrl {
+    pub fn canonical_url(&self) -> &str {
+        &self.canonical_url
+    }
+
+    pub fn sanitized_projection(&self) -> &str {
+        &self.sanitized_projection
+    }
+
+    pub fn destination_digest(&self) -> &str {
+        &self.destination_digest
+    }
+}
+
+pub fn validate_public_navigation_url(
+    input: &str,
+    policy: NavigationNetworkPolicy,
+) -> Result<ValidatedNavigationUrl, NavigationValidationError> {
+    validate_public_navigation_url_with(input, policy, |host, port| {
+        (host, port)
+            .to_socket_addrs()
+            .map(|addresses| addresses.map(|address| address.ip()).collect())
+    })
+}
+
+pub fn validate_public_navigation_url_with<F>(
+    input: &str,
+    policy: NavigationNetworkPolicy,
+    resolver: F,
+) -> Result<ValidatedNavigationUrl, NavigationValidationError>
+where
+    F: Fn(&str, u16) -> io::Result<Vec<IpAddr>>,
+{
+    if input.is_empty() {
+        return Err(NavigationValidationError::Empty);
+    }
+    if input.len() > MAX_PUBLIC_NAVIGATION_URL_BYTES {
+        return Err(NavigationValidationError::TooLong {
+            max_bytes: MAX_PUBLIC_NAVIGATION_URL_BYTES,
+        });
+    }
+
+    let mut url = Url::parse(input).map_err(|_| NavigationValidationError::InvalidUrl)?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return Err(NavigationValidationError::InvalidUrl);
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(NavigationValidationError::CredentialsNotAllowed);
+    }
+    url.set_fragment(None);
+    if let Some(Host::Domain(host)) = url.host() {
+        let canonical_host = host.trim_end_matches('.');
+        if canonical_host.is_empty() {
+            return Err(NavigationValidationError::InvalidUrl);
+        }
+        if canonical_host != host {
+            let canonical_host = canonical_host.to_string();
+            url.set_host(Some(&canonical_host))
+                .map_err(|_| NavigationValidationError::InvalidUrl)?;
+        }
+    }
+
+    if policy == NavigationNetworkPolicy::PublicOnly {
+        let addresses = match url.host().expect("host checked above") {
+            Host::Ipv4(address) => vec![IpAddr::V4(address)],
+            Host::Ipv6(address) => vec![IpAddr::V6(address)],
+            Host::Domain(host) => resolver(host, url.port_or_known_default().unwrap_or(80))
+                .map_err(|_| NavigationValidationError::ResolutionFailed)?,
+        };
+        if addresses.is_empty() {
+            return Err(NavigationValidationError::ResolutionFailed);
+        }
+        if addresses
+            .into_iter()
+            .any(|address| !is_global_address(address))
+        {
+            return Err(NavigationValidationError::NonPublicAddress);
+        }
+    }
+
+    let canonical_url = url.as_str().to_string();
+    let sanitized_projection = sanitized_projection(&url);
+    let destination_digest = hex::encode(Sha256::digest(canonical_url.as_bytes()));
+    Ok(ValidatedNavigationUrl {
+        canonical_url,
+        sanitized_projection,
+        destination_digest,
+    })
+}
+
+pub(crate) fn redirect_approval_digest(original: &str, destination: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"dragon-head:navigate-redirect:v1\0");
+    digest.update(original.len().to_be_bytes());
+    digest.update(original.as_bytes());
+    digest.update(destination.len().to_be_bytes());
+    digest.update(destination.as_bytes());
+    hex::encode(digest.finalize())
+}
+
+fn sanitized_projection(url: &Url) -> String {
+    let host = match url.host().expect("validated URL has a host") {
+        Host::Domain(host) => host.to_string(),
+        Host::Ipv4(host) => host.to_string(),
+        Host::Ipv6(host) => format!("[{host}]"),
+    };
+    let port = url
+        .port()
+        .map(|port| format!(":{port}"))
+        .unwrap_or_default();
+    format!("{}://{host}{port}{}", url.scheme(), url.path())
+}
+
+fn is_global_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => is_global_ipv4(address),
+        IpAddr::V6(address) => is_global_ipv6(address),
+    }
+}
+
+fn is_global_ipv4(address: Ipv4Addr) -> bool {
+    let value = u32::from(address);
+    let in_prefix = |network: u32, bits: u32| {
+        let mask = if bits == 0 {
+            0
+        } else {
+            u32::MAX << (32 - bits)
+        };
+        value & mask == network & mask
+    };
+
+    if in_prefix(0x0000_0000, 8)
+        || in_prefix(0x0a00_0000, 8)
+        || in_prefix(0x6440_0000, 10)
+        || in_prefix(0x7f00_0000, 8)
+        || in_prefix(0xa9fe_0000, 16)
+        || in_prefix(0xac10_0000, 12)
+        || in_prefix(0xc000_0200, 24)
+        || in_prefix(0xc058_6300, 24)
+        || in_prefix(0xc0a8_0000, 16)
+        || in_prefix(0xc612_0000, 15)
+        || in_prefix(0xc633_6400, 24)
+        || in_prefix(0xcb00_7100, 24)
+        || in_prefix(0xe000_0000, 4)
+        || in_prefix(0xf000_0000, 4)
+    {
+        return false;
+    }
+
+    // 192.0.0.0/24 is protocol assignment space; only its two anycast
+    // addresses are globally reachable.
+    if in_prefix(0xc000_0000, 24) {
+        return matches!(address.octets(), [192, 0, 0, 9] | [192, 0, 0, 10]);
+    }
+    true
+}
+
+fn is_global_ipv6(address: Ipv6Addr) -> bool {
+    if address.to_ipv4_mapped().is_some() {
+        return false;
+    }
+    let segments = address.segments();
+    let value = u128::from(address);
+    let in_prefix = |network: u128, bits: u32| {
+        let mask = if bits == 0 {
+            0
+        } else {
+            u128::MAX << (128 - bits)
+        };
+        value & mask == network & mask
+    };
+    if address.is_unspecified()
+        || address.is_loopback()
+        || matches!(segments, [0, 0, 0, 0, 0, 0, _, _])
+        || matches!(segments, [0, 0, 0, 0, 0xffff, 0, _, _])
+        || in_prefix(0x0064_ff9b_0001_0000_0000_0000_0000_0000, 48)
+        || in_prefix(0x0100_0000_0000_0000_0000_0000_0000_0000, 64)
+        || in_prefix(0x2002_0000_0000_0000_0000_0000_0000_0000, 16)
+        || in_prefix(0x2001_0db8_0000_0000_0000_0000_0000_0000, 32)
+        || in_prefix(0x3fff_0000_0000_0000_0000_0000_0000_0000, 20)
+        || in_prefix(0x5f00_0000_0000_0000_0000_0000_0000_0000, 16)
+        || in_prefix(0xfc00_0000_0000_0000_0000_0000_0000_0000, 7)
+        || in_prefix(0xfe80_0000_0000_0000_0000_0000_0000_0000, 10)
+        || in_prefix(0xfec0_0000_0000_0000_0000_0000_0000_0000, 10)
+        || in_prefix(0xff00_0000_0000_0000_0000_0000_0000_0000, 8)
+    {
+        return false;
+    }
+
+    // IETF protocol assignments (2001::/23) are non-global except for the
+    // explicitly globally reachable assignments in the IANA registry.
+    if in_prefix(0x2001_0000_0000_0000_0000_0000_0000_0000, 23) {
+        let globally_reachable_exception =
+            matches!(
+                value,
+                0x2001_0001_0000_0000_0000_0000_0000_0001
+                    | 0x2001_0001_0000_0000_0000_0000_0000_0002
+            ) || in_prefix(0x2001_0003_0000_0000_0000_0000_0000_0000, 32)
+                || in_prefix(0x2001_0004_0112_0000_0000_0000_0000_0000, 48)
+                || in_prefix(0x2001_0020_0000_0000_0000_0000_0000_0000, 28)
+                || in_prefix(0x2001_0030_0000_0000_0000_0000_0000_0000, 28);
+        return globally_reachable_exception;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redirect_approval_digest;
+
+    #[test]
+    fn redirect_digest_binds_both_destinations() {
+        let digest = redirect_approval_digest("https://a.test/", "https://b.test/?secret=1");
+        assert_ne!(
+            digest,
+            redirect_approval_digest("https://a.test/", "https://c.test/")
+        );
+        assert_ne!(
+            digest,
+            redirect_approval_digest("https://x.test/", "https://b.test/?secret=1")
+        );
+        assert!(!digest.contains("secret"));
+    }
+}

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -19,9 +19,10 @@ pub use sre::{
 };
 
 pub use browser::{
-    is_browser_disconnected, ActionLogEntry, BrowserClient, PageSession, SemanticTarget,
-    SemanticWaitOptions, SemanticWaitState, SomMark, SomTrigger, VisualCapture,
-    STABLE_KEY_SHORT_LEN,
+    is_browser_disconnected, validate_public_navigation_url, validate_public_navigation_url_with,
+    ActionLogEntry, BrowserClient, NavigationNetworkPolicy, NavigationValidationError, PageSession,
+    SemanticTarget, SemanticWaitOptions, SemanticWaitState, SomMark, SomTrigger,
+    ValidatedNavigationUrl, VisualCapture, MAX_PUBLIC_NAVIGATION_URL_BYTES, STABLE_KEY_SHORT_LEN,
 };
 pub mod error;
 pub use audit_sink::DurabilityMode;

--- a/core-runtime/tests/audit_logging.rs
+++ b/core-runtime/tests/audit_logging.rs
@@ -366,6 +366,7 @@ fn replay_report_includes_timestamps_state_hashes_and_decisions() -> anyhow::Res
             rule_id: "R-42".to_string(),
             action: "block".to_string(),
             decision: "deny".to_string(),
+            destination_fingerprint: None,
             timestamp: 2_000,
         },
         AuditEvent::StatePatch {

--- a/core-runtime/tests/audit_persistence.rs
+++ b/core-runtime/tests/audit_persistence.rs
@@ -30,6 +30,7 @@ fn policy_event(n: u32) -> AuditEvent {
         rule_id: format!("R{n}"),
         action: "click".into(),
         decision: "allow".into(),
+        destination_fingerprint: None,
         timestamp: n as u64,
     }
 }

--- a/core-runtime/tests/audit_schema.rs
+++ b/core-runtime/tests/audit_schema.rs
@@ -51,12 +51,39 @@ fn test_policy_decision_serialization() {
         rule_id: "rule-123".to_string(),
         action: "click".to_string(),
         decision: "block".to_string(),
+        destination_fingerprint: None,
         timestamp: 12345,
     };
 
     let serialized = serde_json::to_string(&event).unwrap();
     assert!(serialized.contains(r#""type":"POLICY_DECISION""#));
     assert!(serialized.contains(r#""decision":"block""#));
+}
+
+#[test]
+fn navigation_policy_evidence_is_non_reversible_and_legacy_json_remains_compatible() {
+    let fingerprint = format!("sha256:{}", "ab".repeat(32));
+    let event = AuditEvent::PolicyDecision {
+        rule_id: "navigation-rule".to_string(),
+        action: "navigate".to_string(),
+        decision: "allow".to_string(),
+        destination_fingerprint: Some(fingerprint.clone()),
+        timestamp: 12346,
+    };
+    let serialized = serde_json::to_string(&event).unwrap();
+    assert!(serialized.contains(&fingerprint));
+    assert!(!serialized.contains("query-secret"));
+    assert!(!serialized.contains("fragment-secret"));
+
+    let legacy = r#"{"type":"POLICY_DECISION","rule_id":"r","action":"click","decision":"allow","timestamp":1}"#;
+    let decoded: AuditEvent = serde_json::from_str(legacy).unwrap();
+    assert!(matches!(
+        decoded,
+        AuditEvent::PolicyDecision {
+            destination_fingerprint: None,
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/core-runtime/tests/public_navigation_policy.rs
+++ b/core-runtime/tests/public_navigation_policy.rs
@@ -22,6 +22,7 @@ enum Route {
     Html(&'static str),
     Redirect(&'static str),
     RedirectLocalhost(&'static str),
+    Refresh(&'static str),
 }
 
 struct TestHttpServer {
@@ -125,6 +126,10 @@ fn serve_request(
         Some(Route::RedirectLocalhost(path)) => write!(
             stream,
             "HTTP/1.1 302 Found\r\nLocation: http://localhost:{port}{path}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )?,
+        Some(Route::Refresh(location)) => write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nRefresh: 0; url={location}\r\nContent-Type: text/html\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         )?,
         None => write!(
             stream,
@@ -311,6 +316,40 @@ fn public_navigation_blocks_redirect_before_destination_request() -> anyhow::Res
     let error = page
         .navigate_public(&server.url("/start"), true)
         .expect_err("redirect policy must block destination");
+    assert!(matches!(
+        error.downcast_ref::<ActionError>(),
+        Some(ActionError::Blocked { .. })
+    ));
+    assert_eq!(server.request_count("/start"), 1);
+    assert_eq!(server.request_count("/blocked"), 0);
+    Ok(())
+}
+
+#[test]
+fn public_navigation_blocks_unchained_top_level_refresh_before_destination_request(
+) -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        ("/start", Route::Refresh("/blocked")),
+        (
+            "/blocked",
+            Route::Html("<html><body>must not load</body></html>"),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![navigation_rule(
+        "block-unchained-refresh",
+        Some("/blocked"),
+        PolicyAction::Block,
+    )])?;
+
+    let error = page
+        .navigate_public(&server.url("/start"), true)
+        .expect_err("unchained top-level refresh must be policy checked");
     assert!(matches!(
         error.downcast_ref::<ActionError>(),
         Some(ActionError::Blocked { .. })

--- a/core-runtime/tests/public_navigation_policy.rs
+++ b/core-runtime/tests/public_navigation_policy.rs
@@ -1,0 +1,499 @@
+use core_runtime::{
+    audit::AuditEvent,
+    plugin_hooks::{PluginHookConfig, PolicyPlugin},
+    policy::{ApprovalScope, PolicyAction, PolicyRule},
+    sre::{normalize_dom, LoadProfile, SemanticState},
+    ActionError, BrowserClient, PageSession,
+};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+#[derive(Clone, Copy)]
+enum Route {
+    Html(&'static str),
+    Redirect(&'static str),
+    RedirectLocalhost(&'static str),
+}
+
+struct TestHttpServer {
+    base_url: String,
+    counts: Arc<Mutex<HashMap<String, usize>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl TestHttpServer {
+    fn start(routes: HashMap<&'static str, Route>) -> anyhow::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let address = listener.local_addr()?;
+        let counts = Arc::new(Mutex::new(HashMap::new()));
+        let thread_counts = Arc::clone(&counts);
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        if thread_stop.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let _ = serve_request(&mut stream, &routes, &thread_counts, address.port());
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Ok(Self {
+            base_url: format!("http://{address}"),
+            counts,
+            stop,
+            thread: Some(handle),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    fn request_count(&self, path: &str) -> usize {
+        self.counts
+            .lock()
+            .expect("request counts lock")
+            .get(path)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+impl Drop for TestHttpServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(self.base_url.trim_start_matches("http://"));
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn serve_request(
+    stream: &mut TcpStream,
+    routes: &HashMap<&'static str, Route>,
+    counts: &Arc<Mutex<HashMap<String, usize>>>,
+    port: u16,
+) -> anyhow::Result<()> {
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let mut request = [0_u8; 4096];
+    let read = stream.read(&mut request)?;
+    let request = String::from_utf8_lossy(&request[..read]);
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|target| target.split('?').next())
+        .unwrap_or("/")
+        .to_string();
+    *counts
+        .lock()
+        .expect("request counts lock")
+        .entry(path.clone())
+        .or_default() += 1;
+
+    match routes.get(path.as_str()).copied() {
+        Some(Route::Html(body)) => write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )?,
+        Some(Route::Redirect(location)) => write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )?,
+        Some(Route::RedirectLocalhost(path)) => write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: http://localhost:{port}{path}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )?,
+        None => write!(
+            stream,
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )?,
+    }
+    stream.flush()?;
+    Ok(())
+}
+
+struct BlockRedirectPlugin;
+
+impl PolicyPlugin for BlockRedirectPlugin {
+    fn plugin_id(&self) -> &str {
+        "block-redirect-plugin"
+    }
+
+    fn before_act(&self, intent_json: &str) -> Result<String, String> {
+        let intent: serde_json::Value =
+            serde_json::from_str(intent_json).map_err(|error| error.to_string())?;
+        let blocked = intent["url"]
+            .as_str()
+            .is_some_and(|url| url.contains("/plugin-blocked"));
+        Ok(if blocked {
+            r#"{"allow":false,"reason":"blocked redirect"}"#.to_string()
+        } else {
+            r#"{"allow":true}"#.to_string()
+        })
+    }
+}
+
+fn navigation_rule(id: &str, path_prefix: Option<&str>, action: PolicyAction) -> PolicyRule {
+    PolicyRule {
+        id: id.to_string(),
+        domain: None,
+        path_prefix: path_prefix.map(str::to_string),
+        role: None,
+        text_regex: None,
+        context_regex: None,
+        action,
+        scope: (action == PolicyAction::RequireHumanApproval).then_some(ApprovalScope::ActionOnly),
+        outcome_projector: None,
+    }
+}
+
+#[test]
+fn public_navigation_initial_block_sends_zero_requests_and_audits_once() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([(
+        "/blocked",
+        Route::Html("<html><body>must not load</body></html>"),
+    )]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![navigation_rule(
+        "block-initial",
+        Some("/blocked"),
+        PolicyAction::Block,
+    )])?;
+    page.clear_audit_events();
+
+    let error = page
+        .navigate_public(&server.url("/blocked"), true)
+        .expect_err("initial block must reject navigation");
+    assert!(matches!(
+        error.downcast_ref::<ActionError>(),
+        Some(ActionError::Blocked { .. })
+    ));
+    assert_eq!(server.request_count("/blocked"), 0);
+
+    let decisions = wait_for_policy_decisions(&page, "block", 1);
+    assert_eq!(decisions, 1, "initial destination must be audited once");
+    Ok(())
+}
+
+#[test]
+fn public_navigation_hitl_grant_is_bound_to_identical_destination() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        (
+            "/approved",
+            Route::Html("<html><body>approved</body></html>"),
+        ),
+        (
+            "/different",
+            Route::Html("<html><body>different</body></html>"),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![navigation_rule(
+        "approve-navigation",
+        None,
+        PolicyAction::RequireHumanApproval,
+    )])?;
+
+    let approved_url = server.url("/approved");
+    let first = page
+        .navigate_public(&approved_url, true)
+        .expect_err("first navigation must require approval");
+    assert!(matches!(
+        first.downcast_ref::<ActionError>(),
+        Some(ActionError::HumanApprovalRequired { .. })
+    ));
+    assert_eq!(server.request_count("/approved"), 0);
+    page.approve_pending_policy_action()?;
+
+    let different = page
+        .navigate_public(&server.url("/different"), true)
+        .expect_err("a different destination must not consume the grant");
+    assert!(matches!(
+        different.downcast_ref::<ActionError>(),
+        Some(ActionError::HumanApprovalRequired { .. })
+    ));
+    assert_eq!(server.request_count("/different"), 0);
+
+    let final_url = page.navigate_public(&approved_url, true)?;
+    assert_eq!(final_url, approved_url);
+    assert_eq!(server.request_count("/approved"), 1);
+    Ok(())
+}
+
+#[test]
+fn public_navigation_allows_redirect_and_subsequent_action_after_cleanup() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        ("/start", Route::Redirect("/final")),
+        (
+            "/final",
+            Route::Html(
+                "<html><body><button onclick=\"document.body.dataset.clicked='yes'\">Ready</button></body></html>",
+            ),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(Vec::new())?;
+
+    let final_url = page.navigate_public(&server.url("/start"), true)?;
+    assert_eq!(final_url, server.url("/final"));
+    assert_eq!(server.request_count("/start"), 1);
+    assert_eq!(server.request_count("/final"), 1);
+
+    let (target_id, stable_key) = find_button_info(&page)?;
+    page.act(Some(target_id), Some(&stable_key), "click", None)?;
+    let clicked = page
+        .evaluate_script("document.body.dataset.clicked")?
+        .value
+        .and_then(|value| value.as_str().map(str::to_string));
+    assert_eq!(clicked.as_deref(), Some("yes"));
+    Ok(())
+}
+
+#[test]
+fn public_navigation_blocks_redirect_before_destination_request() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        ("/start", Route::Redirect("/blocked")),
+        (
+            "/blocked",
+            Route::Html("<html><body>must not load</body></html>"),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![navigation_rule(
+        "block-redirect",
+        Some("/blocked"),
+        PolicyAction::Block,
+    )])?;
+
+    let error = page
+        .navigate_public(&server.url("/start"), true)
+        .expect_err("redirect policy must block destination");
+    assert!(matches!(
+        error.downcast_ref::<ActionError>(),
+        Some(ActionError::Blocked { .. })
+    ));
+    assert_eq!(server.request_count("/start"), 1);
+    assert_eq!(server.request_count("/blocked"), 0);
+    Ok(())
+}
+
+#[test]
+fn public_navigation_redirect_hitl_grant_is_bound_to_original_and_destination() -> anyhow::Result<()>
+{
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        ("/start", Route::RedirectLocalhost("/approved")),
+        (
+            "/approved",
+            Route::Html("<html><body>approved redirect</body></html>"),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![PolicyRule {
+        id: "approve-localhost-redirect".to_string(),
+        domain: Some("localhost".to_string()),
+        path_prefix: Some("/approved".to_string()),
+        role: None,
+        text_regex: None,
+        context_regex: None,
+        action: PolicyAction::RequireHumanApproval,
+        scope: Some(ApprovalScope::ActionOnly),
+        outcome_projector: None,
+    }])?;
+
+    let original_url = server.url("/start");
+    let approved_url = original_url
+        .replace("127.0.0.1", "localhost")
+        .replace("/start", "/approved");
+    let first = page
+        .navigate_public(&original_url, true)
+        .expect_err("redirect must require approval before destination I/O");
+    assert!(matches!(
+        first.downcast_ref::<ActionError>(),
+        Some(ActionError::HumanApprovalRequired { .. })
+    ));
+    assert_eq!(server.request_count("/start"), 1);
+    assert_eq!(server.request_count("/approved"), 0);
+    page.approve_pending_policy_action()?;
+
+    let direct = page
+        .navigate_public(&approved_url, true)
+        .expect_err("redirect grant must not approve a direct destination call");
+    assert!(matches!(
+        direct.downcast_ref::<ActionError>(),
+        Some(ActionError::HumanApprovalRequired { .. })
+    ));
+    assert_eq!(server.request_count("/approved"), 0);
+
+    let final_url = page.navigate_public(&original_url, true)?;
+    assert_eq!(final_url, approved_url);
+    assert_eq!(server.request_count("/start"), 2);
+    assert_eq!(server.request_count("/approved"), 1);
+    Ok(())
+}
+
+#[test]
+fn public_navigation_plugin_veto_blocks_redirect_before_destination_request() -> anyhow::Result<()>
+{
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        ("/start", Route::Redirect("/plugin-blocked")),
+        (
+            "/plugin-blocked",
+            Route::Html("<html><body>must not load</body></html>"),
+        ),
+    ]))?;
+    let mut plugins = PluginHookConfig::default();
+    plugins.policy_plugins.push(Box::new(BlockRedirectPlugin));
+    let client = BrowserClient::new_with_plugin_hooks(plugins)?;
+    let page = client.new_page()?;
+
+    let error = page
+        .navigate_public(&server.url("/start"), true)
+        .expect_err("plugin must veto the redirect destination");
+    assert!(matches!(
+        error.downcast_ref::<ActionError>(),
+        Some(ActionError::Blocked { rule_id }) if rule_id == "plugin:block-redirect-plugin"
+    ));
+    assert_eq!(server.request_count("/start"), 1);
+    assert_eq!(server.request_count("/plugin-blocked"), 0);
+    Ok(())
+}
+
+#[test]
+fn public_navigation_does_not_apply_top_level_redirect_policy_to_iframes() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let server = TestHttpServer::start(HashMap::from([
+        (
+            "/start",
+            Route::Html("<html><body><iframe src='/iframe'></iframe></body></html>"),
+        ),
+        ("/iframe", Route::Redirect("/iframe-final")),
+        (
+            "/iframe-final",
+            Route::Html("<html><body>iframe loaded</body></html>"),
+        ),
+    ]))?;
+    let client = BrowserClient::new()?;
+    let page = client.new_page()?;
+    page.set_policy_rules(vec![navigation_rule(
+        "block-only-if-top-level",
+        Some("/iframe-final"),
+        PolicyAction::Block,
+    )])?;
+
+    let final_url = page.navigate_public(&server.url("/start"), true)?;
+    assert_eq!(final_url, server.url("/start"));
+    assert!(wait_for_request_count(&server, "/iframe-final", 1));
+    assert_eq!(server.request_count("/iframe"), 1);
+    assert_eq!(server.request_count("/iframe-final"), 1);
+    Ok(())
+}
+
+fn find_button_info(page: &PageSession) -> anyhow::Result<(i64, String)> {
+    let root = page.get_document_node()?;
+    let semantic = normalize_dom(LoadProfile::Interactive, &root)?;
+    let state = SemanticState::new(semantic, LoadProfile::Interactive);
+    find_button_info_in_node(state.root()).ok_or_else(|| anyhow::anyhow!("button not found"))
+}
+
+fn find_button_info_in_node(
+    node: &core_runtime::sre::state::SemanticNode,
+) -> Option<(i64, String)> {
+    if node.role == "button" {
+        return Some((
+            node.backend_node_id,
+            node.stable_key.clone().unwrap_or_default(),
+        ));
+    }
+    node.children.iter().find_map(find_button_info_in_node)
+}
+
+fn wait_for_policy_decisions(page: &PageSession, expected: &str, count: usize) -> usize {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(2) {
+        let found = page
+            .audit_events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    AuditEvent::PolicyDecision {
+                        action,
+                        decision,
+                        ..
+                    } if action == "navigate" && decision == expected
+                )
+            })
+            .count();
+        if found >= count {
+            return found;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    0
+}
+
+fn wait_for_request_count(server: &TestHttpServer, path: &str, count: usize) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(2) {
+        if server.request_count(path) >= count {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    false
+}

--- a/core-runtime/tests/public_navigation_validation.rs
+++ b/core-runtime/tests/public_navigation_validation.rs
@@ -1,0 +1,244 @@
+use core_runtime::{
+    validate_public_navigation_url_with, NavigationNetworkPolicy, NavigationValidationError,
+};
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+fn resolve(addresses: Vec<IpAddr>) -> impl Fn(&str, u16) -> io::Result<Vec<IpAddr>> {
+    move |_, _| Ok(addresses.clone())
+}
+
+#[test]
+fn canonicalizes_destination_and_builds_secret_free_projection() {
+    let validated = validate_public_navigation_url_with(
+        "HTTPS://Example.COM:443/path?q=secret#fragment",
+        NavigationNetworkPolicy::PublicOnly,
+        resolve(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        validated.canonical_url(),
+        "https://example.com/path?q=secret"
+    );
+    assert_eq!(validated.sanitized_projection(), "https://example.com/path");
+    assert_eq!(validated.destination_digest().len(), 64);
+    assert!(!validated.destination_digest().contains("secret"));
+}
+
+#[test]
+fn removes_a_trailing_dns_dot_before_resolution_policy_identity_and_audit_projection() {
+    let validated = validate_public_navigation_url_with(
+        "https://Example.COM./path?q=secret#fragment",
+        NavigationNetworkPolicy::PublicOnly,
+        |host, _| {
+            assert_eq!(host, "example.com");
+            Ok(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))])
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        validated.canonical_url(),
+        "https://example.com/path?q=secret"
+    );
+    assert_eq!(validated.sanitized_projection(), "https://example.com/path");
+}
+
+#[test]
+fn rejects_credentials_forbidden_schemes_relative_and_oversized_utf8() {
+    let public = resolve(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]);
+    for input in [
+        "https://user:password@example.com/",
+        "file:///etc/passwd",
+        "data:text/plain,hello",
+        "javascript:alert(1)",
+        "about:blank",
+        "/relative",
+        "not a url",
+        "",
+    ] {
+        assert!(
+            validate_public_navigation_url_with(
+                input,
+                NavigationNetworkPolicy::PublicOnly,
+                &public,
+            )
+            .is_err(),
+            "accepted {input:?}"
+        );
+    }
+
+    let oversized = format!("https://example.com/{}", "界".repeat(3000));
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            &oversized,
+            NavigationNetworkPolicy::PublicOnly,
+            &public,
+        ),
+        Err(NavigationValidationError::TooLong { .. })
+    ));
+}
+
+#[test]
+fn rejects_any_non_global_dns_answer_and_ipv4_mapped_ipv6() {
+    let mixed = vec![
+        IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+    ];
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            "https://example.com/",
+            NavigationNetworkPolicy::PublicOnly,
+            resolve(mixed),
+        ),
+        Err(NavigationValidationError::NonPublicAddress)
+    ));
+
+    let mapped = IpAddr::V6(Ipv6Addr::from(0xffff_7f00_0001u128));
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            "https://example.com/",
+            NavigationNetworkPolicy::PublicOnly,
+            resolve(vec![mapped]),
+        ),
+        Err(NavigationValidationError::NonPublicAddress)
+    ));
+
+    let mapped_public = IpAddr::V6(Ipv6Addr::from(0xffff_5db8_d822u128));
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            "https://example.com/",
+            NavigationNetworkPolicy::PublicOnly,
+            resolve(vec![mapped_public]),
+        ),
+        Err(NavigationValidationError::NonPublicAddress)
+    ));
+
+    let benchmark = "2001:2::1".parse().unwrap();
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            "https://example.com/",
+            NavigationNetworkPolicy::PublicOnly,
+            resolve(vec![benchmark]),
+        ),
+        Err(NavigationValidationError::NonPublicAddress)
+    ));
+}
+
+#[test]
+fn enforces_exact_8192_and_8193_utf8_byte_boundaries() {
+    fn url_with_len(target: usize) -> String {
+        let base = "https://example.com/";
+        let remaining = target - base.len();
+        format!(
+            "{base}{}{}",
+            "é".repeat(remaining / 2),
+            "a".repeat(remaining % 2)
+        )
+    }
+    let public = resolve(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]);
+    let at_limit = url_with_len(8192);
+    let over_limit = url_with_len(8193);
+    assert_eq!(at_limit.len(), 8192);
+    assert_eq!(over_limit.len(), 8193);
+    assert!(validate_public_navigation_url_with(
+        &at_limit,
+        NavigationNetworkPolicy::PublicOnly,
+        &public,
+    )
+    .is_ok());
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            &over_limit,
+            NavigationNetworkPolicy::PublicOnly,
+            &public,
+        ),
+        Err(NavigationValidationError::TooLong { .. })
+    ));
+}
+
+#[test]
+fn private_network_opt_in_skips_dns_publicness_gate() {
+    let validated = validate_public_navigation_url_with(
+        "http://127.0.0.1:8080/start",
+        NavigationNetworkPolicy::AllowPrivate,
+        |_, _| panic!("resolver should not be called for an IP literal with private opt-in"),
+    )
+    .unwrap();
+    assert_eq!(validated.canonical_url(), "http://127.0.0.1:8080/start");
+}
+
+#[test]
+fn rejects_resolution_failure_and_empty_answers_without_disclosure() {
+    let failed = validate_public_navigation_url_with(
+        "https://secret.example/path?q=token",
+        NavigationNetworkPolicy::PublicOnly,
+        |_, _| Err(io::Error::new(io::ErrorKind::NotFound, "resolver detail")),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        failed,
+        NavigationValidationError::ResolutionFailed
+    ));
+    assert!(!failed.to_string().contains("secret.example"));
+    assert!(!failed.to_string().contains("token"));
+
+    assert!(matches!(
+        validate_public_navigation_url_with(
+            "https://example.com/",
+            NavigationNetworkPolicy::PublicOnly,
+            resolve(vec![]),
+        ),
+        Err(NavigationValidationError::ResolutionFailed)
+    ));
+}
+
+#[test]
+fn rejects_representative_iana_special_purpose_ranges() {
+    let non_global = [
+        "0.1.2.3",
+        "10.0.0.1",
+        "100.64.0.1",
+        "127.0.0.1",
+        "169.254.1.1",
+        "172.16.0.1",
+        "192.0.0.8",
+        "192.0.2.1",
+        "192.88.99.1",
+        "192.168.0.1",
+        "198.18.0.1",
+        "198.51.100.1",
+        "203.0.113.1",
+        "224.0.0.1",
+        "240.0.0.1",
+        "::192.0.2.1",
+        "::ffff:0:192.0.2.1",
+        "64:ff9b:1::1",
+        "100::1",
+        "2001:2::1",
+        "2001:db8::1",
+        "2002::1",
+        "3fff::1",
+        "5f00::1",
+        "fc00::1",
+        "fe80::1",
+        "fec0::1",
+        "ff00::1",
+    ];
+    for address in non_global {
+        let address: IpAddr = address.parse().unwrap();
+        assert!(
+            matches!(
+                validate_public_navigation_url_with(
+                    "https://example.com/",
+                    NavigationNetworkPolicy::PublicOnly,
+                    resolve(vec![address]),
+                ),
+                Err(NavigationValidationError::NonPublicAddress)
+            ),
+            "accepted special-purpose address {address}"
+        );
+    }
+}

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -1,6 +1,6 @@
 # AI_CONTEXT.md
 
-**Last updated:** 2026-07-06
+**Last updated:** 2026-07-19
 
 Read this first. It is a map for deciding which files to open next; it is not a
 full manual.
@@ -14,11 +14,12 @@ the MCP tools to inspect pages, act on stable targets, verify outcomes, request
 human approval, run declarative skills, extract structured data, and inspect
 usage meters.
 
-The current MCP tool contract has 8 tools, defined in `McpServer::tools()` in
+The current MCP tool contract has 9 tools, defined in `McpServer::tools()` in
 `mcp-server/src/lib.rs`:
 
 <!-- mcp-tool-list:start -->
 - `get_state`
+- `navigate`
 - `act`
 - `verify`
 - `get_visual`
@@ -27,6 +28,13 @@ The current MCP tool contract has 8 tools, defined in `McpServer::tools()` in
 - `get_usage_report`
 - `extract`
 <!-- mcp-tool-list:end -->
+
+`navigate` bootstraps a fresh empty MCP tab with an absolute HTTP(S) URL. It
+rejects credentials and non-global destinations by default, evaluates policy and
+plugin hooks for the requested URL and top-level redirects, and returns the live
+final URL. Trusted local deployments may opt in to private-network destinations
+with `[navigation] allow_private_network = true`; external egress controls remain
+required for untrusted deployments.
 
 The required `mcp_client_contract` CI suite snapshots the full tool definitions
 and checks these canonical documentation lists for exact name-set equality.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ flowchart TD
 
 | Component | Responsibility |
 |---|---|
-| `mcp-server` | stdio JSON-RPC server; tool contract (8 tools: `get_state`, `act`, `verify`, `get_visual`, `ask_human`, `run_skill`, `get_usage_report`, `extract`); config loading; `--doctor`/`--init`; usage metering and plan-tier gating |
+| `mcp-server` | stdio JSON-RPC server; tool contract (9 tools: `get_state`, `navigate`, `act`, `verify`, `get_visual`, `ask_human`, `run_skill`, `get_usage_report`, `extract`); config loading; `--doctor`/`--init`; usage metering and plan-tier gating |
 | `core-runtime::browser` | Owns the Chrome process and per-tab `PageSession`; executes actions; crash/disconnect detection and relaunch |
 | `core-runtime::sre` | DOM → `SemanticState`/`SemanticNode` capture and normalization; `stable_key` identity; delta computation |
 | `core-runtime::policy` | `PolicyEngine` — rule-based action gating (Allow/Block/RequireHumanApproval) and Guardian Angel outcome projection |
@@ -56,6 +56,7 @@ The canonical MCP tool names are:
 
 <!-- mcp-tool-list:start -->
 - `get_state`
+- `navigate`
 - `act`
 - `verify`
 - `get_visual`
@@ -87,8 +88,29 @@ is no cyclic dependency between workspace crates.
 5. For delta requests: `current.select_update(previous, DeltaPolicy)` produces
    `StateUpdate::{Noop, Full, Delta}` (an RFC 6902 JSON Patch for `Delta`).
 
-`PolicyEngine` is **not** consulted on `get_state` — only `act` goes through
-policy.
+`PolicyEngine` is **not** consulted on `get_state`; mutating `act` and `navigate`
+operations go through policy.
+
+## Data flow: `navigate`
+
+1. Parse and canonicalize the destination before side effects. Accept only
+   absolute HTTP(S) URLs without credentials; strip fragments and reject
+   non-global addresses unless the trusted-deployment opt-in is enabled.
+2. Evaluate built-in and plugin policy against the requested destination before
+   browser I/O. Blocked and approval-required requests send no destination request.
+3. Temporarily intercept top-level document redirects. Each new redirect
+   destination repeats URL, network, policy, and plugin validation before Chrome
+   may continue it; iframe and subresource traffic is not re-evaluated here.
+4. Restore the default request interceptor and disable Fetch on every exit path.
+   After I/O begins, invalidate page-local, full/delta, and speculative state;
+   the next delta capture establishes a full verified baseline.
+5. Return the fragment-free requested URL and the live final URL. Audit records
+   contain a sanitized scheme/host/port/path projection or fingerprint, never
+   credentials, query values, or fragments.
+
+Private-network checks reduce accidental server-side request forgery exposure,
+but cannot eliminate DNS-rebinding races. Untrusted deployments must also enforce
+OS/container-level egress policy.
 
 ## Data flow: `act`
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -608,6 +608,13 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > `core-runtime -> plugin-host` 依存を明記した。tool定義snapshotとdocs name-setの
 > 完全一致テストにより、tool追加・削除・改名時のdriftを必須CIで検出する。
 
+> **Follow-up (ISSUE-244, done)**: fresh MCP sessionをbootstrapするpolicy-aware `navigate`
+> toolを追加し、absolute HTTP(S) URL validation、default-deny private-network境界、requested URLと
+> top-level redirect hopのPolicy/HITL/plugin評価、audit URL sanitization、navigation後の
+> full/delta/speculative state resetを実装した。runtime、snapshot、README、AI context、
+> Architecture、SPECの9-tool contractを一致させ、fresh-process stdio E2Eとnegative contract
+> testsで固定した。
+
 > **Follow-up (ISSUE-211, done)**: `prompt_injection.additional_phrases` にJSON配列形式の
 > env overrideを追加し、件数・個別長・総量を制限した。runtimeが認識するconfig env名を
 > READMEと`--doctor`へ同期し、完全一致contract testと値非開示binary testでdriftを防ぐ。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -212,6 +212,7 @@ Model Context Protocol (MCP) 準拠のツール定義。
 | Tool Name | Arguments | Description |
 | :--- | :--- | :--- |
 | `get_state` | `format`: "json"\|"markdown", `force_refresh`: bool | ページ状態と、検出した既知リスクを要素単位の `security_flags` で返す。 |
+| `navigate` | `url`: absolute HTTP(S) string | Policy/HITL とredirect検証を経てページを読み込み、requested URLとlive final URLを返す。 |
 | `act` | `target_id`: int, `target_stable_key`: string, `action`: "click"\|"type", `value`: string | アクション実行。 |
 | `verify` | `target_id`: int, `expected`: {text: string} | ハルシネーション防止の事前検証。 |
 | `get_visual` | `mode`: "clean"\|"som", `viewport`: "full" | 視覚情報の取得。 |
@@ -228,6 +229,31 @@ Model Context Protocol (MCP) 準拠のツール定義。
 plan tier、audit-retention snapshotを読み取る。自身の呼び出しはmeterへ加算せず
 (does not meter itself)、action audit eventも生成しない
 (does not emit an action audit event)。
+
+`navigate` は1〜8192 UTF-8 bytesのabsolute `http:` / `https:` URLのみ受理し、
+hostを必須とする。relative URL、malformed URL、username/passwordを含むURL、
+その他schemeはbrowser I/O・policy副作用・meteringより前に拒否する。fragmentは
+policy/approval identityと実リクエストから除去し、path/queryはリクエスト用URLに保持する。
+
+既定ではloopback、private、link-local、multicast、unspecifiedなどnon-globalな
+IPv4/IPv6 address、およびそのいずれかへ解決されるhostnameを拒否する。信頼済みlocal
+deployment/testのみ `[navigation] allow_private_network = true` または厳格boolean環境変数
+`NAVIGATION_ALLOW_PRIVATE_NETWORK=true` で許可できる。この設定はDNS rebindingを閉じる
+network sandboxではなく、untrusted deploymentにはOS/container egress制御も必須である。
+
+requested destinationはnetwork access前にaction `navigate` としてbuilt-in Policy Engineと
+plugin policy hookを各1回評価する。top-level main-frame redirectは各hopの送信前に同じURL・
+network・policy/plugin検証を繰り返すが、initial requestを二重評価せず、iframe/subresourceは
+継続する。block/HITL/plugin vetoは対象destinationへのrequestをzeroに保つ。承認はcanonical
+full destinationのdigestへ束縛し、redirect承認はoriginal requested URLとredirect destination
+の組へ束縛する。
+
+成功responseは `status="ok"`, fragment-free `requested_url`, live `final_url` を返す。
+成功のみ `actions_executed` を1増加し、redirect数は加算しない。HITL requestと後続の
+`ask_human` approvalは既存`act`同様に各1 eventを加算する。navigation I/O開始後は成功・失敗
+ともpage/MCP delta/speculative stateを保守的に無効化し、次のdeltaはfull baselineを返す。
+TOOL_CALL/POLICY_DECISION audit evidenceはscheme/host/explicit port/pathまたは非可逆fingerprint
+のみを含み、username/password/query/fragmentをrecent/persistent/webhook/stderr/errorへ出さない。
 <!-- mcp-tool-semantics:end -->
 
 **ACT-05: HITL Concurrency & Safety**

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -16,6 +16,7 @@ pub const ENV_CHROME_PATH: &str = "CHROME_PATH";
 pub const ENV_PROMPT_INJECTION_MODE: &str = "PROMPT_INJECTION_MODE";
 pub const ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES: &str = "PROMPT_INJECTION_ADDITIONAL_PHRASES";
 pub const ENV_POLICY_FILE: &str = "POLICY_FILE";
+pub const ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK: &str = "NAVIGATION_ALLOW_PRIVATE_NETWORK";
 pub const ENV_AUDIT_LOG_DIR: &str = "AUDIT_LOG_DIR";
 pub const ENV_AUDIT_LOG_MAX_BYTES: &str = "AUDIT_LOG_MAX_BYTES";
 pub const ENV_AUDIT_DURABILITY: &str = "AUDIT_DURABILITY";
@@ -27,6 +28,7 @@ pub const HONORED_CONFIG_ENV_VARS: &[&str] = &[
     ENV_PROMPT_INJECTION_MODE,
     ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
     ENV_POLICY_FILE,
+    ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK,
     ENV_AUDIT_LOG_DIR,
     ENV_AUDIT_LOG_MAX_BYTES,
     ENV_AUDIT_DURABILITY,
@@ -46,6 +48,8 @@ pub struct FileConfig {
     #[serde(default)]
     pub policy: PolicyFileConfig,
     #[serde(default)]
+    pub navigation: NavigationFileConfig,
+    #[serde(default)]
     pub audit: AuditFileConfig,
 }
 
@@ -62,6 +66,13 @@ pub struct PromptInjectionFileConfig {
 pub struct PolicyFileConfig {
     /// Path to a JSON file of `PolicyRule`s, loaded via `PolicyEngine::try_from_file`.
     pub file: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct NavigationFileConfig {
+    /// Allows HTTP(S) navigation to non-global destinations for trusted local deployments.
+    #[serde(default)]
+    pub allow_private_network: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -95,6 +106,8 @@ pub enum ConfigError {
         "invalid {ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES} (expected a JSON array of strings)"
     )]
     InvalidAdditionalPhrasesFormat,
+    #[error("invalid {ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK} (expected exactly 'true' or 'false')")]
+    InvalidNavigationAllowPrivateNetwork,
     #[error("too many prompt-injection additional phrases (maximum {max})")]
     TooManyAdditionalPhrases { max: usize },
     #[error("prompt-injection additional phrase exceeds {max_bytes} UTF-8 bytes")]
@@ -110,6 +123,18 @@ pub fn validate_unicode_additional_phrases_env() -> Result<(), ConfigError> {
         Ok(_) | Err(std::env::VarError::NotPresent) => Ok(()),
         Err(std::env::VarError::NotUnicode(_)) => Err(ConfigError::NonUnicodeEnvVar {
             name: ENV_PROMPT_INJECTION_ADDITIONAL_PHRASES,
+        }),
+    }
+}
+
+/// Rejects non-Unicode values for configuration variables whose absence would
+/// otherwise silently select a less explicit value.
+pub fn validate_unicode_config_env() -> Result<(), ConfigError> {
+    validate_unicode_additional_phrases_env()?;
+    match std::env::var(ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK) {
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(()),
+        Err(std::env::VarError::NotUnicode(_)) => Err(ConfigError::NonUnicodeEnvVar {
+            name: ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK,
         }),
     }
 }
@@ -166,6 +191,7 @@ pub struct ResolvedConfig {
     pub audit_log_dir: Option<String>,
     pub audit_max_bytes: Option<u64>,
     pub audit_durability: Option<String>,
+    pub navigation_allow_private_network: bool,
 }
 
 /// Merges `file_config` (`None` means "no config file present, use defaults") with
@@ -175,6 +201,7 @@ pub struct ResolvedConfig {
 /// `prompt_injection.mode` (default `report_only`);
 /// `PROMPT_INJECTION_ADDITIONAL_PHRASES` > `prompt_injection.additional_phrases`;
 /// `POLICY_FILE` > `policy.file`;
+/// `NAVIGATION_ALLOW_PRIVATE_NETWORK` > `navigation.allow_private_network` (default `false`);
 /// `AUDIT_LOG_DIR`/`AUDIT_LOG_MAX_BYTES`/`AUDIT_DURABILITY` > `audit.*`.
 pub fn resolve_config(
     file_config: Option<&FileConfig>,
@@ -201,6 +228,11 @@ pub fn resolve_config(
     let policy_file = lookup(ENV_POLICY_FILE)
         .or_else(|| fc.policy.file.clone())
         .map(PathBuf::from);
+
+    let navigation_allow_private_network = match lookup(ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK) {
+        Some(raw) => parse_strict_bool(&raw)?,
+        None => fc.navigation.allow_private_network,
+    };
 
     let audit_log_dir = lookup(ENV_AUDIT_LOG_DIR).or_else(|| fc.audit.log_dir.clone());
 
@@ -233,7 +265,16 @@ pub fn resolve_config(
         audit_log_dir,
         audit_max_bytes,
         audit_durability,
+        navigation_allow_private_network,
     })
+}
+
+fn parse_strict_bool(value: &str) -> Result<bool, ConfigError> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(ConfigError::InvalidNavigationAllowPrivateNetwork),
+    }
 }
 
 fn normalize_additional_phrases(phrases: Vec<String>) -> Result<Vec<String>, ConfigError> {
@@ -372,6 +413,7 @@ durability = "sync"
                 policy: PolicyFileConfig {
                     file: Some("/etc/dragon-head/policy.json".to_string()),
                 },
+                navigation: NavigationFileConfig::default(),
                 audit: AuditFileConfig {
                     log_dir: Some("/var/log/dragon-head".to_string()),
                     max_bytes: Some(1_048_576),
@@ -392,6 +434,7 @@ durability = "sync"
             PromptInjectionFileConfig::default()
         );
         assert_eq!(config.policy, PolicyFileConfig::default());
+        assert_eq!(config.navigation, NavigationFileConfig::default());
         assert_eq!(config.audit, AuditFileConfig::default());
     }
 
@@ -424,6 +467,15 @@ durability = "sync"
         assert!(matches!(err, ConfigError::Parse { .. }), "got: {err:?}");
     }
 
+    #[test]
+    fn load_config_file_parses_navigation_private_network_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(&dir, "[navigation]\nallow_private_network = true");
+        let config = load_config_file(&path).unwrap().unwrap();
+
+        assert!(config.navigation.allow_private_network);
+    }
+
     // --- resolve_config ---
 
     #[test]
@@ -439,8 +491,55 @@ durability = "sync"
                 audit_log_dir: None,
                 audit_max_bytes: None,
                 audit_durability: None,
+                navigation_allow_private_network: false,
             }
         );
+    }
+
+    #[test]
+    fn resolve_config_uses_navigation_file_value() {
+        let fc = FileConfig {
+            navigation: NavigationFileConfig {
+                allow_private_network: true,
+            },
+            ..Default::default()
+        };
+
+        let resolved = resolve_config(Some(&fc), no_env).unwrap();
+
+        assert!(resolved.navigation_allow_private_network);
+    }
+
+    #[test]
+    fn resolve_config_navigation_env_overrides_file_value() {
+        let fc = FileConfig {
+            navigation: NavigationFileConfig {
+                allow_private_network: true,
+            },
+            ..Default::default()
+        };
+
+        let resolved = resolve_config(Some(&fc), |key| {
+            (key == ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK).then(|| "false".to_string())
+        })
+        .unwrap();
+
+        assert!(!resolved.navigation_allow_private_network);
+    }
+
+    #[test]
+    fn resolve_config_rejects_invalid_navigation_boolean_without_echoing_value() {
+        let secret = "true-secret-navigation-value";
+        let err = resolve_config(None, |key| {
+            (key == ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK).then(|| secret.to_string())
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ConfigError::InvalidNavigationAllowPrivateNetwork
+        ));
+        assert!(!err.to_string().contains(secret));
     }
 
     #[test]
@@ -454,6 +553,7 @@ durability = "sync"
             policy: PolicyFileConfig {
                 file: Some("/etc/policy.json".to_string()),
             },
+            navigation: NavigationFileConfig::default(),
             audit: AuditFileConfig {
                 log_dir: Some("/var/log/dh".to_string()),
                 max_bytes: Some(2048),
@@ -487,6 +587,7 @@ durability = "sync"
             policy: PolicyFileConfig {
                 file: Some("/etc/policy.json".to_string()),
             },
+            navigation: NavigationFileConfig::default(),
             audit: AuditFileConfig {
                 log_dir: Some("/var/log/dh".to_string()),
                 max_bytes: Some(2048),

--- a/mcp-server/src/doctor.rs
+++ b/mcp-server/src/doctor.rs
@@ -134,7 +134,8 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
 
     let summary = format!(
         "chrome_path={}, prompt_injection.mode={:?}, \
-         prompt_injection.additional_phrases={}, policy.file={}, supported_env=[{}]",
+         prompt_injection.additional_phrases={}, policy.file={}, \
+         navigation.allow_private_network={}, supported_env=[{}]",
         resolved.chrome_path.as_deref().unwrap_or("<unset>"),
         resolved.injection_mode,
         resolved.injection_additional_phrases.len(),
@@ -143,6 +144,7 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
             .as_ref()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "<unset>".to_string()),
+        resolved.navigation_allow_private_network,
         config::HONORED_CONFIG_ENV_VARS.join(","),
     );
 
@@ -161,7 +163,7 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
 }
 
 fn config_file_detail() -> (bool, String, bool) {
-    if let Err(err) = config::validate_unicode_additional_phrases_env() {
+    if let Err(err) = config::validate_unicode_config_env() {
         return (false, format!("environment — {err}"), false);
     }
     config_file_detail_with(|key| std::env::var(key).ok())
@@ -500,5 +502,25 @@ mod tests {
         assert!(passed, "detail: {detail}");
         assert!(detail.contains("prompt_injection.additional_phrases=1"));
         assert!(!detail.contains(secret));
+    }
+
+    #[test]
+    fn config_summary_reports_only_resolved_navigation_boolean() {
+        let secret = "true-with-secret-suffix";
+        let (passed, detail, informational) = config_file_detail_with(|key| {
+            (key == config::ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK).then(|| secret.to_string())
+        });
+
+        assert!(!passed);
+        assert!(!informational);
+        assert!(detail.contains(config::ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK));
+        assert!(!detail.contains(secret));
+
+        let (passed, detail, informational) = config_file_detail_with(|key| {
+            (key == config::ENV_NAVIGATION_ALLOW_PRIVATE_NETWORK).then(|| "true".to_string())
+        });
+        assert!(passed, "detail: {detail}");
+        assert!(informational);
+        assert!(detail.contains("navigation.allow_private_network=true"));
     }
 }

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -8,10 +8,10 @@ use anyhow::{Context, Result};
 use core_runtime::{
     speculative::{ActionSignature, SpeculativeEngine, SpeculativePrediction, StateDelta},
     sre::{LoadProfile, SemanticNode},
-    ActionError, ApprovalScope, BrowserClient, DeltaPolicy, PageSession, PolicyRule,
-    PromptInjectionMode, PromptInjectionSanitizer, PromptInjectionSanitizerConfig, SemanticState,
-    SemanticTarget, SemanticWaitState, SessionError, StateUpdate, VerifyError,
-    STABLE_KEY_SHORT_LEN,
+    validate_public_navigation_url, ActionError, ApprovalScope, BrowserClient, DeltaPolicy,
+    NavigationNetworkPolicy, PageSession, PolicyRule, PromptInjectionMode,
+    PromptInjectionSanitizer, PromptInjectionSanitizerConfig, SemanticState, SemanticTarget,
+    SemanticWaitState, SessionError, StateUpdate, VerifyError, STABLE_KEY_SHORT_LEN,
 };
 // Internal-only metering types (pub(crate) in metering.rs)
 use metering::{PlanFeature, UsageMeters};
@@ -57,7 +57,8 @@ struct InvalidToolArguments {
 fn is_known_tool(name: &str) -> bool {
     matches!(
         name,
-        "get_state"
+        "navigate"
+            | "get_state"
             | "act"
             | "verify"
             | "get_visual"
@@ -72,6 +73,7 @@ fn validate_tool_arguments(name: &str, arguments: &Value) -> Result<()> {
     static VALIDATORS: OnceLock<HashMap<&'static str, jsonschema::Validator>> = OnceLock::new();
     let validators = VALIDATORS.get_or_init(|| {
         [
+            ("navigate", navigate_input_schema()),
             ("get_state", get_state_input_schema()),
             ("act", act_input_schema()),
             ("verify", verify_input_schema()),
@@ -104,6 +106,7 @@ fn validate_tool_arguments(name: &str, arguments: &Value) -> Result<()> {
 }
 
 pub trait McpBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value>;
     fn get_state(&mut self, arguments: Value) -> Result<Value>;
     fn act(&mut self, arguments: Value) -> Result<Value>;
     fn verify(&mut self, arguments: Value) -> Result<Value>;
@@ -172,6 +175,11 @@ impl<B: McpBackend> McpServer<B> {
     pub fn tools(&self) -> Vec<ToolDefinition> {
         vec![
             ToolDefinition {
+                name: "navigate".to_string(),
+                description: "Navigate the current page to an HTTP(S) URL".to_string(),
+                input_schema: navigate_input_schema(),
+            },
+            ToolDefinition {
                 name: "get_state".to_string(),
                 description: "Retrieve the semantic page state".to_string(),
                 input_schema: get_state_input_schema(),
@@ -231,6 +239,7 @@ impl<B: McpBackend> McpServer<B> {
         let speculative_hits_before = self.backend.speculative_usage().0;
 
         let result = match name {
+            "navigate" => self.backend.navigate(arguments.clone()),
             "get_state" => self.backend.get_state(arguments.clone()),
             "act" => self.backend.act(arguments.clone()),
             "verify" => self.backend.verify(arguments.clone()),
@@ -485,7 +494,7 @@ impl<B: McpBackend> McpServer<B> {
                     self.usage_meters.visual_captures += 1;
                 }
             }
-            "act" => match payload.get("status").and_then(Value::as_str) {
+            "act" | "navigate" => match payload.get("status").and_then(Value::as_str) {
                 Some("ok") => {
                     self.usage_meters.actions_executed += 1;
                 }
@@ -511,6 +520,12 @@ impl<B: McpBackend> McpServer<B> {
             _ => {}
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NavigateArguments {
+    url: String,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
@@ -809,6 +824,9 @@ pub struct CoreRuntimeBackend {
     client: Option<BrowserClient>,
     /// Policy rules to reapply to the page created by a browser restart.
     policy_rules: Vec<PolicyRule>,
+    /// Whether public navigation may target private and otherwise non-global networks.
+    /// Defaults to false and is set from the resolved startup configuration.
+    navigation_allow_private_network: bool,
     /// Total number of successful automatic browser restarts.
     browser_restarts: u64,
     /// Timestamps of recent restart attempts, used for rate limiting.
@@ -877,6 +895,7 @@ impl CoreRuntimeBackend {
             }),
             client: None,
             policy_rules: Vec::new(),
+            navigation_allow_private_network: false,
             browser_restarts: 0,
             restart_history: VecDeque::new(),
             speculative: SpeculativeEngine::new(Vec::new()),
@@ -925,6 +944,25 @@ impl CoreRuntimeBackend {
         self.page.set_policy_rules(rules.clone())?;
         self.policy_rules = rules;
         Ok(())
+    }
+
+    pub fn set_navigation_allow_private_network(&mut self, allow: bool) {
+        self.navigation_allow_private_network = allow;
+    }
+
+    /// Invalidates every page-local MCP and speculative cursor after browser I/O begins.
+    /// Learned speculative transitions, cumulative hit/miss counters, skills, and policy rules
+    /// intentionally survive navigation.
+    fn reset_navigation_state(&mut self) {
+        self.state_cache = None;
+        self.previous_semantic_state = None;
+        self.pending_action = None;
+        self.last_action = None;
+        self.last_served_prediction = None;
+        self.last_served_prediction_source_hash = None;
+        self.action_chain_broken = false;
+        self.previous_state_verified = true;
+        self.speculative.clear_action_cursor();
     }
 
     pub fn register_extraction_rule(&mut self, name: &str, value: &Value) -> Result<()> {
@@ -1226,6 +1264,45 @@ impl CoreRuntimeBackend {
 }
 
 impl McpBackend for CoreRuntimeBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        let args: NavigateArguments =
+            serde_json::from_value(arguments).context("invalid navigate arguments")?;
+        // Produce the fragment-free public response identity without performing a duplicate DNS
+        // lookup. `navigate_public` applies the configured network policy before browser I/O and
+        // repeats it for redirects.
+        let requested =
+            validate_public_navigation_url(&args.url, NavigationNetworkPolicy::AllowPrivate)?;
+        let requested_url = requested.canonical_url().to_string();
+        let attempts_before = self.page.public_navigation_attempt_count();
+
+        let result = self
+            .page
+            .navigate_public(&requested_url, self.navigation_allow_private_network);
+        let browser_io_started = self.page.public_navigation_attempt_count() > attempts_before;
+        if browser_io_started {
+            self.reset_navigation_state();
+        }
+
+        match result {
+            Ok(final_url) => {
+                if !browser_io_started {
+                    self.reset_navigation_state();
+                }
+                Ok(json!({
+                    "status": "ok",
+                    "requested_url": requested_url,
+                    "final_url": final_url
+                }))
+            }
+            Err(err) => {
+                if let Some(action_err) = err.downcast_ref::<ActionError>() {
+                    return Ok(action_error_payload(action_err));
+                }
+                Err(err.context("navigate tool failed"))
+            }
+        }
+    }
+
     fn get_state(&mut self, arguments: Value) -> Result<Value> {
         let args = parse_get_state_arguments(&arguments)?;
 
@@ -1398,44 +1475,7 @@ impl McpBackend for CoreRuntimeBackend {
             }
             Err(err) => {
                 if let Some(action_err) = err.downcast_ref::<ActionError>() {
-                    let payload = match action_err {
-                        ActionError::VerifyRequired => json!({ "status": "verify_required" }),
-                        ActionError::Blocked { rule_id } => {
-                            json!({ "status": "blocked", "rule_id": rule_id })
-                        }
-                        ActionError::HumanApprovalRequired {
-                            rule_id,
-                            scope,
-                            outcome,
-                        } => {
-                            let mut payload = json!({
-                                "status": "requires_human_approval",
-                                "rule_id": rule_id,
-                                "scope": approval_scope_name(*scope)
-                            });
-                            if let Some(projection) = outcome {
-                                match serde_json::to_value(projection) {
-                                    Ok(v) => {
-                                        payload["outcome_projection"] = v;
-                                    }
-                                    Err(e) => {
-                                        // Serialization failure is unexpected (f64 is always
-                                        // finite from regex parse); log and omit the field.
-                                        eprintln!(
-                                            "[mcp-server] failed to serialize \
-                                             outcome_projection: {e}"
-                                        );
-                                    }
-                                }
-                            }
-                            payload
-                        }
-                        ActionError::AskHumanRequired { reason } => json!({
-                            "status": "ask_human_required",
-                            "reason": reason
-                        }),
-                    };
-                    return Ok(payload);
+                    return Ok(action_error_payload(action_err));
                 }
                 Err(err.context("act tool failed"))
             }
@@ -2043,6 +2083,39 @@ fn approval_scope_name(scope: ApprovalScope) -> &'static str {
     }
 }
 
+fn action_error_payload(error: &ActionError) -> Value {
+    match error {
+        ActionError::VerifyRequired => json!({ "status": "verify_required" }),
+        ActionError::Blocked { rule_id } => {
+            json!({ "status": "blocked", "rule_id": rule_id })
+        }
+        ActionError::HumanApprovalRequired {
+            rule_id,
+            scope,
+            outcome,
+        } => {
+            let mut payload = json!({
+                "status": "requires_human_approval",
+                "rule_id": rule_id,
+                "scope": approval_scope_name(*scope)
+            });
+            if let Some(projection) = outcome {
+                match serde_json::to_value(projection) {
+                    Ok(value) => payload["outcome_projection"] = value,
+                    Err(error) => {
+                        eprintln!("[mcp-server] failed to serialize outcome_projection: {error}");
+                    }
+                }
+            }
+            payload
+        }
+        ActionError::AskHumanRequired { reason } => json!({
+            "status": "ask_human_required",
+            "reason": reason
+        }),
+    }
+}
+
 fn skill_run_status_name(status: SkillRunStatus) -> &'static str {
     match status {
         SkillRunStatus::Completed => "completed",
@@ -2194,6 +2267,21 @@ fn get_state_input_schema() -> Value {
             "delivery": {
                 "type": "string",
                 "enum": ["full", "delta"]
+            }
+        }
+    })
+}
+
+fn navigate_input_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url"],
+        "properties": {
+            "url": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 8192
             }
         }
     })
@@ -2419,6 +2507,174 @@ mod tests {
             },
             LoadProfile::Interactive,
         )
+    }
+
+    fn seed_navigation_backend_state(backend: &mut CoreRuntimeBackend) -> ActionSignature {
+        let state = state_with_label("before navigation");
+        backend.state_cache = Some(ExternalSemanticState {
+            metadata: StateMetadata {
+                url: "https://example.com/before".to_string(),
+                page_instance_id: state.page_instance_id().to_string(),
+                state_hash: state.state_hash().to_string(),
+                load_profile: "interactive".to_string(),
+                timestamp: state.timestamp(),
+                speculative: false,
+            },
+            interactive_elements: vec![],
+        });
+        backend.previous_semantic_state = Some(state);
+        backend.pending_action = Some(action("click:pending"));
+        backend.last_action = Some(action("click:last"));
+        backend.last_served_prediction = Some(SpeculativePrediction {
+            predicted_action: action("click:predicted"),
+            predicted_state_hash: Some("predicted-state".to_string()),
+            confidence: 1.0,
+        });
+        backend.last_served_prediction_source_hash = Some("source-state".to_string());
+        backend.action_chain_broken = true;
+        backend.previous_state_verified = false;
+        backend.speculative_hits = 7;
+        backend.speculative_misses = 11;
+        backend.skills.insert(
+            "kept-skill".to_string(),
+            SkillDefinition {
+                schema_version: 1,
+                name: "kept-skill".to_string(),
+                steps: vec![],
+            },
+        );
+        backend.policy_rules.push(PolicyRule {
+            id: "kept-rule".to_string(),
+            domain: None,
+            path_prefix: None,
+            role: None,
+            text_regex: None,
+            context_regex: None,
+            action: core_runtime::PolicyAction::Allow,
+            scope: None,
+            outcome_projector: None,
+        });
+        backend.navigation_allow_private_network = true;
+
+        let stale_cursor = action("click:stale-cursor");
+        backend.speculative.advance_action_cursor(&stale_cursor);
+        stale_cursor
+    }
+
+    fn assert_navigation_state_was_reset(backend: &CoreRuntimeBackend) {
+        assert!(backend.state_cache.is_none());
+        assert!(backend.previous_semantic_state.is_none());
+        assert!(backend.pending_action.is_none());
+        assert!(backend.last_action.is_none());
+        assert!(backend.last_served_prediction.is_none());
+        assert!(backend.last_served_prediction_source_hash.is_none());
+        assert!(!backend.action_chain_broken);
+        assert!(backend.previous_state_verified);
+        assert_eq!(backend.speculative_hits, 7);
+        assert_eq!(backend.speculative_misses, 11);
+        assert!(backend.skills.contains_key("kept-skill"));
+        assert_eq!(backend.policy_rules.len(), 1);
+        assert_eq!(backend.policy_rules[0].id, "kept-rule");
+        assert!(backend.navigation_allow_private_network);
+    }
+
+    #[test]
+    fn reset_navigation_state_clears_page_state_and_cursor_but_preserves_configuration() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let mut backend = CoreRuntimeBackend::new(page);
+        let stale_cursor = seed_navigation_backend_state(&mut backend);
+
+        backend.reset_navigation_state();
+
+        assert_navigation_state_was_reset(&backend);
+        let next = action("type:after-navigation");
+        backend
+            .speculative
+            .record_transition("after-navigation", &next, "after-type");
+        assert_eq!(
+            backend
+                .speculative
+                .predict("after-navigation", Some(&stale_cursor)),
+            None,
+            "reset must clear the speculative action cursor instead of learning a stale sequence"
+        );
+    }
+
+    #[test]
+    fn navigate_preflight_rejection_preserves_backend_state() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let mut backend = CoreRuntimeBackend::new(page);
+        seed_navigation_backend_state(&mut backend);
+        let attempts_before = backend.page.public_navigation_attempt_count();
+
+        backend
+            .navigate(json!({"url": "data:text/html,not-public"}))
+            .expect_err("public MCP navigation must reject data URLs");
+
+        assert_eq!(
+            backend.page.public_navigation_attempt_count(),
+            attempts_before
+        );
+        assert!(backend.state_cache.is_some());
+        assert!(backend.previous_semantic_state.is_some());
+        assert!(backend.pending_action.is_some());
+        assert!(backend.last_action.is_some());
+        assert!(backend.last_served_prediction.is_some());
+        assert!(backend.last_served_prediction_source_hash.is_some());
+        assert!(backend.action_chain_broken);
+        assert!(!backend.previous_state_verified);
+        assert_eq!(backend.speculative_hits, 7);
+        assert_eq!(backend.speculative_misses, 11);
+        assert!(backend.skills.contains_key("kept-skill"));
+        assert_eq!(backend.policy_rules[0].id, "kept-rule");
+    }
+
+    #[test]
+    fn navigate_post_io_error_resets_backend_state() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind closed port");
+        let address = listener.local_addr().expect("local address");
+        drop(listener);
+
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let mut backend = CoreRuntimeBackend::new(page);
+        seed_navigation_backend_state(&mut backend);
+        let attempts_before = backend.page.public_navigation_attempt_count();
+
+        backend
+            .navigate(json!({"url": format!("http://{address}/unreachable")}))
+            .expect_err("closed local port must fail after browser I/O starts");
+
+        assert!(backend.page.public_navigation_attempt_count() > attempts_before);
+        assert_navigation_state_was_reset(&backend);
+    }
+
+    #[test]
+    fn navigation_network_configuration_survives_browser_relaunch() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let mut backend = CoreRuntimeBackend::new_with_client(client, page);
+        backend.set_navigation_allow_private_network(true);
+
+        backend
+            .handle_browser_disconnect()
+            .expect("managed browser relaunch");
+
+        assert!(backend.navigation_allow_private_network);
     }
 
     #[test]
@@ -2807,6 +3063,12 @@ mod tests {
     }
 
     impl McpBackend for MockBackend {
+        fn navigate(&mut self, arguments: Value) -> anyhow::Result<Value> {
+            Ok(
+                json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+            )
+        }
+
         fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
             Ok(self.get_state_result.clone().unwrap_or_else(|| json!({})))
         }
@@ -3029,6 +3291,12 @@ mod tests {
     }
 
     impl McpBackend for RestartMockBackend {
+        fn navigate(&mut self, arguments: Value) -> anyhow::Result<Value> {
+            Ok(
+                json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+            )
+        }
+
         fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
             if self.fail_get_state_with_disconnect {
                 self.fail_get_state_with_disconnect = false;
@@ -3112,6 +3380,12 @@ mod tests {
     fn call_tool_does_not_intercept_page_level_errors() {
         struct PageErrorBackend;
         impl McpBackend for PageErrorBackend {
+            fn navigate(&mut self, arguments: Value) -> anyhow::Result<Value> {
+                Ok(
+                    json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+                )
+            }
+
             fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
                 Err(anyhow::anyhow!("Could not find node with given id"))
             }

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> anyhow::Result<()> {
             .with_context(|| format!("failed to load config file {}", path.display()))?,
         None => None,
     };
-    config::validate_unicode_additional_phrases_env()
+    config::validate_unicode_config_env()
         .context("failed to resolve dragon-head-mcp configuration")?;
     let resolved = config::resolve_config(file_config.as_ref(), env_lookup)
         .context("failed to resolve dragon-head-mcp configuration")?;
@@ -138,6 +138,7 @@ fn main() -> anyhow::Result<()> {
         mode: resolved.injection_mode,
         additional_phrases: resolved.injection_additional_phrases.clone(),
     });
+    backend.set_navigation_allow_private_network(resolved.navigation_allow_private_network);
     let mut server = McpServer::new(backend);
     eprintln!("dragon-head-mcp: ready, listening on stdio");
 

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -33,6 +33,11 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "delta",
         scenario_delta_delivery_full_seeds_baseline,
     );
+    bench.run_scenario(
+        "navigate_contract_and_metering",
+        "navigation",
+        scenario_navigate_contract_and_metering,
+    );
 
     bench.write_if_configured()?;
     bench.assert_required_scenarios(&[
@@ -40,10 +45,25 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "hitl_flow",
         "usage_report_plan_gating",
         "delta_delivery_full_seeds_baseline",
+        "navigate_contract_and_metering",
     ])?;
     bench.assert_all_passed()?;
 
     Ok(())
+}
+
+fn scenario_navigate_contract_and_metering() -> Result<Value> {
+    let mut server = McpServer::new(MockBackend::default());
+    let response = server.call_tool("navigate", json!({"url": "https://example.com/start"}))?;
+    assert_eq!(response["status"], "ok");
+    assert_eq!(response["requested_url"], "https://example.com/start");
+    let usage = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(usage["actions_executed"], 1);
+
+    Ok(json!({
+        "status": response["status"],
+        "actions_executed": usage["actions_executed"]
+    }))
 }
 
 fn scenario_tool_flow_state_and_act() -> Result<Value> {
@@ -266,6 +286,12 @@ impl Default for MockBackend {
 }
 
 impl McpBackend for MockBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        Ok(
+            json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+        )
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({
             "metadata": {

--- a/mcp-server/tests/fixtures/mcp_tools.snapshot.json
+++ b/mcp-server/tests/fixtures/mcp_tools.snapshot.json
@@ -296,6 +296,24 @@
     "name": "get_visual"
   },
   {
+    "description": "Navigate the current page to an HTTP(S) URL",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "maxLength": 8192,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "name": "navigate"
+  },
+  {
     "description": "Execute a declarative skill workflow",
     "inputSchema": {
       "additionalProperties": false,

--- a/mcp-server/tests/mcp_billing_plan_gating.rs
+++ b/mcp-server/tests/mcp_billing_plan_gating.rs
@@ -6,6 +6,8 @@ struct MockBackend {
     audit_snapshot: Option<AuditRetentionSnapshot>,
     act_responses: Vec<Value>,
     act_call_count: usize,
+    navigate_responses: Vec<Value>,
+    navigate_call_count: usize,
 }
 
 impl Default for MockBackend {
@@ -14,11 +16,28 @@ impl Default for MockBackend {
             audit_snapshot: None,
             act_responses: vec![json!({"status": "ok"})],
             act_call_count: 0,
+            navigate_responses: vec![json!({
+                "status": "ok",
+                "requested_url": "https://example.com/start",
+                "final_url": "https://example.com/home"
+            })],
+            navigate_call_count: 0,
         }
     }
 }
 
 impl McpBackend for MockBackend {
+    fn navigate(&mut self, _arguments: Value) -> Result<Value> {
+        let response = self
+            .navigate_responses
+            .get(self.navigate_call_count)
+            .cloned()
+            .or_else(|| self.navigate_responses.last().cloned())
+            .unwrap_or_else(|| json!({"status": "blocked", "rule_id": "test"}));
+        self.navigate_call_count += 1;
+        Ok(response)
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({
             "metadata": {
@@ -80,6 +99,7 @@ fn test_usage_report_tracks_metered_calls() -> Result<()> {
             json!({"status": "ok"}),
         ],
         act_call_count: 0,
+        ..Default::default()
     };
     let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
 
@@ -105,6 +125,29 @@ fn test_usage_report_tracks_metered_calls() -> Result<()> {
     // cost: state(280) + visual(850) + action(60) + hitl(2*1200=2400) + audit(300) = 3890
     assert_eq!(report["cost_microusd"]["total"], json!(3890));
 
+    Ok(())
+}
+
+#[test]
+fn test_navigate_metering_matches_action_and_hitl_contract() -> Result<()> {
+    let backend = MockBackend {
+        navigate_responses: vec![
+            json!({"status": "requires_human_approval", "rule_id": "review", "scope": "action_only"}),
+            json!({"status": "blocked", "rule_id": "blocked"}),
+            json!({"status": "ok", "requested_url": "https://example.com/start", "final_url": "https://example.com/home"}),
+        ],
+        ..Default::default()
+    };
+    let mut server = McpServer::new_with_plan(backend, PlanTier::Enterprise);
+
+    server.call_tool("navigate", json!({"url": "https://example.com/start"}))?;
+    server.call_tool("ask_human", json!({"reason": "review"}))?;
+    server.call_tool("navigate", json!({"url": "https://example.com/blocked"}))?;
+    server.call_tool("navigate", json!({"url": "https://example.com/start"}))?;
+
+    let report = server.call_tool("get_usage_report", json!({}))?;
+    assert_eq!(report["actions_executed"], 1);
+    assert_eq!(report["hitl_events"], 2);
     Ok(())
 }
 

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -1,6 +1,7 @@
 use mcp_server::{McpBackend, McpServer};
 use serde_json::{json, Value};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
 use std::sync::{mpsc, OnceLock};
 use std::thread;
@@ -11,6 +12,7 @@ use test_bench_support::should_skip_browser_tests;
 use std::os::unix::process::CommandExt;
 
 const REQUIRED_TOOL_NAMES: &[&str] = &[
+    "navigate",
     "get_state",
     "act",
     "verify",
@@ -42,6 +44,14 @@ fn assert_required_tools(tools: &[Value]) {
 struct NullBackend;
 
 impl McpBackend for NullBackend {
+    fn navigate(&mut self, arguments: Value) -> anyhow::Result<Value> {
+        Ok(json!({
+            "status": "ok",
+            "requested_url": arguments["url"],
+            "final_url": arguments["url"]
+        }))
+    }
+
     fn get_state(&mut self, _: Value) -> anyhow::Result<Value> {
         Ok(json!({}))
     }
@@ -705,6 +715,97 @@ fn test_mcp_binary_stdio_smoke() -> anyhow::Result<()> {
     );
     assert!(stdout_lines.iter().all(|line| !line.trim().is_empty()));
     eprintln!("[timing] total: {:?}", t0.elapsed());
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires Chrome; starts a real browser process"]
+fn test_mcp_binary_fresh_session_navigate_returns_full_delta_baseline() -> anyhow::Result<()> {
+    if should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let address = listener.local_addr()?;
+    let fixture = thread::spawn(move || -> anyhow::Result<()> {
+        let (mut stream, _) = listener.accept()?;
+        let mut request = [0_u8; 2048];
+        let _ = stream.read(&mut request)?;
+        let body = "<html><body><h1>Fresh navigation</h1><button>Ready</button></body></html>";
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )?;
+        stream.flush()?;
+        Ok(())
+    });
+
+    let bin_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_dragon-head-mcp"));
+    let config_home = tempfile::tempdir()?;
+    let mut child = Command::new(&bin_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("NAVIGATION_ALLOW_PRIVATE_NETWORK", "true")
+        .env_remove("POLICY_FILE")
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut stderr = child.stderr.take().expect("stderr");
+    let stderr_reader = thread::spawn(move || {
+        let mut output = String::new();
+        let _ = stderr.read_to_string(&mut output);
+        output
+    });
+    let mut reader = BufReader::new(stdout);
+    mcp_handshake(&mut stdin, &mut reader)?;
+
+    let requested_url = format!("http://{address}/start#ignored");
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "navigate", "arguments": {"url": requested_url}}
+        })
+    )?;
+    stdin.flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let navigate: Value = serde_json::from_str(&line)?;
+    assert_eq!(navigate["result"]["structuredContent"]["status"], "ok");
+    assert_eq!(
+        navigate["result"]["structuredContent"]["requested_url"],
+        format!("http://{address}/start")
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "get_state", "arguments": {"delivery": "delta"}}
+        })
+    )?;
+    stdin.flush()?;
+    line.clear();
+    reader.read_line(&mut line)?;
+    let state: Value = serde_json::from_str(&line)?;
+    assert_eq!(state["result"]["structuredContent"]["type"], "full");
+
+    drop(stdin);
+    let status = child.wait()?;
+    assert!(status.success(), "dragon-head-mcp exited with {status}");
+    let stderr = stderr_reader.join().expect("stderr reader panicked");
+    assert!(!stderr.contains("#ignored"));
+    fixture.join().expect("fixture thread panicked")?;
     Ok(())
 }
 

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
-use std::sync::{mpsc, OnceLock};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 use test_bench_support::should_skip_browser_tests;
@@ -196,20 +196,10 @@ fn mcp_handshake(
     Ok(())
 }
 
-/// Build the binary once per test-binary invocation to avoid redundant recompiles.
 fn build_binary_once() -> anyhow::Result<std::path::PathBuf> {
-    static BIN: OnceLock<std::path::PathBuf> = OnceLock::new();
-    if let Some(path) = BIN.get() {
-        return Ok(path.clone());
-    }
-    let build = escargot::CargoBuild::new()
-        .bin("dragon-head-mcp")
-        .package("mcp-server")
-        .current_release()
-        .run()?;
-    let path = build.path().to_owned();
-    let _ = BIN.set(path.clone());
-    Ok(path)
+    Ok(std::path::PathBuf::from(env!(
+        "CARGO_BIN_EXE_dragon-head-mcp"
+    )))
 }
 
 struct ChildGuard {

--- a/mcp-server/tests/mcp_client_contract.rs
+++ b/mcp-server/tests/mcp_client_contract.rs
@@ -15,6 +15,16 @@ const TOOL_SEMANTICS_END: &str = "<!-- mcp-tool-semantics:end -->";
 struct MockBackend;
 
 impl McpBackend for MockBackend {
+    fn navigate(&mut self, _arguments: Value) -> Result<Value> {
+        Ok(json!({
+            "ok": true,
+            "tool": "navigate",
+            "status": "ok",
+            "requested_url": "https://example.com/start",
+            "final_url": "https://example.com/home"
+        }))
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({"ok": true, "tool": "get_state"}))
     }
@@ -227,6 +237,15 @@ impl SemanticMockBackend {
 }
 
 impl McpBackend for SemanticMockBackend {
+    fn navigate(&mut self, _arguments: Value) -> Result<Value> {
+        self.previous_state = None;
+        Ok(json!({
+            "status": "ok",
+            "requested_url": "https://example.com/start",
+            "final_url": "https://example.com/home"
+        }))
+    }
+
     fn get_state(&mut self, arguments: Value) -> Result<Value> {
         let is_delta = arguments.get("delivery").and_then(|v| v.as_str()) == Some("delta");
 
@@ -318,6 +337,26 @@ fn test_mcp_contract_exposes_required_tools() {
     assert!(names.contains(&"ask_human"));
     assert!(names.contains(&"run_skill"));
     assert!(names.contains(&"get_usage_report"));
+    assert!(names.contains(&"navigate"));
+    assert_eq!(
+        names.len(),
+        9,
+        "the public MCP contract must expose exactly nine tools"
+    );
+    let navigate = tools
+        .iter()
+        .find(|tool| tool.name == "navigate")
+        .expect("navigate tool must exist");
+    assert_eq!(navigate.input_schema["additionalProperties"], json!(false));
+    assert_eq!(navigate.input_schema["required"], json!(["url"]));
+    assert_eq!(
+        navigate.input_schema["properties"]["url"]["minLength"],
+        json!(1)
+    );
+    assert_eq!(
+        navigate.input_schema["properties"]["url"]["maxLength"],
+        json!(8192)
+    );
     assert_eq!(
         get_state.input_schema["properties"]["delivery"]["enum"],
         json!(["full", "delta"])
@@ -329,6 +368,7 @@ fn test_mcp_contract_all_tools_are_callable() {
     let mut server = McpServer::new(MockBackend);
 
     for (name, arguments) in [
+        ("navigate", json!({"url": "https://example.com/start"})),
         ("get_state", json!({})),
         ("act", json!({"action": "click"})),
         (
@@ -462,6 +502,26 @@ fn test_delta_first_call_returns_full_state_with_hint() -> Result<()> {
         "first delta call must include state object"
     );
 
+    Ok(())
+}
+
+#[test]
+fn successful_navigation_forces_next_delta_to_full_baseline() -> Result<()> {
+    let backend = SemanticMockBackend::with_states(vec![
+        make_full_state("https://example.com/before"),
+        make_full_state("https://example.com/after"),
+    ]);
+    let mut server = McpServer::new(backend);
+
+    server.call_tool("get_state", json!({"delivery": "delta"}))?;
+    server.call_tool("navigate", json!({"url": "https://example.com/start"}))?;
+    let after = server.call_tool("get_state", json!({"delivery": "delta"}))?;
+
+    assert_eq!(after["type"], "full");
+    assert_eq!(
+        after["state"]["metadata"]["url"],
+        "https://example.com/after"
+    );
     Ok(())
 }
 
@@ -657,6 +717,12 @@ struct SecurityFlagsMockBackend {
 }
 
 impl McpBackend for SecurityFlagsMockBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        Ok(
+            json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+        )
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         let mut element = json!({
             "id": 1,

--- a/mcp-server/tests/mcp_protocol_compliance.rs
+++ b/mcp-server/tests/mcp_protocol_compliance.rs
@@ -7,6 +7,15 @@ use std::{fs, path::Path};
 struct MockBackend;
 
 impl McpBackend for MockBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        let requested_url = arguments["url"].clone();
+        Ok(json!({
+            "status": "ok",
+            "requested_url": requested_url,
+            "final_url": "https://example.com/home"
+        }))
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({"metadata": {"url": "https://example.com"}, "interactive_elements": []}))
     }
@@ -144,11 +153,35 @@ fn test_jsonrpc_tools_call_compliance() {
     assert_eq!(&fallback, structured);
 }
 
+#[test]
+fn navigate_jsonrpc_returns_structured_urls() {
+    let mut server = McpServer::new(MockBackend);
+    let response = call_tool_jsonrpc(
+        &mut server,
+        "navigate",
+        json!({"url": "https://example.com/start"}),
+    );
+
+    assert_eq!(response["result"]["structuredContent"]["status"], "ok");
+    assert_eq!(
+        response["result"]["structuredContent"]["requested_url"],
+        "https://example.com/start"
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["final_url"],
+        "https://example.com/home"
+    );
+}
+
 struct ErrorBackend {
     error_msg: &'static str,
 }
 
 impl McpBackend for ErrorBackend {
+    fn navigate(&mut self, _arguments: Value) -> Result<Value> {
+        Err(anyhow!("{}", self.error_msg))
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Err(anyhow!("{}", self.error_msg))
     }
@@ -247,6 +280,13 @@ struct CountingBackend {
 }
 
 impl McpBackend for CountingBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        self.calls += 1;
+        Ok(
+            json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+        )
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         self.calls += 1;
         Ok(json!({"metadata": {}, "interactive_elements": []}))
@@ -299,6 +339,10 @@ fn call_tool_jsonrpc<B: McpBackend>(
 #[test]
 fn every_tool_rejects_unknown_fields_without_side_effects() {
     let cases = [
+        (
+            "navigate",
+            json!({"url": "https://example.com", "unexpected": true}),
+        ),
         ("get_state", json!({"unexpected": true})),
         ("act", json!({"action": "click", "unexpected": true})),
         (
@@ -334,6 +378,9 @@ fn every_tool_rejects_unknown_fields_without_side_effects() {
 #[test]
 fn malformed_enums_types_and_nested_fields_return_invalid_params() {
     let cases = [
+        ("navigate", json!({})),
+        ("navigate", json!({"url": ""})),
+        ("navigate", json!({"url": false})),
         ("get_state", json!({"format": "xml"})),
         ("get_state", json!({"delivery": "detla"})),
         ("get_state", json!({"force_refresh": "true"})),

--- a/mcp-server/tests/mcp_usage_metering_gaps.rs
+++ b/mcp-server/tests/mcp_usage_metering_gaps.rs
@@ -24,6 +24,12 @@ impl Default for MockBackend {
 }
 
 impl McpBackend for MockBackend {
+    fn navigate(&mut self, arguments: Value) -> Result<Value> {
+        Ok(
+            json!({"status": "ok", "requested_url": arguments["url"], "final_url": arguments["url"]}),
+        )
+    }
+
     fn get_state(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({
             "metadata": {


### PR DESCRIPTION
## Summary

- add the ninth MCP tool, `navigate`, for bootstrapping a fresh browser session
- validate absolute public HTTP(S) destinations and enforce built-in/plugin Policy + HITL on the initial URL and every main-frame redirect
- preserve privacy in audit/replay output, meter successful actions and HITL consistently, and reset page/MCP/speculative state after browser I/O
- add trusted private-network opt-in configuration plus synchronized tool snapshots and public documentation

Closes #244

## Acceptance criteria

- Fresh-process stdio navigation and first-delta full baseline are covered.
- Invalid, credential-bearing, oversized, forbidden-scheme, and non-global destinations are rejected before browser I/O.
- Initial and redirect Policy/HITL/plugin decisions are destination-bound; iframe/subresource requests are excluded.
- Fetch interception cleanup is covered across success, rejection, partial setup failure, and recovery paths.
- Audit destination fingerprints and sanitized projections exclude credentials, query strings, and fragments.
- Runtime, snapshot, README, AI_CONTEXT, ARCHITECTURE, and SPEC expose exactly nine tools.

## Verification

- `cargo test --workspace`: 839 passed, 9 ignored across 86 suites
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace -- -D warnings`: passed
- `cargo deny check`: advisories, bans, licenses, and sources passed
- `python3 scripts/check_mvp_docs.py`: passed
- Public navigation validation + browser Policy/HITL/redirect tests: 15 passed
- MCP contract/protocol/fresh-process binary/billing/metering tests: 59 passed, 3 ignored
- Fresh Chrome stdio E2E: `navigate` followed by first delta returned a full baseline

`cargo audit` reports five advisories in unchanged transitive lockfile dependencies (`quinn-proto` and `rustls-webpki`); this PR does not change `Cargo.lock`.

## gstack gates

- `gstack-review`: clean, no unresolved P1/P2 findings
- `gstack-qa-only`: backend/MCP report-only QA clean; no unresolved findings
- Codex branch review: in-call unchained top-level navigation P1 fixed in `1cc35a1`; delayed post-call navigation finding documented as outside the explicit temporary-interception/cleanup contract
