### PR TITLE
[ISSUE-246] Return get_visual PNG as MCP image content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ name = "mcp-server"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "base64",
  "core-runtime",
  "escargot",
  "hex",

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ specific Chromium build.
 | `navigate` | Load an HTTP(S) URL through destination and redirect policy checks. |
 | `act` | Execute an interaction action. |
 | `verify` | Verify precondition text before acting. |
-| `get_visual` | Capture visual context with optional marks. |
+| `get_visual` | Capture PNG visual context as an MCP image block with hash and optional marks metadata. |
 | `ask_human` | Resolve a pending human-in-the-loop request. |
 | `run_skill` | Execute a declarative skill workflow. |
 | `get_usage_report` | Retrieve usage meters and plan tier summary. |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -499,6 +499,12 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 > PR 必須 CI に追加する。stdout が JSON-RPC 応答だけで構成されることと、stdin 終了後の
 > 正常 shutdown を検証し、起動・framing・stdio loop の回帰を merge 前に検出する。
 
+> **Follow-up (ISSUE-246, done)**: `get_visual` の PNG を MCP 標準の
+> `image` content block (`mimeType: image/png`) で返し、text fallback と
+> `structuredContent` には hash/marks metadata のみを保持する。raw PNG のサイズ上限、
+> SHA-256 整合、clean/SoM 両 mode、stdio framing を protocol test・実バイナリ E2E・
+> comprehensive evaluation で固定する。
+
 ### PR-15: NFR Benchmark & Capacity Validation
 - Status: `DONE` (Local)
 - Spec Ref: Section 6

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -76,7 +76,10 @@ VLMとLLMの認識を一致させ、要素特定を堅牢にする。
   - AIが `get_visual()` を明示的に要求した時。
   - `act()` が ambiguous エラーを返した時。
   - `verify()` が失敗した時。
-- **Output**: 画像データに加え、`marks` メタデータ（ID, BBox, Stable Keyの対応表）を返す。
+- **Output**: MCP `content` に `image/png` の image block として画像データを返し、
+  `structuredContent` と text fallback には `image_sha256`、mode、viewport、
+  `marks` メタデータ（ID, BBox, Stable Keyの対応表）を返す。画像データは metadata
+  へ重複させず、`image_sha256` は image block を base64 decode した元の PNG bytes と一致する。
 
 ### 3.3 Interaction & Latency Optimization
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,7 @@ The CI pipeline is defined in `.github/workflows/`.
 
 - **Goal**: Provide a single dashboard that verifies the main Dragon Head feature areas across `core-runtime`, `mcp-server`, `skills-engine`, `plugin-host`, and `marketplace`.
 - **Modes**:
-  - `smoke`: Required on PRs. Covers representative scenarios for state capture, action recovery, wait semantics, policy/HITL, audit/session, MCP flow, skill execution, plugin validation, and marketplace accounting.
+- `smoke`: Required on PRs. Covers representative scenarios for state capture, action recovery, wait semantics, policy/HITL, audit/session, MCP flow (including visual image content delivery), skill execution, plugin validation, and marketplace accounting.
   - `full`: Runs on nightly/manual workflows. Uses the same report format and is reserved for expanded scenario sets and longer-running variants.
 - **Artifacts**:
   - JSON reports: `target/evaluation-bench/*.json`

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = "0.22"
 core-runtime = { path = "../core-runtime" }
 json-patch = "4.2"
 serde = { workspace = true }

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod metering;
 pub(crate) mod protocol;
 
 use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use core_runtime::{
     speculative::{ActionSignature, SpeculativeEngine, SpeculativePrediction, StateDelta},
     sre::{LoadProfile, SemanticNode},
@@ -32,6 +33,9 @@ use std::{
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
+
+const MAX_VISUAL_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
 
 // Re-export public types at the crate level to preserve the existing public API.
 pub use dto::{ExternalInteractiveElement, ExternalSemanticState, StateMetadata};
@@ -114,6 +118,11 @@ pub trait McpBackend {
     fn ask_human(&mut self, arguments: Value) -> Result<Value>;
     fn run_skill(&mut self, arguments: Value) -> Result<Value>;
     fn extract(&mut self, arguments: Value) -> Result<Value>;
+    /// Consume image bytes produced by the most recent successful `get_visual` call.
+    /// Backends without binary visual output retain the metadata-only behavior.
+    fn take_visual_image(&mut self) -> Option<Vec<u8>> {
+        None
+    }
     fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {
         None
     }
@@ -157,6 +166,41 @@ pub struct McpServer<B> {
     backend: B,
     plan_tier: PlanTier,
     usage_meters: UsageMeters,
+}
+
+struct ToolCallOutput {
+    structured_content: Value,
+    visual_image: Option<Vec<u8>>,
+}
+
+fn validate_visual_image(image: &[u8], max_bytes: usize) -> Result<()> {
+    if image.len() > max_bytes {
+        anyhow::bail!(
+            "get_visual image exceeds maximum size of {max_bytes} bytes (received {} bytes)",
+            image.len()
+        );
+    }
+    if !image.starts_with(PNG_SIGNATURE) {
+        anyhow::bail!("get_visual capture is not a valid PNG image");
+    }
+    Ok(())
+}
+
+fn image_content_block(image: &[u8], structured_content: &Value) -> Result<Value> {
+    validate_visual_image(image, MAX_VISUAL_IMAGE_BYTES)?;
+    let reported_hash = structured_content
+        .get("image_sha256")
+        .and_then(Value::as_str)
+        .context("get_visual metadata is missing image_sha256")?;
+    let actual_hash = hex::encode(Sha256::digest(image));
+    if reported_hash != actual_hash {
+        anyhow::bail!("get_visual image_sha256 does not match captured image bytes");
+    }
+    Ok(json!({
+        "type": "image",
+        "data": BASE64_STANDARD.encode(image),
+        "mimeType": "image/png"
+    }))
 }
 
 impl<B: McpBackend> McpServer<B> {
@@ -223,17 +267,27 @@ impl<B: McpBackend> McpServer<B> {
     }
 
     pub fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value> {
+        Ok(self.call_tool_output(name, arguments)?.structured_content)
+    }
+
+    fn call_tool_output(&mut self, name: &str, arguments: Value) -> Result<ToolCallOutput> {
         if !is_known_tool(name) {
             anyhow::bail!("unknown MCP tool: {name}");
         }
         validate_tool_arguments(name, &arguments)?;
 
         if name == "get_usage_report" {
-            return self.get_usage_report_payload();
+            return Ok(ToolCallOutput {
+                structured_content: self.get_usage_report_payload()?,
+                visual_image: None,
+            });
         }
 
         if let Some(payload) = self.check_plan_gate(name, &arguments) {
-            return Ok(payload);
+            return Ok(ToolCallOutput {
+                structured_content: payload,
+                visual_image: None,
+            });
         }
 
         let speculative_hits_before = self.backend.speculative_usage().0;
@@ -266,10 +320,18 @@ impl<B: McpBackend> McpServer<B> {
         if !payload.is_object() {
             anyhow::bail!("MCP structuredContent must be a JSON object");
         }
+        let visual_image = if name == "get_visual" {
+            self.backend.take_visual_image()
+        } else {
+            None
+        };
         let speculative_hit = self.backend.speculative_usage().0 > speculative_hits_before;
         self.record_usage(name, &arguments, &payload, speculative_hit);
 
-        Ok(payload)
+        Ok(ToolCallOutput {
+            structured_content: payload,
+            visual_image,
+        })
     }
 
     pub fn handle_jsonrpc(&mut self, request: &str) -> Option<String> {
@@ -338,17 +400,24 @@ impl<B: McpBackend> McpServer<B> {
                             .cloned()
                             .unwrap_or_else(|| json!({}));
 
-                        self.call_tool(name, arguments)
-                            .map(|payload| {
-                                let text = serde_json::to_string(&payload)
+                        self.call_tool_output(name, arguments)
+                            .and_then(|output| {
+                                let text = serde_json::to_string(&output.structured_content)
                                     .expect("serializing a serde_json::Value cannot fail");
-                                json!({
-                                    "content": [{
-                                        "type": "text",
-                                        "text": text
-                                    }],
-                                    "structuredContent": payload
-                                })
+                                let mut content = vec![json!({
+                                    "type": "text",
+                                    "text": text
+                                })];
+                                if let Some(image) = output.visual_image {
+                                    content.push(image_content_block(
+                                        &image,
+                                        &output.structured_content,
+                                    )?);
+                                }
+                                Ok(json!({
+                                    "content": content,
+                                    "structuredContent": output.structured_content
+                                }))
                             })
                             .map_err(|err| {
                                 if err.downcast_ref::<InvalidToolArguments>().is_some() {
@@ -815,6 +884,7 @@ pub struct CoreRuntimeBackend {
     skill_engine: SkillEngine,
     skills: HashMap<String, SkillDefinition>,
     last_skill_delta: SkillUsageDelta,
+    pending_visual_image: Option<Vec<u8>>,
     schema_registry: SchemaRegistry,
     /// Prompt-injection sanitizer applied before any SemanticState is exposed to the LLM.
     injection_sanitizer: PromptInjectionSanitizer,
@@ -888,6 +958,7 @@ impl CoreRuntimeBackend {
             skill_engine: SkillEngine::new(),
             skills: HashMap::new(),
             last_skill_delta: SkillUsageDelta::default(),
+            pending_visual_image: None,
             schema_registry: SchemaRegistry::new(),
             injection_sanitizer: PromptInjectionSanitizer::new(PromptInjectionSanitizerConfig {
                 mode: PromptInjectionMode::ReportOnly,
@@ -1513,6 +1584,7 @@ impl McpBackend for CoreRuntimeBackend {
     }
 
     fn get_visual(&mut self, arguments: Value) -> Result<Value> {
+        self.pending_visual_image = None;
         let args: GetVisualArguments =
             serde_json::from_value(arguments).context("invalid get_visual arguments")?;
         let capture = self.page.get_visual()?;
@@ -1536,6 +1608,8 @@ impl McpBackend for CoreRuntimeBackend {
                 })
                 .collect::<Vec<_>>()
         };
+
+        self.pending_visual_image = Some(capture.image_png);
 
         Ok(json!({
             "mode": args.mode,
@@ -1684,6 +1758,10 @@ impl McpBackend for CoreRuntimeBackend {
 
     fn take_skill_usage_delta(&mut self) -> SkillUsageDelta {
         std::mem::take(&mut self.last_skill_delta)
+    }
+
+    fn take_visual_image(&mut self) -> Option<Vec<u8>> {
+        self.pending_visual_image.take()
     }
 
     fn handle_browser_disconnect(&mut self) -> std::result::Result<u64, String> {
@@ -2477,6 +2555,27 @@ mod tests {
     use crate::protocol::LATEST_PROTOCOL_VERSION;
     use core_runtime::sre::SemanticNode;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn visual_image_size_limit_accepts_exact_boundary_and_rejects_next_byte() {
+        let exact = PNG_SIGNATURE.to_vec();
+        assert!(validate_visual_image(&exact, exact.len()).is_ok());
+
+        let mut over = exact.clone();
+        over.push(0);
+        let err = validate_visual_image(&over, exact.len()).unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum size"));
+        assert!(!err.to_string().contains("PNG"));
+    }
+
+    #[test]
+    fn visual_image_validation_rejects_non_png_bytes() {
+        let err = validate_visual_image(b"not a png", 1024).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "get_visual capture is not a valid PNG image"
+        );
+    }
 
     fn make_node(id: i64, children: Vec<SemanticNode>) -> SemanticNode {
         SemanticNode {

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
 use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use test_bench_support::{EvaluationBench, EvaluationMode};
 
 #[test]
@@ -38,6 +40,11 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "navigation",
         scenario_navigate_contract_and_metering,
     );
+    bench.run_scenario(
+        "visual_image_content_contract",
+        "visual",
+        scenario_visual_image_content_contract,
+    );
 
     bench.write_if_configured()?;
     bench.assert_required_scenarios(&[
@@ -46,10 +53,45 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "usage_report_plan_gating",
         "delta_delivery_full_seeds_baseline",
         "navigate_contract_and_metering",
+        "visual_image_content_contract",
     ])?;
     bench.assert_all_passed()?;
 
     Ok(())
+}
+
+fn scenario_visual_image_content_contract() -> Result<Value> {
+    let png = STANDARD.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5dM2QAAAAASUVORK5CYII=")?;
+    let mut server = McpServer::new(MockBackend {
+        visual_image: Some(png.clone()),
+        ..Default::default()
+    });
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "get_visual", "arguments": {"mode": "som"}}
+    });
+    let response: Value = serde_json::from_str(
+        &server
+            .handle_jsonrpc(&request.to_string())
+            .context("get_visual response")?,
+    )?;
+    let content = response["result"]["content"]
+        .as_array()
+        .context("content array")?;
+    let decoded = STANDARD.decode(content[1]["data"].as_str().context("image data")?)?;
+    assert_eq!(decoded, png);
+    assert_eq!(content[1]["mimeType"], "image/png");
+    assert_eq!(
+        response["result"]["structuredContent"]["image_sha256"],
+        hex::encode(Sha256::digest(&decoded))
+    );
+
+    Ok(json!({
+        "content_blocks": content.len(),
+        "mime_type": content[1]["mimeType"]
+    }))
 }
 
 fn scenario_navigate_contract_and_metering() -> Result<Value> {
@@ -243,6 +285,7 @@ fn scenario_usage_report_plan_gating() -> Result<Value> {
                 json!({"status": "ok"}),
             ],
             act_call_count: 0,
+            visual_image: None,
         },
         PlanTier::Enterprise,
     );
@@ -273,6 +316,7 @@ struct MockBackend {
     audit_snapshot: Option<AuditRetentionSnapshot>,
     act_responses: Vec<Value>,
     act_call_count: usize,
+    visual_image: Option<Vec<u8>>,
 }
 
 impl Default for MockBackend {
@@ -281,6 +325,7 @@ impl Default for MockBackend {
             audit_snapshot: None,
             act_responses: vec![json!({"status": "ok"})],
             act_call_count: 0,
+            visual_image: None,
         }
     }
 }
@@ -321,7 +366,12 @@ impl McpBackend for MockBackend {
     }
 
     fn get_visual(&mut self, _arguments: Value) -> Result<Value> {
-        Ok(json!({"image_sha256": "abc"}))
+        let image_sha256 = self
+            .visual_image
+            .as_deref()
+            .map(|image| hex::encode(Sha256::digest(image)))
+            .unwrap_or_else(|| "abc".to_string());
+        Ok(json!({"image_sha256": image_sha256}))
     }
 
     fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
@@ -334,6 +384,10 @@ impl McpBackend for MockBackend {
 
     fn extract(&mut self, _arguments: Value) -> Result<Value> {
         Ok(json!({"rule": "mock", "result": null}))
+    }
+
+    fn take_visual_image(&mut self) -> Option<Vec<u8>> {
+        self.visual_image.take()
     }
 
     fn audit_retention_snapshot(&self) -> Option<AuditRetentionSnapshot> {

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -1,5 +1,7 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use mcp_server::{McpBackend, McpServer};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
@@ -795,6 +797,126 @@ fn test_mcp_binary_fresh_session_navigate_returns_full_delta_baseline() -> anyho
     assert!(status.success(), "dragon-head-mcp exited with {status}");
     let stderr = stderr_reader.join().expect("stderr reader panicked");
     assert!(!stderr.contains("#ignored"));
+    fixture.join().expect("fixture thread panicked")?;
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires Chrome; starts a real browser process"]
+fn test_mcp_binary_get_visual_returns_png_for_clean_and_som() -> anyhow::Result<()> {
+    if should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let address = listener.local_addr()?;
+    let fixture = thread::spawn(move || -> anyhow::Result<()> {
+        let (mut stream, _) = listener.accept()?;
+        let mut request = [0_u8; 2048];
+        let _ = stream.read(&mut request)?;
+        let body = "<html><body><button id='ready'>Ready</button></body></html>";
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )?;
+        stream.flush()?;
+        Ok(())
+    });
+
+    let bin_path = build_binary_once()?;
+    let config_home = tempfile::tempdir()?;
+    let mut child = Command::new(&bin_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("NAVIGATION_ALLOW_PRIVATE_NETWORK", "true")
+        .env_remove("POLICY_FILE")
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut stderr = child.stderr.take().expect("stderr");
+    let stderr_reader = thread::spawn(move || {
+        let mut output = String::new();
+        let _ = stderr.read_to_string(&mut output);
+        output
+    });
+    let mut reader = BufReader::new(stdout);
+    mcp_handshake(&mut stdin, &mut reader)?;
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "navigate",
+                "arguments": {"url": format!("http://{address}/visual")}
+            }
+        })
+    )?;
+    stdin.flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let navigate: Value = serde_json::from_str(&line)?;
+    assert_eq!(navigate["result"]["structuredContent"]["status"], "ok");
+
+    for (id, mode) in [(3, "clean"), (4, "som")] {
+        writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {"name": "get_visual", "arguments": {"mode": mode}}
+            })
+        )?;
+        stdin.flush()?;
+
+        line.clear();
+        reader.read_line(&mut line)?;
+        let response: Value = serde_json::from_str(&line)?;
+        let result = &response["result"];
+        let content = result["content"].as_array().expect("content array");
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["mimeType"], "image/png");
+
+        let encoded = content[1]["data"].as_str().expect("base64 PNG");
+        let png = STANDARD.decode(encoded)?;
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+        assert_eq!(
+            result["structuredContent"]["image_sha256"],
+            hex::encode(Sha256::digest(&png))
+        );
+        let fallback: Value = serde_json::from_str(content[0]["text"].as_str().unwrap())?;
+        assert_eq!(fallback, result["structuredContent"]);
+        assert!(!content[0]["text"].as_str().unwrap().contains(encoded));
+
+        let marks = result["structuredContent"]["marks"]
+            .as_array()
+            .expect("marks array");
+        if mode == "clean" {
+            assert!(marks.is_empty());
+        } else {
+            assert!(
+                !marks.is_empty(),
+                "SoM capture should mark the fixture button"
+            );
+        }
+    }
+
+    drop(stdin);
+    let status = child.wait()?;
+    assert!(status.success(), "dragon-head-mcp exited with {status}");
+    let stderr = stderr_reader.join().expect("stderr reader panicked");
+    assert!(!stderr.contains("iVBOR"), "base64 image leaked to stderr");
     fixture.join().expect("fixture thread panicked")?;
     Ok(())
 }

--- a/mcp-server/tests/mcp_protocol_compliance.rs
+++ b/mcp-server/tests/mcp_protocol_compliance.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use mcp_server::{McpBackend, McpServer, PlanTier};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{fs, path::Path};
 
 #[derive(Default)]
@@ -151,6 +153,136 @@ fn test_jsonrpc_tools_call_compliance() {
     )
     .expect("text fallback must contain serialized JSON");
     assert_eq!(&fallback, structured);
+}
+
+struct VisualImageBackend {
+    image: Option<Vec<u8>>,
+    reported_hash: Option<String>,
+}
+
+impl McpBackend for VisualImageBackend {
+    fn navigate(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn get_state(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn act(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn verify(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn get_visual(&mut self, arguments: Value) -> Result<Value> {
+        let image = self.image.as_ref().expect("fixture image");
+        let image_sha256 = self
+            .reported_hash
+            .clone()
+            .unwrap_or_else(|| hex::encode(Sha256::digest(image)));
+        Ok(json!({
+            "mode": arguments.get("mode").and_then(Value::as_str).unwrap_or("som"),
+            "viewport": "full",
+            "image_sha256": image_sha256,
+            "marks": [{"id": 7, "stable_key": "abc123", "bbox": [1, 2, 3, 4]}]
+        }))
+    }
+    fn ask_human(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn run_skill(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn extract(&mut self, _arguments: Value) -> Result<Value> {
+        unreachable!()
+    }
+    fn take_visual_image(&mut self) -> Option<Vec<u8>> {
+        self.image.take()
+    }
+}
+
+#[test]
+fn get_visual_returns_png_image_content_without_copying_it_into_metadata() {
+    let png = STANDARD.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5dM2QAAAAASUVORK5CYII=").unwrap();
+    let mut server = McpServer::new(VisualImageBackend {
+        image: Some(png.clone()),
+        reported_hash: None,
+    });
+
+    let response = call_tool_jsonrpc(&mut server, "get_visual", json!({"mode": "som"}));
+    let result = &response["result"];
+    let content = result["content"].as_array().expect("content array");
+    assert_eq!(content.len(), 2);
+    assert_eq!(content[0]["type"], "text");
+    assert_eq!(content[1]["type"], "image");
+    assert_eq!(content[1]["mimeType"], "image/png");
+
+    let encoded = content[1]["data"].as_str().expect("base64 image data");
+    assert!(!encoded.contains(['\r', '\n', ' ', '\t']));
+    assert_eq!(STANDARD.decode(encoded).expect("valid base64"), png);
+
+    let structured = &result["structuredContent"];
+    let fallback: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(&fallback, structured);
+    assert_eq!(
+        structured["image_sha256"],
+        hex::encode(Sha256::digest(&png))
+    );
+    assert!(!structured.to_string().contains(encoded));
+    assert!(!content[0]["text"].as_str().unwrap().contains(encoded));
+}
+
+#[test]
+fn get_visual_rejects_oversized_png_without_emitting_partial_content() {
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    png.resize(8 * 1024 * 1024 + 1, 0);
+    let mut server = McpServer::new(VisualImageBackend {
+        image: Some(png),
+        reported_hash: None,
+    });
+
+    let response = call_tool_jsonrpc(&mut server, "get_visual", json!({"mode": "som"}));
+    assert_eq!(response["error"]["code"], -32000);
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("exceeds maximum size"));
+    assert!(response.get("result").is_none());
+    assert!(response.to_string().len() < 1024);
+
+    let usage = server.call_tool("get_usage_report", json!({})).unwrap();
+    assert_eq!(usage["visual_captures"], 1);
+}
+
+#[test]
+fn direct_call_tool_keeps_oversized_visual_metadata_compatible() {
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    png.resize(8 * 1024 * 1024 + 1, 0);
+    let expected_hash = hex::encode(Sha256::digest(&png));
+    let mut server = McpServer::new(VisualImageBackend {
+        image: Some(png),
+        reported_hash: None,
+    });
+
+    let payload = server
+        .call_tool("get_visual", json!({"mode": "som"}))
+        .unwrap();
+    assert_eq!(payload["image_sha256"], expected_hash);
+}
+
+#[test]
+fn get_visual_rejects_image_bytes_that_do_not_match_reported_hash() {
+    let png = STANDARD.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5dM2QAAAAASUVORK5CYII=").unwrap();
+    let mut server = McpServer::new(VisualImageBackend {
+        image: Some(png),
+        reported_hash: Some("0".repeat(64)),
+    });
+
+    let response = call_tool_jsonrpc(&mut server, "get_visual", json!({"mode": "clean"}));
+    assert_eq!(response["error"]["code"], -32000);
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("image_sha256 does not match"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #246

## Summary
- return captured PNG bytes as an MCP image content block with `image/png`
- keep hash, mode, viewport, and marks in text fallback and `structuredContent` without duplicating base64
- enforce an 8 MiB raw-image boundary and verify transport bytes against `image_sha256`
- cover clean/SoM behavior in protocol, real-binary, and comprehensive evaluation tests

## Exit criteria
- [x] MCP clients receive the captured PNG
- [x] returned bytes match `image_sha256`
- [x] clean and SoM modes have binary-level coverage
- [x] clean marks remain empty and SoM marks are preserved
- [x] oversized/invalid/mismatched images fail without partial content or binary stderr leakage
- [x] structured fallback remains metadata-only and useful

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo audit`
- `cargo deny check`
- `CHROME_INSTALLED=true cargo test -p mcp-server --test mcp_binary_e2e test_mcp_binary_get_visual_returns_png_for_clean_and_som -- --ignored --nocapture`
- `CHROME_INSTALLED=true cargo test -p mcp-server --test comprehensive_evaluation test_mcp_server_comprehensive_evaluation_suite -- --nocapture`

## Review and QA
- gstack-style pre-landing API, testing, security, and red-team review completed; all actionable findings resolved
- report-only MCP QA exercised stdio framing, PNG decoding, MIME type, SHA-256 binding, clean/SoM marks, metadata fallback, size errors, and stderr non-disclosure
- no unresolved P1/P2 findings