### PR TITLE
fix: exempt small binary fixtures from LFS and guard against drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,9 @@
 **/tests/fixtures/**/*.webp filter=lfs diff=lfs merge=lfs -text
 **/tests/fixtures/**/*.gif filter=lfs diff=lfs merge=lfs -text
 **/tests/fixtures/**/*.bin filter=lfs diff=lfs merge=lfs -text
+
+# Exceptions: files matched by the LFS globs above but below the ~500 KB threshold.
+# Keeping these as plain git blobs avoids a permanent false-dirty `git status`/`git diff`
+# (the LFS clean filter would otherwise compare a smudged pointer against the raw blob).
+# See docs/testing.md 3.3 and ISSUE-251.
+core-runtime/tests/fixtures/som/som_visual_baseline.png -filter -diff -merge -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Run clippy
       run: cargo clippy --workspace -- -D warnings
+    - name: Verify LFS-tracked fixtures are real LFS pointers
+      run: scripts/check_lfs_fixtures.sh
 
   security-audit:
     runs-on: ubuntu-latest

--- a/docs/FILE_GUIDE.md
+++ b/docs/FILE_GUIDE.md
@@ -160,6 +160,6 @@
 | `target/**` | Build output | Do not commit |
 | `core-runtime/target/nfr-dashboard*.md` | Benchmark output | Do not commit |
 | `nfr-baseline/*.json` | Baseline data | Update only via script |
-| `core-runtime/tests/fixtures/som/som_visual_baseline.png` | Git LFS fixture | Do not mix into docs-only PRs |
+| `core-runtime/tests/fixtures/som/som_visual_baseline.png` | Binary fixture (plain git blob, below the ~500 KB LFS threshold — see `.gitattributes` exception) | Do not mix into docs-only PRs |
 | `.config/nextest.toml` | nextest profiles | `ci` does not inherit from `default` |
 | `deny.toml` | cargo-deny config | Add rationale for advisory exceptions |

--- a/scripts/check_lfs_fixtures.sh
+++ b/scripts/check_lfs_fixtures.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Verify every file matched by an LFS glob in .gitattributes is actually stored as a
+# real Git LFS pointer in HEAD, not a raw blob.
+#
+# Background (ISSUE-251): a fixture can end up declared as `filter=lfs` in
+# .gitattributes without ever being migrated (e.g. the glob was added/fixed after the
+# file was first committed). Git then applies the LFS "clean" filter to the working-tree
+# file for every `git status`/`git diff`, producing a small pointer-text blob that never
+# matches the raw binary blob still sitting in the index — a permanent false-dirty diff
+# that has nothing to do with the file's actual (correct) content.
+#
+# This script catches that class of bug at commit/CI time, before it reaches `main`.
+#
+# Usage:
+#   scripts/check_lfs_fixtures.sh
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Only validate files whose *resolved* filter attribute is "lfs" — this respects any
+# per-path .gitattributes exceptions (e.g. `-filter`) that opt a small file back out of
+# LFS tracking, rather than re-matching the same glob pattern text.
+status=0
+checked=0
+
+while IFS= read -r -d '' file; do
+  resolved_filter="$(git check-attr filter -- "${file}" | sed 's/.*: filter: //')"
+  if [ "${resolved_filter}" != "lfs" ]; then
+    continue
+  fi
+  checked=$((checked + 1))
+  first_line="$(git cat-file -p "HEAD:${file}" 2>/dev/null | head -c 7 || true)"
+  if [ "${first_line}" != "version" ]; then
+    echo "error: '${file}' resolves to filter=lfs but is not a valid LFS pointer in HEAD" >&2
+    echo "  fix: either 'git lfs track \"${file}\" && git add \"${file}\"' to migrate it," >&2
+    echo "       or add a .gitattributes exception ('-filter -diff -merge -text') if it's under the ~500 KB LFS threshold" >&2
+    status=1
+  fi
+done < <(git ls-files -z)
+
+if [ "${status}" -eq 0 ]; then
+  echo "ok: ${checked} LFS-tracked file(s) verified as real LFS pointers"
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Summary
- The SoM visual baseline PNG matched the LFS glob in `.gitattributes` but was never actually migrated to LFS, causing a permanent false-dirty `git status`/`git diff` (LFS clean filter output compared against the raw blob in the index).
- Add a `.gitattributes` exception opting fixtures under the ~500 KB LFS threshold back out of `filter=lfs`/`diff=lfs`/`merge=lfs`.
- Add `scripts/check_lfs_fixtures.sh`, wired into `ci.yml`, which fails the build if any file that resolves to `filter=lfs` is not a real LFS pointer blob in HEAD — catches this class of bug before it reaches `main`.
- Update `docs/FILE_GUIDE.md` to describe the fixture's new (correct) tracking state.

Fixes ISSUE-251.

## Test plan
- [x] `bash -n scripts/check_lfs_fixtures.sh` — syntax check
- [x] `bash scripts/check_lfs_fixtures.sh` — runs clean locally (`ok: 0 LFS-tracked file(s) verified as real LFS pointers`)
- [x] `git status --short core-runtime/tests/fixtures/som/som_visual_baseline.png` — confirmed empty (no more false-dirty)
- [ ] CI: confirm the new `Verify LFS-tracked fixtures are real LFS pointers` step passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)