### PR TITLE
[ISSUE-256] Fix extract tool DOM property access (textContent/innerText/value)

### DIFF
--- a/plugin-host/src/schema_registry.rs
+++ b/plugin-host/src/schema_registry.rs
@@ -109,6 +109,10 @@ impl ExtractionRule {
                         "(() => {{ const el = document.querySelector({sel_json}); \
                          return el ? (el.innerText || el.textContent || '').trim() : null; }})()"
                     ),
+                    Some(attr) if is_dom_property(attr) => format!(
+                        "(() => {{ const el = document.querySelector({sel_json}); \
+                         return el ? el.{attr} : null; }})()"
+                    ),
                     Some(attr) => {
                         let attr_json =
                             serde_json::to_string(attr).unwrap_or_else(|_| "\"\"".to_string());
@@ -148,6 +152,13 @@ impl ExtractionRule {
             }
         }
     }
+}
+
+/// DOM properties that must be accessed via `.propName`, not `.getAttribute("propName")` —
+/// `getAttribute` only reads the HTML attribute string and returns null/stale values for
+/// these, since they reflect live JS-side element state.
+fn is_dom_property(attr: &str) -> bool {
+    matches!(attr, "textContent" | "innerText" | "value")
 }
 
 fn parse_fields_map(value: &Value) -> Result<HashMap<String, String>, ExtractionRuleError> {
@@ -410,6 +421,61 @@ mod tests {
         assert!(js.contains("querySelector(\".amt\")"));
         assert!(js.contains("\"price\""));
         assert!(js.contains("items.map"));
+    }
+
+    #[test]
+    fn single_rule_with_text_content_attribute_generates_property_access() {
+        let rule = ExtractionRule {
+            name: "heading".into(),
+            mode: ExtractionMode::Single {
+                selector: "h1".into(),
+                attribute: Some("textContent".into()),
+            },
+        };
+        let js = rule.to_js_script();
+        assert!(js.contains(".textContent"));
+        assert!(!js.contains("getAttribute"));
+    }
+
+    #[test]
+    fn single_rule_with_inner_text_attribute_generates_property_access() {
+        let rule = ExtractionRule {
+            name: "heading".into(),
+            mode: ExtractionMode::Single {
+                selector: "h1".into(),
+                attribute: Some("innerText".into()),
+            },
+        };
+        let js = rule.to_js_script();
+        assert!(js.contains(".innerText"));
+        assert!(!js.contains("getAttribute"));
+    }
+
+    #[test]
+    fn single_rule_with_value_attribute_generates_property_access() {
+        let rule = ExtractionRule {
+            name: "input_value".into(),
+            mode: ExtractionMode::Single {
+                selector: "input".into(),
+                attribute: Some("value".into()),
+            },
+        };
+        let js = rule.to_js_script();
+        assert!(js.contains(".value"));
+        assert!(!js.contains("getAttribute"));
+    }
+
+    #[test]
+    fn single_rule_with_href_attribute_still_uses_get_attribute() {
+        let rule = ExtractionRule {
+            name: "link".into(),
+            mode: ExtractionMode::Single {
+                selector: "a".into(),
+                attribute: Some("href".into()),
+            },
+        };
+        let js = rule.to_js_script();
+        assert!(js.contains("getAttribute(\"href\")"));
     }
 
     #[test]

--- a/plugin-host/src/schema_registry.rs
+++ b/plugin-host/src/schema_registry.rs
@@ -111,7 +111,7 @@ impl ExtractionRule {
                     ),
                     Some(attr) if is_dom_property(attr) => format!(
                         "(() => {{ const el = document.querySelector({sel_json}); \
-                         return el ? el.{attr} : null; }})()"
+                         return el ? (el.{attr} ?? null) : null; }})()"
                     ),
                     Some(attr) => {
                         let attr_json =
@@ -463,6 +463,21 @@ mod tests {
         let js = rule.to_js_script();
         assert!(js.contains(".value"));
         assert!(!js.contains("getAttribute"));
+    }
+
+    #[test]
+    fn single_rule_with_dom_property_coalesces_undefined_to_null() {
+        let rule = ExtractionRule {
+            name: "heading".into(),
+            mode: ExtractionMode::Single {
+                selector: "h1".into(),
+                attribute: Some("value".into()),
+            },
+        };
+        let js = rule.to_js_script();
+        // Elements without the requested property (e.g. `value` on a <div>) yield
+        // `undefined`, which is not valid JSON and breaks evaluate_script_json.
+        assert!(js.contains("el.value ?? null"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ExtractionRule::to_js_script()` in `plugin-host/src/schema_registry.rs` used `.getAttribute()` for every `attribute` value, including `textContent`, `innerText`, and `value` — DOM **properties**, not HTML attributes. `getAttribute("textContent")` returns `null`, so `{"selector": "h1", "attribute": "textContent"}` silently returned `null` instead of the heading text.
- Added `is_dom_property()` — an explicit whitelist of `textContent` / `innerText` / `value` — and route those through `.propName` property access, keeping `.getAttribute()` for real HTML attributes (`href`, `src`, `class`, `data-*`, `aria-*`, etc).
- Scope matches the issue exactly: only `to_js_script()`'s `Single` mode `attribute` field was affected. The `Structured` mode's `fields` map holds CSS selectors per the SPEC DSL (`items: { selector, fields: { price: ".amt" } }`), not attribute names, so it isn't affected by this bug.

Closes #256

## Test plan

- [x] Added 4 unit tests: `textContent`/`innerText`/`value` generate property access with no `getAttribute` call; `href` still uses `getAttribute("href")` (regression guard).
- [x] `cargo test -p plugin-host --lib` — 25 passed
- [x] `cargo test --workspace` — 862 passed, 11 ignored
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` — no issues
- [x] Manual review: attribute names reaching the `.{attr}` interpolation are restricted to the fixed 3-item whitelist (exact string match via `matches!`), so no JS-injection risk was introduced.
- [x] Reviewed for sibling code paths producing the same output (`grep getAttribute` across core-runtime/plugin-host/mcp-server/skills-engine) — no other occurrence found.