### PR TITLE
[ISSUE-261] Confirm CDP liveness before restarting on suspected disconnect

### DIFF
--- a/core-runtime/src/browser/mod.rs
+++ b/core-runtime/src/browser/mod.rs
@@ -20,7 +20,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, Mutex,
+        mpsc, Arc, Mutex,
     },
     thread,
     time::{Duration, Instant},
@@ -47,6 +47,11 @@ const NAVIGATION_FALLBACK_TIMEOUT: Duration = Duration::from_secs(3);
 const NAVIGATION_FALLBACK_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const SRE_EVENT_BRIDGE_SYMBOL: &str = "neural_browser.runtime.sre_event_bridge";
 const ACTION_LOG_BUFFER_LIMIT: usize = 256;
+/// Default bound for [`BrowserClient::confirm_alive`]'s CDP liveness probe
+/// (ISSUE-261), decoupled from headless_chrome's internal 30s
+/// `idle_browser_timeout` default so a suspected-disconnect confirmation
+/// stays fast.
+pub const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SemanticTarget {
@@ -397,11 +402,59 @@ impl BrowserClient {
         });
         Ok(page)
     }
+
+    /// Confirms whether the underlying Chrome process is truly unresponsive
+    /// by issuing a lightweight, session-independent `Browser.getVersion`
+    /// CDP call bounded by `timeout` (ISSUE-261).
+    ///
+    /// [`is_browser_disconnected`] matches error-chain markers ("broken
+    /// pipe", "connection reset", ...) that can also appear when a
+    /// *client-side* request timeout fires on a slow-but-legitimate
+    /// operation (e.g. `get_visual`'s screenshot + SoM pipeline keeping the
+    /// CDP transport busy) rather than an actual Chrome crash. This
+    /// browser-level call is independent of any specific `Tab`'s session,
+    /// so it can succeed even while a particular tab's command channel
+    /// appears stuck. Callers should treat a suspected disconnect as
+    /// confirmed only when this also returns `false`; otherwise the
+    /// original error should be propagated instead of triggering
+    /// [`relaunch`](Self::relaunch).
+    ///
+    /// Bounded independently of headless_chrome's internal 30s
+    /// `idle_browser_timeout` default via a detached probe thread and a
+    /// bounded channel receive: if the probe truly hangs past `timeout`,
+    /// its thread is intentionally left to run to completion in the
+    /// background (holding a cheap `Arc` clone of the browser handle)
+    /// rather than force-killed, since Rust has no safe thread-cancellation
+    /// primitive; each suspected disconnect spawns at most one such thread.
+    pub fn confirm_alive(&self, timeout: Duration) -> bool {
+        let browser = self.inner.clone();
+        confirm_alive_with(move || browser.get_version().is_ok(), timeout)
+    }
+}
+
+/// Test seam for [`BrowserClient::confirm_alive`]: runs `probe` on a
+/// background thread and returns its result if it completes within
+/// `timeout`, otherwise `false` (ISSUE-261).
+fn confirm_alive_with(probe: impl FnOnce() -> bool + Send + 'static, timeout: Duration) -> bool {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        // The receiver may already be gone if `rx.recv_timeout` below timed
+        // out first; ignore the send failure rather than panicking.
+        let _ = tx.send(probe());
+    });
+    rx.recv_timeout(timeout).unwrap_or(false)
 }
 
 /// Returns `true` if `err`'s error chain indicates that the underlying Chrome
 /// process disconnected (crashed, was killed, or the CDP websocket dropped),
 /// as opposed to a page-level error (ISSUE-149).
