### PR TITLE
[ISSUE-247] Load configured skills in standalone MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ allow_private_network = false
 log_dir = "/var/log/dragon-head"
 max_bytes = 10485760
 durability = "flush"  # "flush" (default) or "sync"
+
+[skills]
+# JSON files containing one SkillDefinition each. Relative paths resolve from
+# the directory containing this config.toml; absolute paths remain absolute.
+files = ["skills/checkout.json", "/opt/dragon-head/skills/search.json"]
 ```
 
 ### Precedence
@@ -228,7 +233,15 @@ switch does not replace OS/container network isolation or deployment egress cont
 Run `dragon-head-mcp --doctor` to validate the config file and list every
 supported configuration environment variable. A malformed file or invalid env
 override makes the "Config file" check fail. The summary reports only the
-effective additional-phrase count, never the phrase contents.
+effective additional-phrase and loaded-skill counts, never their contents.
+
+Configured skills are loaded before the server reports readiness. At most 64
+regular files are accepted, each limited to 1 MiB. Every file must contain
+exactly one JSON `SkillDefinition`; schema and semantic validation, including
+duplicate-name rejection, completes for the full set before any definition is
+registered.
+Startup and `--doctor` fail with the affected path and reason when validation
+fails, without printing the definition body.
 
 Setting `prompt_injection.mode` to `redact` or `off` changes the default
 security posture — see [Security: Prompt Injection

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -193,6 +193,12 @@ MVPは「外部クライアントから安全に利用可能な Neural-Browser R
 - Exit Criteria
   - [x] `config.toml` で `chrome_path` / `prompt_injection.mode` / `policy.file` / `audit.*` がユーザー設定可能になり、`--doctor` がその内容を検証する。
 
+> **Follow-up (ISSUE-247, done)**: `[skills].files` で standalone server の
+> SkillDefinition JSON を読み込む。config file 相対 path、件数・file size 上限、
+> schema/semantic validation、重複名拒否を startup/`--doctor` 共通 loader で実施し、
+> 全件検証後かつ stdio ready 通知前にのみ登録する。相対 fixture を用いた実バイナリ
+> Chrome E2E で `run_skill` 完了まで固定する。
+
 ### PR-30: Chrome Crash/Disconnect Recovery in Long-Running MCP Sessions
 - Status: `DONE`
 - Spec Ref: ISSUE-149

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -220,7 +220,7 @@ Model Context Protocol (MCP) 準拠のツール定義。
 | `verify` | `target_id`: int, `expected`: {text: string} | ハルシネーション防止の事前検証。 |
 | `get_visual` | `mode`: "clean"\|"som", `viewport`: "full" | 視覚情報の取得。 |
 | `ask_human` | `reason`: string, `context`: bool, `outcome_projection`: object | HITL要求（2FA/判断不能/高額決済時）。承認要求に未来投影データを同梱。 |
-| `run_skill` | `skill_name`: string, `params`: object | 定義済みSkillの実行。 |
+| `run_skill` | `skill_name`: string, `params`: object | 起動時に `config.toml` の `[skills].files` から全件検証・登録されたSkillの実行。 |
 | `get_usage_report` | なし | 現在のplan tier、usage meters、audit-retention snapshotを返す。 |
 | `extract` | `rule_name`: string または `inline`: object | Deep Lens抽出を実行し、`result` と `security_flags` を返す。 |
 <!-- mcp-tool-list:end -->

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,7 @@ The CI pipeline is defined in `.github/workflows/`.
 
 - **Goal**: Provide a single dashboard that verifies the main Dragon Head feature areas across `core-runtime`, `mcp-server`, `skills-engine`, `plugin-host`, and `marketplace`.
 - **Modes**:
-- `smoke`: Required on PRs. Covers representative scenarios for state capture, action recovery, wait semantics, policy/HITL, audit/session, MCP flow (including visual image content delivery), skill execution, plugin validation, and marketplace accounting.
+- `smoke`: Required on PRs. Covers representative scenarios for state capture, action recovery, wait semantics, policy/HITL, audit/session, MCP flow (including visual image content delivery and standalone configured-skill loading), skill execution, plugin validation, and marketplace accounting.
   - `full`: Runs on nightly/manual workflows. Uses the same report format and is reserved for expanded scenario sets and longer-running variants.
 - **Artifacts**:
   - JSON reports: `target/evaluation-bench/*.json`

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 base64 = "0.22"
 core-runtime = { path = "../core-runtime" }
 json-patch = "4.2"
+libc = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 skills-engine = { path = "../skills-engine" }
@@ -26,7 +27,6 @@ path = "src/main.rs"
 [dev-dependencies]
 escargot = "0.5"
 json-patch = "4.2"
-libc = "0.2"
 tempfile = "3.10"
 tokio = { workspace = true }
 urlencoding = "2.1"

--- a/mcp-server/src/cli.rs
+++ b/mcp-server/src/cli.rs
@@ -14,6 +14,10 @@ FLAGS:
     -V, --version     Print version information and exit
     -h, --help        Print this help message and exit
 
+CONFIGURATION:
+    config.toml [skills].files loads validated JSON skill definitions.
+    Relative skill paths resolve from the config.toml directory.
+
 With no flags, starts the stdio MCP server.";
 
 /// The action requested via command-line arguments.

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -7,8 +7,11 @@
 
 use core_runtime::PromptInjectionMode;
 use serde::Deserialize;
+use skills_engine::{parse_skill_definition, validate_skill_definition, SkillDefinition};
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::Read,
     path::{Path, PathBuf},
 };
 
@@ -38,6 +41,8 @@ pub const HONORED_CONFIG_ENV_VARS: &[&str] = &[
 pub const MAX_ADDITIONAL_PHRASES: usize = 64;
 pub const MAX_ADDITIONAL_PHRASE_BYTES: usize = 512;
 pub const MAX_ADDITIONAL_PHRASES_BYTES: usize = 8 * 1024;
+pub const MAX_SKILL_FILES: usize = 64;
+pub const MAX_SKILL_FILE_BYTES: usize = 1024 * 1024;
 
 /// Raw `config.toml` contents.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -51,6 +56,8 @@ pub struct FileConfig {
     pub navigation: NavigationFileConfig,
     #[serde(default)]
     pub audit: AuditFileConfig,
+    #[serde(default)]
+    pub skills: SkillsFileConfig,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
@@ -85,6 +92,13 @@ pub struct AuditFileConfig {
     pub durability: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct SkillsFileConfig {
+    /// JSON files containing one `SkillDefinition` each.
+    #[serde(default)]
+    pub files: Vec<String>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("failed to read config file {path}: {source}")]
@@ -116,6 +130,68 @@ pub enum ConfigError {
     AdditionalPhrasesTooLarge { max_bytes: usize },
     #[error("environment variable {name} is not valid UTF-8")]
     NonUnicodeEnvVar { name: &'static str },
+    #[error("too many configured skill files (maximum {max})")]
+    TooManySkillFiles { max: usize },
+    #[error("failed to read skill file {path}: {source}")]
+    SkillFileIo {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("skill file {path} exceeds {max_bytes} bytes")]
+    SkillFileTooLarge { path: PathBuf, max_bytes: usize },
+    #[error("skill file {path} is not a regular file")]
+    SkillFileNotRegular { path: PathBuf },
+    #[error("failed to parse skill file {path} as JSON: {source}")]
+    SkillFileJson {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("invalid skill definition in {path}: {reason}")]
+    InvalidSkillDefinition { path: PathBuf, reason: String },
+    #[error("duplicate skill name in {path}; first defined in {first_path}")]
+    DuplicateSkillName { path: PathBuf, first_path: PathBuf },
+}
+
+#[cfg(unix)]
+fn open_regular_skill_file(path: &Path) -> Result<(File, std::fs::Metadata), ConfigError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|source| ConfigError::SkillFileIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    regular_skill_file_metadata(path, file)
+}
+
+#[cfg(not(unix))]
+fn open_regular_skill_file(path: &Path) -> Result<(File, std::fs::Metadata), ConfigError> {
+    let file = File::open(path).map_err(|source| ConfigError::SkillFileIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    regular_skill_file_metadata(path, file)
+}
+
+fn regular_skill_file_metadata(
+    path: &Path,
+    file: File,
+) -> Result<(File, std::fs::Metadata), ConfigError> {
+    let metadata = file.metadata().map_err(|source| ConfigError::SkillFileIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(ConfigError::SkillFileNotRegular {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok((file, metadata))
 }
 
 pub fn validate_unicode_additional_phrases_env() -> Result<(), ConfigError> {
@@ -178,6 +254,83 @@ pub fn load_config_file(path: &Path) -> Result<Option<FileConfig>, ConfigError> 
             path: path.to_path_buf(),
             details: err,
         })
+}
+
+/// Loads every configured JSON skill definition with bounded I/O and validates the complete
+/// set before returning it. Relative paths are resolved from the actual `config.toml` parent.
+/// Callers can therefore register the returned definitions atomically after this function
+/// succeeds; no backend is mutated on a partial failure.
+pub fn load_configured_skills(
+    config_path: Option<&Path>,
+    file_config: Option<&FileConfig>,
+) -> Result<Vec<SkillDefinition>, ConfigError> {
+    let files = file_config
+        .map(|config| config.skills.files.as_slice())
+        .unwrap_or_default();
+    if files.len() > MAX_SKILL_FILES {
+        return Err(ConfigError::TooManySkillFiles {
+            max: MAX_SKILL_FILES,
+        });
+    }
+
+    let config_dir = config_path
+        .and_then(Path::parent)
+        .unwrap_or_else(|| Path::new("."));
+    let mut skills = Vec::with_capacity(files.len());
+    let mut names = HashMap::<String, PathBuf>::new();
+
+    for configured_path in files {
+        let configured_path = Path::new(configured_path);
+        let path = if configured_path.is_absolute() {
+            configured_path.to_path_buf()
+        } else {
+            config_dir.join(configured_path)
+        };
+
+        let (file, metadata) = open_regular_skill_file(&path)?;
+        if metadata.len() > MAX_SKILL_FILE_BYTES as u64 {
+            return Err(ConfigError::SkillFileTooLarge {
+                path,
+                max_bytes: MAX_SKILL_FILE_BYTES,
+            });
+        }
+
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.take((MAX_SKILL_FILE_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(|source| ConfigError::SkillFileIo {
+                path: path.clone(),
+                source,
+            })?;
+        if bytes.len() > MAX_SKILL_FILE_BYTES {
+            return Err(ConfigError::SkillFileTooLarge {
+                path,
+                max_bytes: MAX_SKILL_FILE_BYTES,
+            });
+        }
+
+        let value =
+            serde_json::from_slice(&bytes).map_err(|source| ConfigError::SkillFileJson {
+                path: path.clone(),
+                source,
+            })?;
+        let skill =
+            parse_skill_definition(&value).map_err(|_| ConfigError::InvalidSkillDefinition {
+                path: path.clone(),
+                reason: "schema validation failed".to_string(),
+            })?;
+        validate_skill_definition(&skill).map_err(|_| ConfigError::InvalidSkillDefinition {
+            path: path.clone(),
+            reason: "semantic validation failed".to_string(),
+        })?;
+
+        if let Some(first_path) = names.insert(skill.name.clone(), path.clone()) {
+            return Err(ConfigError::DuplicateSkillName { path, first_path });
+        }
+        skills.push(skill);
+    }
+
+    Ok(skills)
 }
 
 /// Effective configuration after merging `file_config` with environment-variable overrides.
@@ -419,6 +572,7 @@ durability = "sync"
                     max_bytes: Some(1_048_576),
                     durability: Some("sync".to_string()),
                 },
+                skills: SkillsFileConfig::default(),
             }
         );
     }
@@ -436,6 +590,7 @@ durability = "sync"
         assert_eq!(config.policy, PolicyFileConfig::default());
         assert_eq!(config.navigation, NavigationFileConfig::default());
         assert_eq!(config.audit, AuditFileConfig::default());
+        assert_eq!(config.skills, SkillsFileConfig::default());
     }
 
     #[test]
@@ -474,6 +629,226 @@ durability = "sync"
         let config = load_config_file(&path).unwrap().unwrap();
 
         assert!(config.navigation.allow_private_network);
+    }
+
+    #[test]
+    fn load_config_file_parses_skill_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(
+            &dir,
+            "[skills]\nfiles = [\"skills/checkout.json\", \"/opt/skills/search.json\"]",
+        );
+
+        let config = load_config_file(&path).unwrap().unwrap();
+
+        assert_eq!(
+            config.skills.files,
+            vec!["skills/checkout.json", "/opt/skills/search.json"]
+        );
+    }
+
+    fn write_skill(path: &Path, name: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            path,
+            serde_json::json!({
+                "schema_version": 1,
+                "name": name,
+                "steps": [{"type": "locate", "query": "id:1"}]
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn configured_skills_resolve_relative_to_config_and_keep_absolute_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config/dragon-head/config.toml");
+        let relative = config_path.parent().unwrap().join("skills/relative.json");
+        let absolute = dir.path().join("absolute.json");
+        write_skill(&relative, "relative");
+        write_skill(&absolute, "absolute");
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![
+                    "skills/relative.json".to_string(),
+                    absolute.display().to_string(),
+                ],
+            },
+            ..Default::default()
+        };
+
+        let skills = load_configured_skills(Some(&config_path), Some(&config)).unwrap();
+
+        assert_eq!(
+            skills
+                .iter()
+                .map(|skill| skill.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["relative", "absolute"]
+        );
+    }
+
+    #[test]
+    fn configured_skills_reject_too_many_files_before_opening_them() {
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: (0..=MAX_SKILL_FILES)
+                    .map(|index| format!("missing-{index}.json"))
+                    .collect(),
+            },
+            ..Default::default()
+        };
+
+        let error = load_configured_skills(None, Some(&config)).unwrap_err();
+
+        assert!(matches!(error, ConfigError::TooManySkillFiles { .. }));
+    }
+
+    #[test]
+    fn configured_skills_reject_oversized_file_without_parsing_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_path = dir.path().join("oversized.json");
+        std::fs::write(&skill_path, vec![b'x'; MAX_SKILL_FILE_BYTES + 1]).unwrap();
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![skill_path.display().to_string()],
+            },
+            ..Default::default()
+        };
+
+        let error = load_configured_skills(None, Some(&config)).unwrap_err();
+
+        assert!(matches!(error, ConfigError::SkillFileTooLarge { .. }));
+        assert!(error.to_string().contains("oversized.json"));
+        assert!(!error.to_string().contains(&"x".repeat(32)));
+    }
+
+    #[test]
+    fn configured_skills_validate_semantics_before_returning_any_definition() {
+        let dir = tempfile::tempdir().unwrap();
+        let valid = dir.path().join("valid.json");
+        let invalid = dir.path().join("invalid.json");
+        write_skill(&valid, "valid");
+        std::fs::write(
+            &invalid,
+            serde_json::json!({
+                "schema_version": 1,
+                "name": "invalid",
+                "steps": [{
+                    "type": "locate",
+                    "query": "id:1",
+                    "control": {"on_success": "missing-step"}
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![valid.display().to_string(), invalid.display().to_string()],
+            },
+            ..Default::default()
+        };
+
+        let error = load_configured_skills(None, Some(&config)).unwrap_err();
+
+        assert!(matches!(error, ConfigError::InvalidSkillDefinition { .. }));
+        assert!(error.to_string().contains("invalid.json"));
+        assert!(!error.to_string().contains("\"steps\""));
+        assert!(!error.to_string().contains("missing-step"));
+    }
+
+    #[test]
+    fn configured_skills_reject_schema_errors_without_disclosing_definition_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let invalid = dir.path().join("invalid-schema.json");
+        let secret = "definition-secret-token";
+        std::fs::write(
+            &invalid,
+            serde_json::json!({
+                "schema_version": 1,
+                "name": "invalid",
+                "steps": [{"type": secret, "query": "id:1"}]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![invalid.display().to_string()],
+            },
+            ..Default::default()
+        };
+
+        let error = load_configured_skills(None, Some(&config)).unwrap_err();
+
+        assert!(matches!(error, ConfigError::InvalidSkillDefinition { .. }));
+        assert!(error.to_string().contains("invalid-schema.json"));
+        assert!(!error.to_string().contains(secret));
+        assert!(!error.to_string().contains("id:1"));
+    }
+
+    #[test]
+    fn configured_skills_reject_duplicate_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.json");
+        let second = dir.path().join("second.json");
+        let secret = "duplicate-definition-secret";
+        write_skill(&first, secret);
+        write_skill(&second, secret);
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![first.display().to_string(), second.display().to_string()],
+            },
+            ..Default::default()
+        };
+
+        let error = load_configured_skills(None, Some(&config)).unwrap_err();
+
+        assert!(matches!(error, ConfigError::DuplicateSkillName { .. }));
+        assert!(error.to_string().contains("first.json"));
+        assert!(error.to_string().contains("second.json"));
+        assert!(!error.to_string().contains(secret));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_skills_reject_fifo_without_blocking() {
+        use std::{os::unix::ffi::OsStrExt, sync::mpsc, time::Duration};
+
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("skill.fifo");
+        let path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `path` is a live, NUL-terminated CString and the mode is valid.
+        let result = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+        let config = FileConfig {
+            skills: SkillsFileConfig {
+                files: vec![fifo.display().to_string()],
+            },
+            ..Default::default()
+        };
+        let (sender, receiver) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            sender
+                .send(load_configured_skills(None, Some(&config)))
+                .ok();
+        });
+
+        let result = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("FIFO validation blocked");
+        let error = result.unwrap_err();
+        assert!(matches!(error, ConfigError::SkillFileNotRegular { .. }));
+        assert!(error.to_string().contains("skill.fifo"));
     }
 
     // --- resolve_config ---
@@ -559,6 +934,7 @@ durability = "sync"
                 max_bytes: Some(2048),
                 durability: Some("sync".to_string()),
             },
+            skills: SkillsFileConfig::default(),
         };
         let resolved = resolve_config(Some(&fc), no_env).unwrap();
         assert_eq!(resolved.chrome_path, Some("/usr/bin/chromium".to_string()));
@@ -593,6 +969,7 @@ durability = "sync"
                 max_bytes: Some(2048),
                 durability: Some("sync".to_string()),
             },
+            skills: SkillsFileConfig::default(),
         };
         let resolved = resolve_config(Some(&fc), |key| match key {
             "CHROME_PATH" => Some("/opt/chrome".to_string()),

--- a/mcp-server/src/doctor.rs
+++ b/mcp-server/src/doctor.rs
@@ -132,10 +132,15 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
         return (false, format!("{label} — {err}"), false);
     }
 
+    let skills = match config::load_configured_skills(path.as_deref(), file_config.as_ref()) {
+        Ok(skills) => skills,
+        Err(err) => return (false, format!("{label} — {err}"), false),
+    };
+
     let summary = format!(
         "chrome_path={}, prompt_injection.mode={:?}, \
          prompt_injection.additional_phrases={}, policy.file={}, \
-         navigation.allow_private_network={}, supported_env=[{}]",
+         navigation.allow_private_network={}, skills.loaded={}, supported_env=[{}]",
         resolved.chrome_path.as_deref().unwrap_or("<unset>"),
         resolved.injection_mode,
         resolved.injection_additional_phrases.len(),
@@ -145,6 +150,7 @@ fn config_file_detail_with(lookup: impl Fn(&str) -> Option<String>) -> (bool, St
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "<unset>".to_string()),
         resolved.navigation_allow_private_network,
+        skills.len(),
         config::HONORED_CONFIG_ENV_VARS.join(","),
     );
 
@@ -353,6 +359,63 @@ mod tests {
             detail.contains("prompt_injection.mode=Redact"),
             "detail: {detail}"
         );
+    }
+
+    #[test]
+    fn config_check_loads_relative_skill_files_with_shared_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        let dragon_head_dir = dir.path().join("dragon-head");
+        let skill_dir = dragon_head_dir.join("skills");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("doctor.json"),
+            r#"{"schema_version":1,"name":"doctor-skill","steps":[{"type":"locate","query":"id:1"}]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dragon_head_dir.join("config.toml"),
+            "[skills]\nfiles = [\"skills/doctor.json\"]",
+        )
+        .unwrap();
+        let xdg = dir.path().to_string_lossy().to_string();
+
+        let (passed, detail, informational) = config_file_detail_with(|key| match key {
+            "XDG_CONFIG_HOME" => Some(xdg.clone()),
+            _ => None,
+        });
+
+        assert!(passed, "detail: {detail}");
+        assert!(informational);
+        assert!(detail.contains("skills.loaded=1"), "detail: {detail}");
+    }
+
+    #[test]
+    fn config_check_rejects_invalid_skill_without_disclosing_definition() {
+        let dir = tempfile::tempdir().unwrap();
+        let dragon_head_dir = dir.path().join("dragon-head");
+        std::fs::create_dir_all(&dragon_head_dir).unwrap();
+        let secret = "doctor-skill-definition-secret";
+        std::fs::write(
+            dragon_head_dir.join("invalid.json"),
+            format!(r#"{{"schema_version":1,"name":"{secret}","steps":[]}}"#),
+        )
+        .unwrap();
+        std::fs::write(
+            dragon_head_dir.join("config.toml"),
+            "[skills]\nfiles = [\"invalid.json\"]",
+        )
+        .unwrap();
+        let xdg = dir.path().to_string_lossy().to_string();
+
+        let (passed, detail, informational) = config_file_detail_with(|key| match key {
+            "XDG_CONFIG_HOME" => Some(xdg.clone()),
+            _ => None,
+        });
+
+        assert!(!passed);
+        assert!(!informational);
+        assert!(detail.contains("invalid.json"), "detail: {detail}");
+        assert!(!detail.contains(secret), "detail: {detail}");
     }
 
     #[test]

--- a/mcp-server/src/init.rs
+++ b/mcp-server/src/init.rs
@@ -43,7 +43,7 @@ pub fn print_init(client: Option<&str>) -> bool {
 
 fn print_config_note() {
     println!("# Optional: ~/.config/dragon-head/config.toml can set chrome_path,");
-    println!("# prompt_injection.mode/additional_phrases, policy.file, and [audit]");
+    println!("# prompt_injection.mode/additional_phrases, policy.file, [audit], and skills.files");
     println!("# (log_dir/max_bytes/durability). See README.md#configuration-configtoml.");
 }
 

--- a/mcp-server/src/main.rs
+++ b/mcp-server/src/main.rs
@@ -98,6 +98,8 @@ fn main() -> anyhow::Result<()> {
         .context("failed to resolve dragon-head-mcp configuration")?;
     let resolved = config::resolve_config(file_config.as_ref(), env_lookup)
         .context("failed to resolve dragon-head-mcp configuration")?;
+    let skills = config::load_configured_skills(config_path.as_deref(), file_config.as_ref())
+        .context("failed to load configured skills")?;
 
     if resolved.injection_mode != PromptInjectionMode::ReportOnly {
         eprintln!(
@@ -139,6 +141,9 @@ fn main() -> anyhow::Result<()> {
         additional_phrases: resolved.injection_additional_phrases.clone(),
     });
     backend.set_navigation_allow_private_network(resolved.navigation_allow_private_network);
+    for skill in skills {
+        backend.register_skill(skill);
+    }
     let mut server = McpServer::new(backend);
     eprintln!("dragon-head-mcp: ready, listening on stdio");
 

--- a/mcp-server/tests/comprehensive_evaluation.rs
+++ b/mcp-server/tests/comprehensive_evaluation.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 use core_runtime::{ApprovalScope, BrowserClient, PolicyAction, PolicyRule};
-use mcp_server::{AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier};
+use mcp_server::{
+    config, AuditRetentionSnapshot, CoreRuntimeBackend, McpBackend, McpServer, PlanTier,
+};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use test_bench_support::{EvaluationBench, EvaluationMode};
@@ -45,6 +47,11 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "visual",
         scenario_visual_image_content_contract,
     );
+    bench.run_scenario(
+        "configured_skill_loading_contract",
+        "skills",
+        scenario_configured_skill_loading_contract,
+    );
 
     bench.write_if_configured()?;
     bench.assert_required_scenarios(&[
@@ -54,10 +61,33 @@ fn test_mcp_server_comprehensive_evaluation_suite() -> Result<()> {
         "delta_delivery_full_seeds_baseline",
         "navigate_contract_and_metering",
         "visual_image_content_contract",
+        "configured_skill_loading_contract",
     ])?;
     bench.assert_all_passed()?;
 
     Ok(())
+}
+
+fn scenario_configured_skill_loading_contract() -> Result<Value> {
+    let dir = tempfile::tempdir()?;
+    let config_path = dir.path().join("config.toml");
+    let skills_dir = dir.path().join("skills");
+    std::fs::create_dir_all(&skills_dir)?;
+    std::fs::write(
+        skills_dir.join("relative.json"),
+        r#"{"schema_version":1,"name":"evaluation-skill","steps":[{"type":"extract","key":"body","selector":"body"}]}"#,
+    )?;
+    std::fs::write(&config_path, "[skills]\nfiles = [\"skills/relative.json\"]")?;
+
+    let file_config = config::load_config_file(&config_path)?.context("config file")?;
+    let skills = config::load_configured_skills(Some(&config_path), Some(&file_config))?;
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].name, "evaluation-skill");
+
+    Ok(json!({
+        "loaded": skills.len(),
+        "name": skills[0].name
+    }))
 }
 
 fn scenario_visual_image_content_contract() -> Result<Value> {

--- a/mcp-server/tests/mcp_binary_e2e.rs
+++ b/mcp-server/tests/mcp_binary_e2e.rs
@@ -449,6 +449,194 @@ fn binary_rejects_malformed_config_without_disclosing_phrase_contents() -> anyho
 }
 
 #[test]
+fn binary_doctor_and_startup_reject_invalid_skill_without_disclosure() -> anyhow::Result<()> {
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let dragon_head_dir = dir.path().join("dragon-head");
+    std::fs::create_dir_all(&dragon_head_dir)?;
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        "[skills]\nfiles = [\"invalid.json\"]",
+    )?;
+
+    let cases = [
+        (
+            "standalone-skill-definition-secret",
+            json!({"schema_version": 1, "name": "invalid", "steps": []}),
+        ),
+        (
+            "schema-definition-secret-token",
+            json!({
+                "schema_version": 1,
+                "name": "invalid",
+                "steps": [{"type": "schema-definition-secret-token", "query": "id:1"}]
+            }),
+        ),
+        (
+            "branch-definition-secret-token",
+            json!({
+                "schema_version": 1,
+                "name": "invalid",
+                "steps": [{
+                    "type": "locate",
+                    "id": "branch-source-secret-token",
+                    "query": "id:1",
+                    "control": {"on_success": "branch-definition-secret-token"}
+                }]
+            }),
+        ),
+        (
+            "duplicate-step-secret-token",
+            json!({
+                "schema_version": 1,
+                "name": "invalid",
+                "steps": [
+                    {"type": "locate", "id": "duplicate-step-secret-token", "query": "id:1"},
+                    {"type": "locate", "id": "duplicate-step-secret-token", "query": "id:2"}
+                ]
+            }),
+        ),
+    ];
+
+    for (secret, definition) in cases {
+        std::fs::write(
+            dragon_head_dir.join("invalid.json"),
+            serde_json::to_vec(&definition)?,
+        )?;
+        for args in [&["--doctor"][..], &[][..]] {
+            let out = Command::new(&bin)
+                .args(args)
+                .env("XDG_CONFIG_HOME", dir.path())
+                .output()?;
+
+            assert!(!out.status.success());
+            if args.is_empty() {
+                assert!(out.stdout.is_empty(), "stdout must remain JSON-RPC clean");
+            } else {
+                assert!(String::from_utf8_lossy(&out.stdout).contains("✗ Config file"));
+            }
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert!(combined.contains("invalid.json"), "combined: {combined}");
+            assert!(!combined.contains(secret), "combined: {combined}");
+            assert!(!combined.contains("\"steps\""), "combined: {combined}");
+            assert!(
+                !combined.contains("ready, listening"),
+                "combined: {combined}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn binary_doctor_and_startup_reject_duplicate_skill_names_without_disclosure() -> anyhow::Result<()>
+{
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let dragon_head_dir = dir.path().join("dragon-head");
+    std::fs::create_dir_all(&dragon_head_dir)?;
+    let secret = "duplicate-skill-name-secret-token";
+    let definition = json!({
+        "schema_version": 1,
+        "name": secret,
+        "steps": [{"type": "locate", "query": "id:1"}]
+    });
+    std::fs::write(
+        dragon_head_dir.join("first.json"),
+        serde_json::to_vec(&definition)?,
+    )?;
+    std::fs::write(
+        dragon_head_dir.join("second.json"),
+        serde_json::to_vec(&definition)?,
+    )?;
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        "[skills]\nfiles = [\"first.json\", \"second.json\"]",
+    )?;
+
+    for args in [&["--doctor"][..], &[][..]] {
+        let out = Command::new(&bin)
+            .args(args)
+            .env("XDG_CONFIG_HOME", dir.path())
+            .output()?;
+        assert!(!out.status.success());
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(combined.contains("first.json"), "combined: {combined}");
+        assert!(combined.contains("second.json"), "combined: {combined}");
+        assert!(!combined.contains(secret), "combined: {combined}");
+        assert!(
+            !combined.contains("ready, listening"),
+            "combined: {combined}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn binary_doctor_and_startup_reject_fifo_without_blocking() -> anyhow::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bin = build_binary_once()?;
+    let dir = tempfile::tempdir()?;
+    let dragon_head_dir = dir.path().join("dragon-head");
+    std::fs::create_dir_all(&dragon_head_dir)?;
+    let fifo = dragon_head_dir.join("skill.fifo");
+    let fifo_c = std::ffi::CString::new(fifo.as_os_str().as_bytes())?;
+    // SAFETY: `fifo_c` is a live, NUL-terminated CString and the mode is valid.
+    let result = unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) };
+    assert_eq!(
+        result,
+        0,
+        "mkfifo failed: {}",
+        std::io::Error::last_os_error()
+    );
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        "[skills]\nfiles = [\"skill.fifo\"]",
+    )?;
+
+    for args in [&["--doctor"][..], &[][..]] {
+        let mut child = Command::new(&bin)
+            .args(args)
+            .env("XDG_CONFIG_HOME", dir.path())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let status = loop {
+            if let Some(status) = child.try_wait()? {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                child.kill()?;
+                child.wait()?;
+                anyhow::bail!("configured FIFO blocked startup/doctor");
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+        assert!(!status.success());
+        let mut combined = String::new();
+        child.stdout.take().unwrap().read_to_string(&mut combined)?;
+        child.stderr.take().unwrap().read_to_string(&mut combined)?;
+        assert!(combined.contains("skill.fifo"), "combined: {combined}");
+        assert!(
+            !combined.contains("ready, listening"),
+            "combined: {combined}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn binary_doctor_rejects_invalid_additional_phrase_env_without_disclosure() -> anyhow::Result<()> {
     let bin = build_binary_once()?;
     let dir = tempfile::tempdir()?;
@@ -918,6 +1106,71 @@ fn test_mcp_binary_get_visual_returns_png_for_clean_and_som() -> anyhow::Result<
     let stderr = stderr_reader.join().expect("stderr reader panicked");
     assert!(!stderr.contains("iVBOR"), "base64 image leaked to stderr");
     fixture.join().expect("fixture thread panicked")?;
+    Ok(())
+}
+
+#[test]
+#[ignore = "requires Chrome; starts a real browser process"]
+fn test_mcp_binary_loads_relative_skill_and_completes_run_skill() -> anyhow::Result<()> {
+    if should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let bin_path = build_binary_once()?;
+    let config_home = tempfile::tempdir()?;
+    let dragon_head_dir = config_home.path().join("dragon-head");
+    let skills_dir = dragon_head_dir.join("skills");
+    std::fs::create_dir_all(&skills_dir)?;
+    std::fs::write(
+        skills_dir.join("relative.json"),
+        r#"{"schema_version":1,"name":"relative-extract","steps":[{"type":"extract","id":"read-body","key":"body","selector":"body"}]}"#,
+    )?;
+    std::fs::write(
+        dragon_head_dir.join("config.toml"),
+        "[skills]\nfiles = [\"skills/relative.json\"]",
+    )?;
+
+    let mut child = Command::new(&bin_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut reader = BufReader::new(stdout);
+    mcp_handshake(&mut stdin, &mut reader)?;
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "run_skill",
+                "arguments": {"skill_name": "relative-extract", "params": {}}
+            }
+        })
+    )?;
+    stdin.flush()?;
+
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let response: Value = serde_json::from_str(&line)?;
+    assert_eq!(
+        response["result"]["structuredContent"]["status"],
+        "completed"
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["trace"][0]["step_id"],
+        "read-body"
+    );
+
+    drop(stdin);
+    let status = child.wait()?;
+    assert!(status.success(), "dragon-head-mcp exited with {status}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add `[skills].files` to load JSON `SkillDefinition` files before stdio readiness
- resolve relative paths from `config.toml`, validate the complete set, and register only after all definitions pass
- share validation with `--doctor`, document limits, and add real-binary `run_skill` coverage
- reject non-regular files without blocking and sanitize definition-validation diagnostics

Closes #247

## Exit criteria
- [x] documented standalone configuration for one or more skill definitions
- [x] startup and `--doctor` validate before readiness with no partial registration
- [x] binary-level real Chrome MCP test completes a configured `run_skill`
- [x] existing top-level audit, policy, billing, and usage-metering paths remain intact

## Verification
- `cargo test -p mcp-server` — 243 passed, 5 ignored
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- standalone real Chrome configured-skill E2E — 1 passed
- run_skill audit — 1 passed
- usage metering — 8 passed
- billing/plan gating — 7 passed
- comprehensive evaluation — 1 passed
- `cargo deny check` — passed with existing warnings

`cargo audit` reports the same five advisories present on `origin/main`: `quinn-proto 0.11.14` and four `rustls-webpki 0.103.9` advisories. Dependency upgrades are intentionally outside this PR.

## Review and QA
- pre-landing contract/security/test reviews found two P2 issues: attacker-controlled validation values could reach diagnostics, and FIFO paths could block startup
- fixed both with stable sanitized categories, path-only duplicate diagnostics, nonblocking open plus opened-handle regular-file validation, and startup/doctor regression tests
- follow-up read-only review found no remaining P1/P2
- report-only QA covered startup/doctor parity, relative and absolute paths, count/size/schema/semantic/duplicate/non-regular failures, atomic registration, readiness ordering, non-disclosure, real stdio `run_skill`, audit, policy, and metering
- no unresolved material findings