### PR TITLE
[ISSUE-268] Bound FlatBuffers vector preallocation to prevent OOM DoS

### DIFF
--- a/core-runtime/src/speculative/codec.rs
+++ b/core-runtime/src/speculative/codec.rs
@@ -3,63 +3,188 @@
 //! `flatc` is not available in this toolchain, so this module encodes
 //! directly with the `flatbuffers` crate's builder/reader primitives — the
 //! same low-level APIs generated code calls — rather than relying on
-//! schema codegen. The wire format is intentionally simple: a flat vector of
-//! strings where every 3 consecutive entries form one
-//! `(from_action, to_action, count)` record, with `count` written as a
-//! decimal string.
+//! schema codegen. The wire format is a small two-field table:
+//!
+//! - field 0 (`names`): a `Vector<ForwardsUOffset<&str>>` where every 2
+//!   consecutive entries form one `(from_action, to_action)` pair.
+//! - field 1 (`counts`): a `Vector<u32>`, one entry per pair, holding the
+//!   transition count as a proper integer instead of a decimal string.
+//!
+//! `decode_model` crosses a trust boundary: domain packs and other
+//! speculative-state payloads can originate outside this process (plugin
+//! hosts, imported packs, etc.), so every length and offset read from
+//! `bytes` is treated as adversarial. FlatBuffers' own verifier
+//! bounds-checks the vectors before this module touches them, but this
+//! module additionally caps its own preallocation using the physical
+//! buffer size rather than trusting a claimed vector length outright — the
+//! verifier is documented as "experimental" upstream and should not be the
+//! only line of defense against an oversized allocation.
 use super::model::ActionSignature;
-use flatbuffers::{ForwardsUOffset, Vector};
+use flatbuffers::{Follow, ForwardsUOffset, Table, VOffsetT, Vector, Verifiable, Verifier};
+
+const FIELD_NAMES: VOffsetT = 4;
+const FIELD_COUNTS: VOffsetT = 6;
+
+/// Conservative lower bound on the wire bytes required per encoded record:
+/// two `ForwardsUOffset` entries in the `names` vector (4 bytes each) plus
+/// one `u32` entry in the `counts` vector (4 bytes) — 12 bytes, ignoring the
+/// string payloads those offsets point at. Used only to derive an upper
+/// bound on preallocation, so a claimed vector length can never force an
+/// allocation larger than the input could plausibly justify.
+const MIN_BYTES_PER_RECORD: usize = 12;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SpeculativeCodecError {
     #[error("flatbuffer payload is malformed: {reason}")]
     Malformed { reason: String },
+    #[error("flatbuffer payload failed verification: {0}")]
+    InvalidFlatbuffer(#[from] flatbuffers::InvalidFlatbuffer),
+}
+
+/// Bound a preallocation size using the claimed element count together with
+/// the physical size of the source buffer, so a crafted claimed length
+/// cannot force an oversized allocation before the input has actually been
+/// walked. Kept as a standalone function so the bound itself can be
+/// exercised directly in tests without needing to hand-craft FlatBuffers
+/// bytes for every case.
+fn bounded_capacity(claimed_records: usize, buffer_len: usize) -> usize {
+    let max_plausible_records = buffer_len / MIN_BYTES_PER_RECORD;
+    claimed_records.min(max_plausible_records)
+}
+
+/// Raw (non-codegen'd) view over the two-field model table described above.
+struct ModelTable<'a> {
+    table: Table<'a>,
+}
+
+impl<'a> ModelTable<'a> {
+    fn names(&self) -> Option<Vector<'a, ForwardsUOffset<&'a str>>> {
+        // Safety: the field's type matches exactly what `run_verifier` below
+        // checked before `flatbuffers::root` ever hands back a `ModelTable`.
+        unsafe {
+            self.table
+                .get::<ForwardsUOffset<Vector<'a, ForwardsUOffset<&'a str>>>>(FIELD_NAMES, None)
+        }
+    }
+
+    fn counts(&self) -> Option<Vector<'a, u32>> {
+        // Safety: see `names` above.
+        unsafe {
+            self.table
+                .get::<ForwardsUOffset<Vector<'a, u32>>>(FIELD_COUNTS, None)
+        }
+    }
+}
+
+impl<'a> Follow<'a> for ModelTable<'a> {
+    type Inner = ModelTable<'a>;
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        ModelTable {
+            table: Table::new(buf, loc),
+        }
+    }
+}
+
+impl Verifiable for ModelTable<'_> {
+    fn run_verifier(v: &mut Verifier, pos: usize) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<ForwardsUOffset<Vector<ForwardsUOffset<&str>>>>(
+                "names",
+                FIELD_NAMES,
+                true,
+            )?
+            .visit_field::<ForwardsUOffset<Vector<u32>>>("counts", FIELD_COUNTS, true)?
+            .finish();
+        Ok(())
+    }
 }
 
 /// Encode `(from_action, to_action, count)` records into a FlatBuffers byte
 /// buffer suitable for export/import as a portable domain pack.
 pub fn encode_model(records: &[(ActionSignature, ActionSignature, u32)]) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::new();
