### PR TITLE
[ISSUE-273] Fix schema_registry non-deterministic JS field order

### DIFF
--- a/plugin-host/src/schema_registry.rs
+++ b/plugin-host/src/schema_registry.rs
@@ -127,8 +127,11 @@ impl ExtractionRule {
                 let sel_json =
                     serde_json::to_string(selector).unwrap_or_else(|_| "\"\"".to_string());
 
-                let field_lines: Vec<String> = fields
-                    .iter()
+                let mut sorted_fields: Vec<(&String, &String)> = fields.iter().collect();
+                sorted_fields.sort_by_key(|(key, _)| key.as_str());
+
+                let field_lines: Vec<String> = sorted_fields
+                    .into_iter()
                     .map(|(key, field_sel)| {
                         let key_json =
                             serde_json::to_string(key).unwrap_or_else(|_| "\"\"".to_string());
@@ -421,6 +424,37 @@ mod tests {
         assert!(js.contains("querySelector(\".amt\")"));
         assert!(js.contains("\"price\""));
         assert!(js.contains("items.map"));
+    }
+
+    #[test]
+    fn structured_rule_generates_deterministic_field_order() {
+        let rule_of = |insertion_order: &[&str]| {
+            let mut fields = HashMap::new();
+            for key in insertion_order {
+                fields.insert((*key).to_string(), format!(".{key}"));
+            }
+            ExtractionRule {
+                name: "products".into(),
+                mode: ExtractionMode::Structured {
+                    selector: "tr.product".into(),
+                    fields,
+                },
+            }
+            .to_js_script()
+        };
+
+        let js_a = rule_of(&["price", "name", "sku", "rating"]);
+        let js_b = rule_of(&["rating", "sku", "name", "price"]);
+        assert_eq!(
+            js_a, js_b,
+            "field order must not depend on HashMap insertion order"
+        );
+
+        let name_pos = js_a.find("\"name\"").unwrap();
+        let price_pos = js_a.find("\"price\"").unwrap();
+        let rating_pos = js_a.find("\"rating\"").unwrap();
+        let sku_pos = js_a.find("\"sku\"").unwrap();
+        assert!(name_pos < price_pos && price_pos < rating_pos && rating_pos < sku_pos);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `ExtractionRule::to_js_script` iterated `fields: HashMap<String, String>` directly when generating field-access lines for Structured extraction mode, so the generated JS script's field order (and its text/hash) varied nondeterministically run-to-run with HashMap's randomized iteration order.
- Sort fields by key before generating field lines, so output is stable across runs and independent of insertion order.

## Test plan
- [x] `cargo test -p plugin-host --lib schema_registry` — 27 passed (1 new regression test asserting byte-identical output across two different insertion orders, and alphabetical field ordering)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build --workspace --tests`

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)