+///
+/// This marker match alone is not sufficient evidence of a genuine crash: a
+/// client-side request timeout on a slow-but-alive operation can surface the
+/// same transport-level wording (ISSUE-261). Callers that intend to restart
+/// the browser on a match should first confirm true unresponsiveness with
+/// [`BrowserClient::confirm_alive`] rather than restarting on this signal
+/// alone.
 pub fn is_browser_disconnected(err: &anyhow::Error) -> bool {
     if err.chain().any(|source| {
         source
@@ -3259,6 +3312,39 @@ mod tests {
     fn is_browser_disconnected_ignores_page_level_errors() {
         let err = anyhow::anyhow!("Could not find node with given id");
         assert!(!is_browser_disconnected(&err));
+    }
+
+    #[test]
+    fn confirm_alive_with_returns_true_when_probe_succeeds_quickly() {
+        assert!(confirm_alive_with(|| true, Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn confirm_alive_with_returns_false_when_probe_fails_quickly() {
+        assert!(!confirm_alive_with(|| false, Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn confirm_alive_with_returns_false_and_respects_bound_when_probe_hangs() {
+        // Simulates a genuinely wedged (open-but-unresponsive) CDP call:
+        // the probe never returns within the bound, so the health check
+        // must report "not confirmed alive" without blocking past
+        // `timeout`, independent of any internal transport default.
+        let timeout = Duration::from_millis(200);
+        let started = Instant::now();
+        let alive = confirm_alive_with(
+            || {
+                thread::sleep(Duration::from_secs(5));
+                true
+            },
+            timeout,
+        );
+        assert!(!alive);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "confirm_alive_with should not block past its bounded timeout, took {:?}",
+            started.elapsed()
+        );
     }
 
     #[test]

--- a/core-runtime/src/lib.rs
+++ b/core-runtime/src/lib.rs
@@ -22,7 +22,8 @@ pub use browser::{
     is_browser_disconnected, validate_public_navigation_url, validate_public_navigation_url_with,
     ActionLogEntry, BrowserClient, NavigationNetworkPolicy, NavigationValidationError, PageSession,
     SemanticTarget, SemanticWaitOptions, SemanticWaitState, SomMark, SomTrigger,
-    ValidatedNavigationUrl, VisualCapture, MAX_PUBLIC_NAVIGATION_URL_BYTES, STABLE_KEY_SHORT_LEN,
+    ValidatedNavigationUrl, VisualCapture, HEALTH_CHECK_TIMEOUT, MAX_PUBLIC_NAVIGATION_URL_BYTES,
+    STABLE_KEY_SHORT_LEN,
 };
 pub mod error;
 pub use audit_sink::DurabilityMode;

--- a/core-runtime/tests/browser_recovery.rs
+++ b/core-runtime/tests/browser_recovery.rs
@@ -65,3 +65,59 @@ fn relaunch_recovers_session_after_chrome_process_is_killed() -> anyhow::Result<
 
     Ok(())
 }
+
+/// `BrowserClient::confirm_alive` (ISSUE-261) should confirm a healthy,
+/// freshly-launched browser as alive well within its bound.
+#[test]
+fn confirm_alive_reports_true_for_healthy_browser() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    assert!(
+        client.confirm_alive(Duration::from_secs(3)),
+        "a freshly launched browser should confirm alive"
+    );
+    Ok(())
+}
+
+/// After the Chrome process is killed, `confirm_alive` should eventually
+/// report `false` (ISSUE-261) -- proving the health-check correctly
+/// distinguishes a genuine crash from a merely slow-but-alive transport.
+#[cfg(unix)]
+#[test]
+fn confirm_alive_reports_false_after_chrome_process_is_killed() -> anyhow::Result<()> {
+    if test_bench_support::should_skip_browser_tests() {
+        return Ok(());
+    }
+
+    let client = BrowserClient::new()?;
+    let _page = client.new_page()?;
+
+    let pid = client
+        .process_id()
+        .expect("launched BrowserClient should have a process id");
+    std::process::Command::new("kill")
+        .arg("-9")
+        .arg(pid.to_string())
+        .status()
+        .context("failed to signal the Chrome process")?;
+
+    // The transport's background thread needs a moment to notice the
+    // closed websocket. Bounded retry: 10 attempts / 200ms apart / 2s total,
+    // each individual health check itself bounded to 2s.
+    let mut confirmed_dead = false;
+    for _ in 0..10 {
+        if !client.confirm_alive(Duration::from_secs(2)) {
+            confirmed_dead = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert!(
+        confirmed_dead,
+        "confirm_alive should report false after the Chrome process is killed"
+    );
+    Ok(())
+}

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -143,6 +143,25 @@ pub trait McpBackend {
         Err("browser restart not supported".to_string())
     }
 
+    /// Confirms whether a suspected browser disconnect (detected via
+    /// [`core_runtime::is_browser_disconnected`]) is a genuine Chrome
+    /// crash/exit rather than a false positive caused by a client-side
+    /// request timeout on a slow-but-alive operation (ISSUE-261's
+    /// `get_visual`/`get_state` transport-busy scenario).
+    ///
+    /// Called by [`McpServer::call_tool_output`] before committing to
+    /// [`handle_browser_disconnect`](Self::handle_browser_disconnect): when
+    /// this returns `false`, the original error is returned to the caller
+    /// unchanged and no restart is performed.
+    ///
+    /// The default implementation reports "confirmed disconnected"
+    /// (`true`), preserving the prior always-restart-on-marker-match
+    /// behavior for backends without a lightweight liveness probe
+    /// available (e.g. test doubles).
+    fn confirm_browser_disconnected(&self) -> bool {
+        true
+    }
+
     /// Total number of automatic browser restarts performed so far.
     fn browser_restart_count(&self) -> u64 {
         0
@@ -306,11 +325,23 @@ impl<B: McpBackend> McpServer<B> {
 
         let result = match result {
             Err(err) if core_runtime::is_browser_disconnected(&err) => {
-                match self.backend.handle_browser_disconnect() {
-                    Ok(restart_count) => {
-                        Err(SessionError::BrowserRestarted { restart_count }.into())
+                // ISSUE-261: a marker match alone can be a false positive
+                // when a slow-but-alive operation (e.g. `get_visual`'s
+                // screenshot + SoM pipeline) causes a client-side request
+                // timeout that a later command then observes as a
+                // transport-level error. Confirm true unresponsiveness
+                // with a bounded CDP health-check before committing to a
+                // restart; if the browser answers, propagate the original
+                // error instead so it isn't misdiagnosed as a crash.
+                if self.backend.confirm_browser_disconnected() {
+                    match self.backend.handle_browser_disconnect() {
+                        Ok(restart_count) => {
+                            Err(SessionError::BrowserRestarted { restart_count }.into())
+                        }
+                        Err(reason) => Err(SessionError::BrowserRestartFailed { reason }.into()),
                     }
-                    Err(reason) => Err(SessionError::BrowserRestartFailed { reason }.into()),
+                } else {
+                    Err(err)
                 }
             }
             other => other,
@@ -1824,6 +1855,17 @@ impl McpBackend for CoreRuntimeBackend {
         self.browser_restarts
     }
 
+    fn confirm_browser_disconnected(&self) -> bool {
+        match self.client.as_ref() {
+            // No managed BrowserClient (e.g. backends constructed via
+            // `CoreRuntimeBackend::new` for tests) cannot run a liveness
+            // probe; preserve the prior always-restart-on-marker-match
+            // behavior.
+            None => true,
+            Some(client) => !client.confirm_alive(core_runtime::HEALTH_CHECK_TIMEOUT),
+        }
+    }
+
     fn speculative_usage(&self) -> (u64, u64) {
         (self.speculative_hits, self.speculative_misses)
     }
@@ -2776,6 +2818,42 @@ mod tests {
         assert!(backend.navigation_allow_private_network);
     }
 
+    /// `CoreRuntimeBackend` constructed via [`CoreRuntimeBackend::new`] has no
+    /// managed `BrowserClient` (ISSUE-261) and therefore cannot run a
+    /// liveness probe; it must preserve the prior always-restart behavior.
+    #[test]
+    fn confirm_browser_disconnected_defaults_true_without_managed_client() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let backend = CoreRuntimeBackend::new(page);
+
+        assert!(
+            backend.confirm_browser_disconnected(),
+            "without a managed BrowserClient, disconnect must be confirmed unconditionally"
+        );
+    }
+
+    /// With a managed `BrowserClient` (ISSUE-261), a healthy browser should
+    /// report as still alive, so the health check should NOT confirm a
+    /// disconnect.
+    #[test]
+    fn confirm_browser_disconnected_is_false_for_healthy_managed_client() {
+        if test_bench_support::should_skip_browser_tests() {
+            return;
+        }
+        let client = BrowserClient::new().expect("browser client");
+        let page = client.new_page().expect("new page");
+        let backend = CoreRuntimeBackend::new_with_client(client, page);
+
+        assert!(
+            !backend.confirm_browser_disconnected(),
+            "a healthy managed browser must not be confirmed as disconnected"
+        );
+    }
+
     #[test]
     fn shorten_key_truncates_64_char_sha256_to_16() {
         let full = "a".repeat(64);
@@ -3387,6 +3465,11 @@ mod tests {
         fail_get_state_with_disconnect: bool,
         disconnect_outcome: std::result::Result<u64, String>,
         browser_restarts: u64,
+        /// Controls `confirm_browser_disconnected` (ISSUE-261): when `true`,
+        /// the health check reports the browser is still alive and
+        /// `call_tool_output` must skip the restart and propagate the
+        /// original error instead.
+        confirmed_still_alive: bool,
     }
 
     impl McpBackend for RestartMockBackend {
@@ -3435,6 +3518,10 @@ mod tests {
         fn browser_restart_count(&self) -> u64 {
             self.browser_restarts
         }
+
+        fn confirm_browser_disconnected(&self) -> bool {
+            !self.confirmed_still_alive
+        }
     }
 
     #[test]
@@ -3443,6 +3530,7 @@ mod tests {
             fail_get_state_with_disconnect: true,
             disconnect_outcome: Ok(1),
             browser_restarts: 0,
+            confirmed_still_alive: false,
         });
 
         let err = server
@@ -3457,11 +3545,40 @@ mod tests {
     }
 
     #[test]
+    fn call_tool_skips_restart_when_health_check_confirms_still_alive() {
+        // ISSUE-261: a marker match on its own must not be enough to
+        // trigger a restart when the CDP health-check confirms the browser
+        // is still responsive -- the original error should propagate
+        // unchanged and `handle_browser_disconnect` must never run.
+        let mut server = McpServer::new(RestartMockBackend {
+            fail_get_state_with_disconnect: true,
+            disconnect_outcome: Ok(1),
+            browser_restarts: 0,
+            confirmed_still_alive: true,
+        });
+
+        let err = server
+            .call_tool("get_state", json!({}))
+            .expect_err("disconnect-shaped error should still propagate");
+        assert_eq!(
+            err.to_string(),
+            "connection is closed",
+            "original error should propagate unchanged when health check confirms the browser is alive"
+        );
+        assert_eq!(
+            server.backend.browser_restart_count(),
+            0,
+            "handle_browser_disconnect must not run when the health check confirms the browser is alive"
+        );
+    }
+
+    #[test]
     fn call_tool_reports_restart_failure_when_relaunch_fails() {
         let mut server = McpServer::new(RestartMockBackend {
             fail_get_state_with_disconnect: true,
             disconnect_outcome: Err("relaunch failed: Failed to launch browser".to_string()),
             browser_restarts: 0,
+            confirmed_still_alive: false,
         });
 
         let err = server
@@ -3521,6 +3638,7 @@ mod tests {
             fail_get_state_with_disconnect: false,
             disconnect_outcome: Ok(0),
             browser_restarts: 2,
+            confirmed_still_alive: false,
         });
 
         let payload = server


### PR DESCRIPTION
## Summary

- `get_visual`'s screenshot + Set-of-Marks pipeline keeps the CDP transport busy long enough that a subsequent command can hit a client-side request timeout (`MCP error -32001: Request timed out`). That timeout surfaces with the same wording (`broken pipe`, `connection reset`) `is_browser_disconnected()` uses to detect a real Chrome crash, so a still-alive browser was being restarted unnecessarily.
- Adds `BrowserClient::confirm_alive(timeout)` (`core-runtime/src/browser/mod.rs`): a lightweight, session-independent `Browser.getVersion()` CDP probe, bounded independently of headless_chrome's internal 30s `idle_browser_timeout` default via a spawned-thread + `mpsc::recv_timeout` pattern (`confirm_alive_with`, a dependency-injected free function for deterministic unit testing of the succeed/fail/hang-past-timeout cases).
- Adds `McpBackend::confirm_browser_disconnected()` (`mcp-server/src/lib.rs`), called from `McpServer::call_tool_output()`'s existing disconnect-handling branch: a restart is only attempted when this confirms the browser is truly unresponsive; otherwise the original error propagates unchanged. Default impl (`true`) preserves prior always-restart behavior for backends without a managed `BrowserClient` (e.g. test doubles, `CoreRuntimeBackend::new`-constructed backends).

## Scope / out-of-scope

- `is_browser_disconnected()`'s marker-matching body is intentionally **untouched** — that's owned by the concurrently-developed #260, which narrows the string-matching heuristics and adds a generic retry-without-restart path. Only its doc comment was extended to document composing with `confirm_alive()`.
- Issue #261 also proposed (2) per-operation timeout tuning for `get_visual`/`get_state` and (3) auditing the pinned `headless_chrome = "=1.0.21"` for macOS timeout-default bugs. Deferred: the health-check fix already resolves the reported false-restart symptom regardless of *why* the transport was busy, and touching per-call timeouts independently risks masking genuine hangs. Findings from the audit: `Browser`-level calls block up to a fixed 30s `idle_browser_timeout`; `Tab`-level calls use a separate fixed 20s `default_timeout`; no headless_chrome 1.0.21-specific macOS timeout bug was found in the vendored source. No code changes made for these two items.

Closes #261

## Test plan

- [x] `confirm_alive_with` unit tests: succeeds quickly, fails quickly, hangs past bound (asserts both the `false` result and an elapsed-time bound) — `core-runtime/src/browser/mod.rs`
- [x] `CoreRuntimeBackend::confirm_browser_disconnected` unit tests: `None` client defaults to `true`; healthy managed client reports `false` (not confirmed disconnected) — `mcp-server/src/lib.rs`
- [x] `McpServer::call_tool_output` unit tests: restart is skipped and the original error propagates when the health check confirms the browser is alive; existing restart-path tests updated and still pass — `mcp-server/src/lib.rs`
- [x] Real-Chrome integration tests (gated by `should_skip_browser_tests()`): `confirm_alive` reports `true` for a healthy browser and `false` after the Chrome process is killed — `core-runtime/tests/browser_recovery.rs`
- [x] `cargo test --workspace` (`CHROME_INSTALLED=true`): 871 passed, 11 ignored
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy --workspace -- -D warnings`: clean
- [x] `code-reviewer` agent review (gstack-review/gstack-qa skills not installed in this environment — used documented fallback): APPROVE, 0 critical/high findings; one trivial nit found and fixed in this PR (unnecessary `mut` binding in the new integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)