-    let mut offsets = Vec::with_capacity(records.len() * 3);
+    let mut name_offsets = Vec::with_capacity(records.len() * 2);
+    let mut counts = Vec::with_capacity(records.len());
     for (from, to, count) in records {
-        offsets.push(builder.create_string(from.as_str()));
-        offsets.push(builder.create_string(to.as_str()));
-        offsets.push(builder.create_string(&count.to_string()));
+        name_offsets.push(builder.create_string(from.as_str()));
+        name_offsets.push(builder.create_string(to.as_str()));
+        counts.push(*count);
     }
-    let vector = builder.create_vector(&offsets);
-    builder.finish_minimal(vector);
+    let names_vector = builder.create_vector(&name_offsets);
+    let counts_vector = builder.create_vector(&counts);
+
+    let table_start = builder.start_table();
+    builder.push_slot_always(FIELD_NAMES, names_vector);
+    builder.push_slot_always(FIELD_COUNTS, counts_vector);
+    let table_end = builder.end_table(table_start);
+    builder.finish_minimal(table_end);
     builder.finished_data().to_vec()
 }
 
 /// Decode a FlatBuffers byte buffer produced by [`encode_model`] back into
 /// `(from_action, to_action, count)` records.
+///
+/// `bytes` crosses a trust boundary and is treated as adversarial input:
+/// every length is verified against the actual buffer before use, and
+/// preallocation is capped by the physical buffer size rather than by the
+/// untrusted claimed vector lengths alone.
 pub fn decode_model(
     bytes: &[u8],
 ) -> Result<Vec<(ActionSignature, ActionSignature, u32)>, SpeculativeCodecError> {
-    let vector = flatbuffers::root::<Vector<ForwardsUOffset<&str>>>(bytes).map_err(|err| {
-        SpeculativeCodecError::Malformed {
-            reason: err.to_string(),
-        }
-    })?;
+    let model = flatbuffers::root::<ModelTable>(bytes)?;
 
-    if vector.len() % 3 != 0 {
+    // `run_verifier` marks both fields required, so a successfully verified
+    // root guarantees both are present; the `ok_or_else` below is a
+    // defensive fallback, not an expected path.
+    let names = model
+        .names()
+        .ok_or_else(|| SpeculativeCodecError::Malformed {
+            reason: "missing names vector".to_string(),
+        })?;
+    let counts = model
+        .counts()
+        .ok_or_else(|| SpeculativeCodecError::Malformed {
+            reason: "missing counts vector".to_string(),
+        })?;
+
+    if names.len() % 2 != 0 {
         return Err(SpeculativeCodecError::Malformed {
             reason: format!(
-                "expected a multiple of 3 string entries, found {}",
-                vector.len()
+                "expected an even number of name entries, found {}",
+                names.len()
+            ),
+        });
+    }
+    if names.len() / 2 != counts.len() {
+        return Err(SpeculativeCodecError::Malformed {
+            reason: format!(
+                "names vector implies {} records but counts vector has {}",
+                names.len() / 2,
+                counts.len()
             ),
         });
     }
 
-    let mut records = Vec::with_capacity(vector.len() / 3);
-    let mut entries = vector.iter();
-    while let (Some(from), Some(to), Some(count_str)) =
-        (entries.next(), entries.next(), entries.next())
-    {
-        let count: u32 = count_str
-            .parse()
-            .map_err(|_| SpeculativeCodecError::Malformed {
-                reason: format!("invalid count value: {count_str:?}"),
+    let claimed_records = counts.len();
+    let mut records = Vec::with_capacity(bounded_capacity(claimed_records, bytes.len()));
+
+    let mut names_iter = names.iter();
+    let mut counts_iter = counts.iter();
+    for _ in 0..claimed_records {
+        let from = names_iter
+            .next()
+            .ok_or_else(|| SpeculativeCodecError::Malformed {
+                reason: "names vector exhausted before expected record count".to_string(),
+            })?;
+        let to = names_iter
+            .next()
+            .ok_or_else(|| SpeculativeCodecError::Malformed {
+                reason: "names vector exhausted before expected record count".to_string(),
+            })?;
+        let count = counts_iter
+            .next()
+            .ok_or_else(|| SpeculativeCodecError::Malformed {
+                reason: "counts vector exhausted before expected record count".to_string(),
             })?;
         records.push((
             ActionSignature::from(from),
@@ -118,46 +243,109 @@ mod tests {
     }
 
     #[test]
-    fn rejects_garbage_bytes_as_malformed() {
-        let err = decode_model(&[0xFF, 0x00, 0x12, 0x34]).unwrap_err();
-        assert!(matches!(err, SpeculativeCodecError::Malformed { .. }));
+    fn round_trips_a_large_count_value() {
+        // Regression check for the old decimal-string encoding: values near
+        // u32::MAX must round-trip exactly now that `count` is encoded as a
+        // real integer.
+        let records = vec![(action("click:a"), action("click:b"), u32::MAX)];
+        let bytes = encode_model(&records);
+        assert_eq!(decode_model(&bytes).unwrap(), records);
     }
 
     #[test]
-    fn rejects_truncated_record_groups_as_malformed() {
-        // A valid vector of 2 strings — not a multiple of 3.
+    fn rejects_garbage_bytes_as_invalid_flatbuffer() {
+        let err = decode_model(&[0xFF, 0x00, 0x12, 0x34]).unwrap_err();
+        assert!(matches!(err, SpeculativeCodecError::InvalidFlatbuffer(_)));
+    }
+
+    #[test]
+    fn rejects_odd_length_names_vector_as_malformed() {
         let mut builder = flatbuffers::FlatBufferBuilder::new();
         let a = builder.create_string("only");
         let b = builder.create_string("two");
-        let vector = builder.create_vector(&[a, b]);
-        builder.finish_minimal(vector);
+        let c = builder.create_string("three");
+        let names = builder.create_vector(&[a, b, c]);
+        let counts = builder.create_vector(&[1u32]);
+
+        let table_start = builder.start_table();
+        builder.push_slot_always(FIELD_NAMES, names);
+        builder.push_slot_always(FIELD_COUNTS, counts);
+        let table_end = builder.end_table(table_start);
+        builder.finish_minimal(table_end);
         let bytes = builder.finished_data().to_vec();
 
         let err = decode_model(&bytes).unwrap_err();
         assert_eq!(
             err,
             SpeculativeCodecError::Malformed {
-                reason: "expected a multiple of 3 string entries, found 2".to_string()
+                reason: "expected an even number of name entries, found 3".to_string()
             }
         );
     }
 
     #[test]
-    fn rejects_non_numeric_count_as_malformed() {
+    fn rejects_mismatched_names_and_counts_lengths_as_malformed() {
         let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let from = builder.create_string("click:a");
-        let to = builder.create_string("click:b");
-        let count = builder.create_string("not-a-number");
-        let vector = builder.create_vector(&[from, to, count]);
-        builder.finish_minimal(vector);
+        let a = builder.create_string("from");
+        let b = builder.create_string("to");
+        let names = builder.create_vector(&[a, b]);
+        // Names imply 1 record, but counts claims 2.
+        let counts = builder.create_vector(&[1u32, 2u32]);
+
+        let table_start = builder.start_table();
+        builder.push_slot_always(FIELD_NAMES, names);
+        builder.push_slot_always(FIELD_COUNTS, counts);
+        let table_end = builder.end_table(table_start);
+        builder.finish_minimal(table_end);
         let bytes = builder.finished_data().to_vec();
 
         let err = decode_model(&bytes).unwrap_err();
         assert_eq!(
             err,
             SpeculativeCodecError::Malformed {
-                reason: "invalid count value: \"not-a-number\"".to_string()
+                reason: "names vector implies 1 records but counts vector has 2".to_string()
             }
         );
+    }
+
+    /// A crafted payload whose vector header claims a huge element count
+    /// that the actual buffer bytes cannot possibly back. `decode_model`
+    /// must reject the payload cleanly instead of attempting an oversized
+    /// allocation driven directly by the untrusted claimed length.
+    #[test]
+    fn rejects_crafted_payload_with_oversized_claimed_length_without_huge_alloc() {
+        let mut bytes = vec![0u8; 8];
+        // Root uoffset: points to offset 4 (relative to position 0).
+        bytes[0..4].copy_from_slice(&4u32.to_le_bytes());
+        // Claimed vector length: absurdly large, far beyond what an 8-byte
+        // buffer could ever physically contain.
+        bytes[4..8].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        let result = decode_model(&bytes);
+        assert!(
+            result.is_err(),
+            "decoding a payload whose claimed length outstrips the buffer must fail \
+             cleanly instead of attempting an oversized allocation"
+        );
+    }
+
+    #[test]
+    fn bounds_preallocation_by_buffer_size_not_claimed_length() {
+        // A claimed length of 10 million records backed by only 24 bytes of
+        // buffer must not translate into a 10-million-element
+        // `Vec::with_capacity` — capacity should be capped by what the
+        // buffer could plausibly contain.
+        let claimed = 10_000_000;
+        let buffer_len = 24;
+        let capped = bounded_capacity(claimed, buffer_len);
+        assert!(capped <= buffer_len / MIN_BYTES_PER_RECORD);
+        assert!(capped < claimed);
+    }
+
+    #[test]
+    fn does_not_shrink_capacity_when_claimed_length_is_plausible() {
+        let claimed = 3;
+        let buffer_len = 1024;
+        assert_eq!(bounded_capacity(claimed, buffer_len), claimed);
     }
 }

--- a/core-runtime/src/speculative/mod.rs
+++ b/core-runtime/src/speculative/mod.rs
@@ -646,7 +646,7 @@ mod tests {
     fn import_model_rejects_malformed_bytes() {
         let engine = SpeculativeEngine::new(vec![]);
         let err = engine.import_model(&[0xFF, 0x00]).unwrap_err();
-        assert!(matches!(err, SpeculativeCodecError::Malformed { .. }));
+        assert!(matches!(err, SpeculativeCodecError::InvalidFlatbuffer(_)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #268

## Summary

`core-runtime/src/speculative/codec.rs` decodes untrusted FlatBuffers
bytes (domain packs, plugin-supplied speculative-state payloads) — a
trust-boundary-crossing input that must be treated as adversarial.
This PR fixes the three issues raised in #268:

1. **Untrusted-allocation DoS (HIGH)**: `decode_model` no longer
   preallocates a `Vec` directly from the untrusted claimed vector
   length. A new `bounded_capacity` helper caps preallocation using
   the physical size of the input buffer, so a crafted claimed length
   can never force an oversized allocation. This is defense-in-depth
   on top of FlatBuffers' own verifier, which the crate itself
   documents as "experimental."
2. **Flattened error detail (MEDIUM)**: `SpeculativeCodecError` now
   has an `InvalidFlatbuffer(#[from] flatbuffers::InvalidFlatbuffer)`
   variant that preserves the structured verifier error instead of
   collapsing it into a plain `String`.
3. **Textual `count` encoding (LOW)**: `count` is no longer encoded as
   a decimal string. The wire format is now a small two-field table
   (`names`: interleaved from/to string pairs, `counts`: a proper
   `Vector<u32>`), built with the crate's low-level builder/reader
   primitives since `flatc` isn't available in this toolchain.

## Test plan

- [x] `cargo test -p core-runtime speculative` — 41 passed, including
      new regression tests: a crafted payload with an oversized
      claimed vector length, mismatched/odd-length vector pairs, and
      a `u32::MAX` round-trip that would have broken under the old
      decimal-string encoding.
- [x] `cargo test --workspace` — full suite passes
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Manual review of the new hand-rolled `ModelTable`
      `Follow`/`Verifiable` impl and its `unsafe` `Table::get` calls —
      safety relies on `flatbuffers::root()` always running the
      verifier before `follow()`, which the decode path enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)